### PR TITLE
build: set bhwi-wasm env vars

### DIFF
--- a/bhwi-wasm/.cargo/config.toml
+++ b/bhwi-wasm/.cargo/config.toml
@@ -1,2 +1,7 @@
 [build]
 rustflags = ["--cfg=web_sys_unstable_apis"]
+
+[env]
+CC_wasm32_unknown_unknown = "clang"
+CFLAGS = "-target wasm32-unknown-unknown -nostdlibinc"
+C_INCLUDE_PATH = { value = "", force = true }

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
- I'm not sure if this will work for everyone else, but for me (on Guix System)
  glibc isn't built with 32-bit support so it makes building wasm not so straight
  forward.

  Setting these env vars seems to give cargo enough hints and allow me to build
  wasm.

- Added .tsbuildinfo files to gitignore