### PR TITLE
Implement Display Address Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "ctr",
  "k256",
  "log",
+ "miniscript",
  "serde",
  "serde_bytes",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,6 @@ dependencies = [
  "ctr",
  "k256",
  "log",
- "miniscript",
  "serde",
  "serde_bytes",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "ctr",
  "k256",
  "log",
+ "miniscript",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -1446,8 +1447,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 [[package]]
 name = "miniscript"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
+source = "git+https://github.com/rust-bitcoin/rust-miniscript.git?rev=c9b0499e#c9b0499e7479b3e21a4d6829a7b85534669eb8b8"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ bhwi-async = { path = "./bhwi-async", version = "0.0.1" }
 futures = "0.3"
 hex = "0.4.3"
 log = "0.4"
-miniscript = "13.0.0"
+# Can move to a version once WalletPolicy is in a release
+miniscript = { git = "https://github.com/rust-bitcoin/rust-miniscript.git", rev = "c9b0499e" }
 rand_core = "0.6.4"
 reqwest = "0.13.2"
 serde = "1.0.228"

--- a/bhwi-async/src/jade.rs
+++ b/bhwi-async/src/jade.rs
@@ -23,7 +23,7 @@ impl<T, S> Jade<T, S> {
 
 impl<C, T, R, E, F, H> crate::CommonInterface<C, T, R, E> for Jade<F, H>
 where
-    C: Into<JadeCommand>,
+    C: TryInto<JadeCommand, Error = E>,
     T: From<JadeTransmit>,
     R: From<JadeResponse>,
     E: From<JadeError>,

--- a/bhwi-async/src/ledger.rs
+++ b/bhwi-async/src/ledger.rs
@@ -51,6 +51,6 @@ pub struct DummyClient;
 impl HttpClient for DummyClient {
     type Error = LedgerError;
     async fn request(&self, _url: &str, _req: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        unreachable!("Coldcard does not need http client")
+        unreachable!("Ledger does not need http client")
     }
 }

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -6,6 +6,8 @@ pub mod transport;
 use std::{error::Error as StdError, fmt::Debug};
 
 use async_trait::async_trait;
+pub use bhwi::common::DeviceContext;
+pub use bhwi::common::DisplayAddress;
 pub use bhwi::common::Info;
 use bhwi::{
     Interpreter,
@@ -14,7 +16,7 @@ use bhwi::{
         bip32::{DerivationPath, Fingerprint, Xpub},
         secp256k1::ecdsa::Signature,
     },
-    common,
+    common::{self},
 };
 pub use jade::Jade;
 pub use ledger::Ledger;
@@ -47,6 +49,11 @@ pub trait HWI {
         message: &[u8],
         path: DerivationPath,
     ) -> Result<(u8, Signature), Self::Error>;
+    async fn display_address(
+        &mut self,
+        address: common::DisplayAddress,
+        context: Option<common::DeviceContext>,
+    ) -> Result<String, Self::Error>;
 }
 
 // TODO: this will become a pain to maintain, but we can have a proc-macro
@@ -67,6 +74,11 @@ pub trait HWIDevice {
         message: &[u8],
         path: DerivationPath,
     ) -> Result<(u8, Signature), HWIDeviceError>;
+    async fn display_address(
+        &mut self,
+        address: common::DisplayAddress,
+        context: Option<common::DeviceContext>,
+    ) -> Result<String, HWIDeviceError>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -165,6 +177,20 @@ where
             Err(common::Error::NoErrorOrResult.into())
         }
     }
+
+    async fn display_address(
+        &mut self,
+        address: common::DisplayAddress,
+        context: Option<common::DeviceContext>,
+    ) -> Result<String, Self::Error> {
+        if let common::Response::Address(addr) =
+            run_command(self, common::Command::DisplayAddress(address, context)).await?
+        {
+            Ok(addr)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -205,6 +231,16 @@ where
         path: DerivationPath,
     ) -> Result<(u8, Signature), HWIDeviceError> {
         HWI::sign_message(self, message, path)
+            .await
+            .map_err(HWIDeviceError::new)
+    }
+
+    async fn display_address(
+        &mut self,
+        address: DisplayAddress,
+        context: Option<DeviceContext>,
+    ) -> Result<String, HWIDeviceError> {
+        HWI::display_address(self, address, context)
             .await
             .map_err(HWIDeviceError::new)
     }

--- a/bhwi-cli/src/address.rs
+++ b/bhwi-cli/src/address.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use bhwi_async::DisplayAddress;
+use bitcoin::address::AddressType;
+
+use crate::DeviceManager;
+
+#[derive(Debug, Clone)]
+pub enum AddressTarget {
+    Path {
+        path: String,
+        display: bool,
+        address_format: Option<AddressType>,
+    },
+    Descriptor {
+        index: u32,
+        change: bool,
+        display: bool,
+        descriptor_name: String,
+    },
+}
+
+impl DeviceManager {
+    pub async fn get_address(&self, target: AddressTarget) -> Result<()> {
+        let Some(mut device) = self.get_device_with_fingerprint().await? else {
+            return Ok(());
+        };
+        let display_address = match target {
+            AddressTarget::Path {
+                path,
+                display,
+                address_format,
+            } => DisplayAddress::ByPath {
+                path: path.parse()?,
+                display,
+                address_format,
+            },
+            AddressTarget::Descriptor {
+                index,
+                change,
+                display,
+                descriptor_name,
+            } => DisplayAddress::ByDescriptor {
+                index,
+                change,
+                display,
+                descriptor_name,
+            },
+        };
+        let address = device
+            .device()
+            .display_address(display_address, None)
+            .await?;
+        println!("{address}");
+        Ok(())
+    }
+}

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
-use bhwi_cli::{DeviceManager, OutputFormat, config::Config};
+use bhwi_cli::{DeviceManager, OutputFormat, address::AddressTarget, config::Config};
 
 use bitcoin::{
     Network,
+    address::AddressType,
     bip32::{DerivationPath, Fingerprint},
 };
 use clap::{Parser, Subcommand};
@@ -43,11 +44,38 @@ impl From<Args> for Config {
 #[derive(Debug, Clone, Subcommand)]
 enum Commands {
     #[command(subcommand)]
+    Address(AddressCommands),
+    #[command(subcommand)]
     Descriptor(DescriptorCommands),
     #[command(subcommand)]
     Device(DeviceCommands),
     #[command(subcommand)]
     Xpub(XpubCommands),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum AddressCommands {
+    /// Get an address from the device
+    Get {
+        /// Derivation path (e.g. m/84'/0'/0'/0/0)
+        #[arg(long, conflicts_with = "from_descriptor")]
+        from_path: Option<String>,
+        /// Miniscript descriptor name registered on device
+        #[arg(long, conflicts_with = "from_path")]
+        from_descriptor: Option<String>,
+        /// Address index for descriptor-based retrieval (default: 0)
+        #[arg(long, default_value_t = 0)]
+        index: u32,
+        /// Change address for descriptor-based retrieval
+        #[arg(long, default_value_t = false)]
+        change: bool,
+        /// Display the address on the device screen
+        #[arg(long, default_value_t = false)]
+        display: bool,
+        /// Address format for path-based retrieval (p2pkh, p2sh, p2wpkh, p2wsh, p2tr)
+        #[arg(long, value_parser = clap::value_parser!(AddressType))]
+        address_format: Option<AddressType>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Subcommand)]
@@ -83,6 +111,33 @@ async fn main() -> Result<()> {
     let config: Config = args.into();
     let dev_man = DeviceManager::new(config);
     match command {
+        Commands::Address(AddressCommands::Get {
+            from_path,
+            from_descriptor,
+            index,
+            change,
+            display,
+            address_format,
+        }) => match (from_path, from_descriptor) {
+            (Some(path), None) => {
+                let target = AddressTarget::Path {
+                    path,
+                    display,
+                    address_format,
+                };
+                dev_man.get_address(target).await?
+            }
+            (None, Some(descriptor_name)) => {
+                let target = AddressTarget::Descriptor {
+                    index,
+                    change,
+                    display,
+                    descriptor_name,
+                };
+                dev_man.get_address(target).await?
+            }
+            _ => anyhow::bail!("either --from-path or --from-descriptor must be specified"),
+        },
         Commands::Descriptor(DescriptorCommands::Pubkeys { account }) => {
             dev_man.get_pubkey_descriptors(account).await?
         }

--- a/bhwi-cli/src/get_descriptors.rs
+++ b/bhwi-cli/src/get_descriptors.rs
@@ -191,9 +191,9 @@ impl DeviceManager {
 
 fn bip44_purpose(desc_type: DescriptorType) -> Result<u32> {
     Ok(match desc_type {
-        DescriptorType::Sh | DescriptorType::ShSortedMulti | DescriptorType::Pkh => 44,
-        DescriptorType::Wpkh | DescriptorType::Wsh | DescriptorType::WshSortedMulti => 84,
-        DescriptorType::ShWsh | DescriptorType::ShWpkh | DescriptorType::ShWshSortedMulti => 49,
+        DescriptorType::Sh | DescriptorType::Pkh => 44,
+        DescriptorType::Wpkh | DescriptorType::Wsh => 84,
+        DescriptorType::ShWsh | DescriptorType::ShWpkh => 49,
         DescriptorType::Tr => 86,
         DescriptorType::Bare => anyhow::bail!("Bare PK descriptors aren't supported"),
     })

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -9,6 +9,7 @@ use strum::{EnumIter, IntoEnumIterator};
 
 use crate::{coldcard::ColdcardDevice, config::Config, jade::JadeDevice, ledger::LedgerDevice};
 
+pub mod address;
 pub mod coldcard;
 pub mod config;
 pub mod get_descriptors;

--- a/bhwi-wasm/src/lib.rs
+++ b/bhwi-wasm/src/lib.rs
@@ -60,6 +60,7 @@ impl<T: AsyncHWI> HWI for T {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum Device {
     Ledger(Ledger<LedgerTransportHID<webhid::WebHidDevice>>),
     Coldcard(Coldcard<ColdcardTransportHID<webhid::WebHidDevice>>),

--- a/bhwi/Cargo.toml
+++ b/bhwi/Cargo.toml
@@ -18,6 +18,7 @@ jade = ["serde", "serde_bytes", "serde_cbor"]
 base64ct = { workspace = true, features = ["alloc"] }
 bitcoin.workspace = true
 log.workspace = true # TODO: remove me
+miniscript.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json.workspace = true
 serde_cbor = { workspace = true, optional = true }

--- a/bhwi/src/coldcard/api.rs
+++ b/bhwi/src/coldcard/api.rs
@@ -17,6 +17,50 @@ pub mod request {
         }
     }
 
+    /// Address format bitmask constants (from ckcc-protocol)
+    pub mod addr_fmt {
+        pub const AFC_PUBKEY: u32 = 0x01;
+        pub const AFC_SEGWIT: u32 = 0x02;
+        pub const AFC_BECH32: u32 = 0x04;
+        pub const AFC_SCRIPT: u32 = 0x08;
+        pub const AFC_WRAPPED: u32 = 0x10;
+        pub const AFC_BECH32M: u32 = 0x20;
+
+        pub const AF_P2PKH: u32 = AFC_PUBKEY;
+        pub const AF_P2WPKH: u32 = AFC_PUBKEY | AFC_SEGWIT | AFC_BECH32;
+        pub const AF_P2WPKH_P2SH: u32 = AFC_PUBKEY | AFC_SEGWIT | AFC_WRAPPED;
+        pub const AF_P2TR: u32 = AFC_PUBKEY | AFC_SEGWIT | AFC_BECH32M;
+        pub const AF_P2SH: u32 = AFC_SCRIPT;
+        pub const AF_P2WSH: u32 = AFC_SCRIPT | AFC_SEGWIT | AFC_BECH32;
+        pub const AF_P2WSH_P2SH: u32 = AFC_SCRIPT | AFC_SEGWIT | AFC_WRAPPED;
+
+        pub fn from_address_type(addr_type: bitcoin::address::AddressType) -> u32 {
+            match addr_type {
+                bitcoin::address::AddressType::P2pkh => AF_P2PKH,
+                bitcoin::address::AddressType::P2sh => AF_P2SH,
+                bitcoin::address::AddressType::P2wpkh => AF_P2WPKH,
+                bitcoin::address::AddressType::P2wsh => AF_P2WSH,
+                bitcoin::address::AddressType::P2tr => AF_P2TR,
+                _ => AF_P2WPKH,
+            }
+        }
+    }
+
+    pub fn show_address(path: &DerivationPath, addr_fmt: u32) -> Vec<u8> {
+        let mut data = b"show".to_vec();
+        data.extend(addr_fmt.to_le_bytes());
+        data.extend(path.to_string().as_bytes());
+        data
+    }
+
+    pub fn miniscript_address(name: &str, change: bool, index: u32) -> Vec<u8> {
+        let mut data = b"msas".to_vec();
+        data.extend((change as u32).to_le_bytes());
+        data.extend(index.to_le_bytes());
+        data.extend(name.as_bytes());
+        data
+    }
+
     pub fn sign_message(message: &[u8], path: &DerivationPath) -> Vec<u8> {
         let mut data = b"smsg".to_vec();
         // coldcard can support a few different address types:
@@ -178,6 +222,34 @@ pub mod response {
         let s =
             std::str::from_utf8(data).map_err(|e| ColdcardError::Serialization(e.to_string()))?;
         Xpub::from_str(s).map_err(|e| ColdcardError::Serialization(e.to_string()))
+    }
+
+    pub fn show_address(res: &[u8]) -> Result<ColdcardResponse, ColdcardError> {
+        match ResponseHandler::parse_response(res)? {
+            (ResponseMessage::Asci, data) => {
+                let address = String::from_utf8(data.to_owned())?;
+                Ok(ColdcardResponse::Address(address))
+            }
+            (ResponseMessage::Refu, _) => Ok(ColdcardResponse::Ok),
+            (msg, _) => Err(ColdcardError::unexpected_response_message(
+                msg,
+                &[ResponseMessage::Asci, ResponseMessage::Refu],
+            )),
+        }
+    }
+
+    pub fn miniscript_address(res: &[u8]) -> Result<ColdcardResponse, ColdcardError> {
+        match ResponseHandler::parse_response(res)? {
+            (ResponseMessage::Asci, data) => {
+                let address = String::from_utf8(data.to_owned())?;
+                Ok(ColdcardResponse::Address(address))
+            }
+            (ResponseMessage::Refu, _) => Ok(ColdcardResponse::Ok),
+            (msg, _) => Err(ColdcardError::unexpected_response_message(
+                msg,
+                &[ResponseMessage::Asci, ResponseMessage::Refu],
+            )),
+        }
     }
 
     pub fn master_fingerprint(res: &[u8]) -> Result<ColdcardResponse, ColdcardError> {

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -207,6 +207,32 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetVersion),
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    address_format,
+                    ..
+                },
+                ..,
+            ) => Ok(Self::ShowAddress {
+                path,
+                addr_fmt: address_format
+                    .map(api::request::addr_fmt::from_address_type)
+                    .unwrap_or(api::request::addr_fmt::AF_P2WPKH),
+            }),
+            Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    descriptor_name,
+                    change,
+                    index,
+                    ..
+                },
+                ..,
+            ) => Ok(Self::MiniscriptAddress {
+                name: descriptor_name,
+                change,
+                index,
+            }),
         }
     }
 }

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -8,7 +8,7 @@ use bitcoin::secp256k1::ecdsa::Signature;
 
 use crate::Interpreter;
 use crate::coldcard::api::response::ResponseMessage;
-use crate::common::{Command, Error, Info, Recipient, Response, Transmit};
+use crate::common::{Command, DisplayAddress, Error, Info, Recipient, Response, Transmit};
 use crate::device::DeviceId;
 
 pub const DEFAULT_CKCC_SOCKET: &str = "/tmp/ckcc-simulator.sock";
@@ -61,6 +61,15 @@ pub enum ColdcardCommand {
         message: Vec<u8>,
         path: DerivationPath,
     },
+    ShowAddress {
+        path: DerivationPath,
+        addr_fmt: u32,
+    },
+    MiniscriptAddress {
+        name: String,
+        change: bool,
+        index: u32,
+    },
 }
 
 pub enum ColdcardResponse {
@@ -78,6 +87,7 @@ pub enum ColdcardResponse {
         xpub: Option<Xpub>,
     },
     Signature(u8, Signature),
+    Address(String),
 }
 
 pub struct ColdcardTransmit {
@@ -147,6 +157,17 @@ where
             ColdcardCommand::SignMessage { message, path } => {
                 request(api::request::sign_message(message, path), self.encryption)?
             }
+            ColdcardCommand::ShowAddress { path, addr_fmt } => {
+                request(api::request::show_address(path, *addr_fmt), self.encryption)?
+            }
+            ColdcardCommand::MiniscriptAddress {
+                name,
+                change,
+                index,
+            } => request(
+                api::request::miniscript_address(name, *change, *index),
+                self.encryption,
+            )?,
         };
 
         self.state = State::Running(command);
@@ -184,6 +205,16 @@ where
             State::Running(ColdcardCommand::StartEncryption) => {
                 let mypub = api::response::mypub(&data)?;
                 self.state = State::Finished(mypub);
+                Ok(None)
+            }
+            State::Running(ColdcardCommand::ShowAddress { .. }) => {
+                let data = self.encryption.decrypt(data)?;
+                self.state = State::Finished(api::response::show_address(&data)?);
+                Ok(None)
+            }
+            State::Running(ColdcardCommand::MiniscriptAddress { .. }) => {
+                let data = self.encryption.decrypt(data)?;
+                self.state = State::Finished(api::response::miniscript_address(&data)?);
                 Ok(None)
             }
             State::Finished(..) => Ok(None),
@@ -258,6 +289,7 @@ impl From<ColdcardResponse> for Response {
             }
             ColdcardResponse::Ok => Response::TaskDone,
             ColdcardResponse::Busy => Response::TaskBusy,
+            ColdcardResponse::Address(address) => Response::Address(address),
         }
     }
 }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -1,4 +1,5 @@
 use bitcoin::Network;
+use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::secp256k1::ecdsa::Signature;
 
@@ -9,6 +10,22 @@ pub struct UnlockOptions {
     pub network: Option<Network>,
 }
 
+#[derive(Clone, Debug)]
+pub enum DisplayAddress {
+    ByPath {
+        path: DerivationPath,
+        display: bool,
+        address_format: Option<AddressType>,
+    },
+    ByDescriptor {
+        index: u32,
+        change: bool,
+        display: bool,
+        descriptor_name: String,
+    },
+}
+
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     GetMasterFingerprint,
     GetVersion,
@@ -16,12 +33,23 @@ pub enum Command {
         path: DerivationPath,
         display: bool,
     },
+    DisplayAddress(DisplayAddress, Option<DeviceContext>),
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
     },
     Unlock {
         options: UnlockOptions,
+    },
+}
+
+/// Device-specific context data required by certain commands.
+#[derive(Clone, Debug)]
+pub enum DeviceContext {
+    /// Required contexts for Ledger devices
+    Ledger {
+        wallet_policy: ledger::LedgerWalletPolicy,
+        wallet_hmac: Option<[u8; 32]>,
     },
 }
 
@@ -33,6 +61,7 @@ pub enum Response {
     Xpub(Xpub),
     EncryptionKey([u8; 64]),
     Signature(u8, Signature),
+    Address(String),
 }
 
 /// Device Information
@@ -79,6 +108,9 @@ pub enum Error {
 
     #[error("authentication refused")]
     AuthenticationRefused,
+
+    #[error("unsupported display address: {0}")]
+    UnsupportedDisplayAddress(String),
 }
 
 impl Error {

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -271,11 +271,29 @@ where
 impl From<Command> for JadeCommand {
     fn from(cmd: Command) -> Self {
         match cmd {
-            Command::Unlock { .. } => Self::Auth,
-            Command::GetMasterFingerprint => Self::GetMasterFingerprint,
-            Command::GetXpub { path, .. } => Self::GetXpub(path),
-            Command::SignMessage { message, path } => Self::SignMessage { message, path },
-            Command::GetVersion => Self::GetInfo,
+            Command::Unlock { .. } => Ok(Self::Auth),
+            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
+            Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
+            Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    index,
+                    change,
+                    descriptor_name,
+                    ..
+                },
+                _ctx,
+            ) => Ok(Self::GetReceiveAddress {
+                index,
+                change,
+                descriptor_name,
+            }),
+            Command::DisplayAddress(DisplayAddress::ByPath { .. }, _) => {
+                Err(Error::UnsupportedDisplayAddress(
+                    "Jade does not support path-based address display".into(),
+                ))
+            }
+            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
+            Command::GetVersion => Ok(Self::GetInfo),
         }
     }
 }
@@ -327,6 +345,9 @@ impl From<JadeError> for Error {
                 format!("jade unexpected result: {msg}"),
             ),
             JadeError::HandshakeRefused => Error::AuthenticationRefused,
+            JadeError::UnsupportedDisplayAddress => {
+                Error::UnsupportedDisplayAddress("unsupported display address on Jade".into())
+            }
         }
     }
 }

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::Interpreter;
-use crate::common::{Command, Error, Info, Recipient, Response, Transmit};
+use crate::common::{Command, DisplayAddress, Error, Info, Recipient, Response, Transmit};
 use crate::device::DeviceId;
 use crate::jade::api::GetInfoResponse;
 
@@ -35,6 +35,7 @@ pub enum JadeError {
     Serialization(String),
     UnexpectedResult(String),
     HandshakeRefused,
+    UnsupportedDisplayAddress,
 }
 
 pub enum JadeCommand {
@@ -42,6 +43,11 @@ pub enum JadeCommand {
     GetMasterFingerprint,
     GetInfo,
     GetXpub(DerivationPath),
+    GetReceiveAddress {
+        index: u32,
+        change: bool,
+        descriptor_name: String,
+    },
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
@@ -54,6 +60,7 @@ pub enum JadeResponse {
     Signature(u8, Signature),
     TaskDone,
     Xpub(Xpub),
+    Address(String),
 }
 
 pub enum JadeRecipient {
@@ -135,7 +142,7 @@ fn from_response<D: DeserializeOwned>(buffer: &[u8]) -> Result<api::Response<D>,
 
 impl<C, T, R, E> Interpreter for JadeInterpreter<C, T, R, E>
 where
-    C: Into<JadeCommand>,
+    C: TryInto<JadeCommand, Error = E>,
     T: From<JadeTransmit>,
     R: From<JadeResponse>,
     E: From<JadeError>,
@@ -146,7 +153,7 @@ where
     type Error = E;
 
     fn start(&mut self, command: Self::Command) -> Result<Self::Transmit, Self::Error> {
-        let command: JadeCommand = command.into();
+        let command: JadeCommand = command.try_into()?;
         let req = match &command {
             JadeCommand::Auth => request(
                 "auth_user",
@@ -175,6 +182,19 @@ where
                     path: path.to_u32_vec(),
                     message: &String::from_utf8(message.to_vec())
                         .map_err(|e| JadeError::Serialization(e.to_string()))?,
+                }),
+            ),
+            JadeCommand::GetReceiveAddress {
+                index,
+                change,
+                descriptor_name,
+            } => request(
+                "get_receive_address",
+                Some(api::DescriptorAddressParams {
+                    network: self.network,
+                    branch: u32::from(*change),
+                    pointer: *index,
+                    descriptor_name,
                 }),
             ),
             JadeCommand::GetInfo => request("get_version_info", None::<api::EmptyRequest>),
@@ -254,6 +274,11 @@ where
                 self.response = Some(JadeResponse::Signature(sig_bytes[0], sig));
                 Ok(None)
             }
+            State::Running(JadeCommand::GetReceiveAddress { .. }) => {
+                let address: String = from_response(&data)?.into_result()?;
+                self.response = Some(JadeResponse::Address(address));
+                Ok(None)
+            }
             State::Running(JadeCommand::GetInfo) => {
                 let info: GetInfoResponse = from_response(&data)?.into_result()?;
                 self.response = Some(JadeResponse::GetInfo(info));
@@ -268,8 +293,10 @@ where
     }
 }
 
-impl From<Command> for JadeCommand {
-    fn from(cmd: Command) -> Self {
+impl TryFrom<Command> for JadeCommand {
+    type Error = Error;
+
+    fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
             Command::Unlock { .. } => Ok(Self::Auth),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
@@ -310,6 +337,7 @@ impl From<JadeResponse> for Response {
                 networks: info.jade_networks.into(),
                 firmware: None,
             }),
+            JadeResponse::Address(address) => Response::Address(address),
         }
     }
 }

--- a/bhwi/src/ledger/command.rs
+++ b/bhwi/src/ledger/command.rs
@@ -9,7 +9,7 @@ use core::default::Default;
 
 use super::{
     apdu::{self, ApduCommand},
-    wallet::WalletPolicy,
+    wallet::LedgerWalletPolicy,
 };
 
 // https://github.com/LedgerHQ/ledger-live/blob/5a0a1aa5dc183116839851b79bceb6704f1de4b9/libs/ledger-live-common/src/hw/openApp.ts#L3
@@ -68,8 +68,8 @@ pub fn get_extended_pubkey(path: &DerivationPath, display: bool) -> ApduCommand 
 }
 
 /// Creates the APDU command required to register the given wallet policy.
-pub fn register_wallet(policy: &WalletPolicy) -> ApduCommand {
-    let bytes = policy.serialize();
+pub fn register_wallet(policy: &LedgerWalletPolicy) -> ApduCommand {
+    let bytes = policy.serialize().expect("wallet policy serialization");
     let mut data = encode::serialize(&VarInt(bytes.len() as u64));
     data.extend(bytes);
     ApduCommand {
@@ -82,7 +82,7 @@ pub fn register_wallet(policy: &WalletPolicy) -> ApduCommand {
 
 /// Creates the APDU command required to retrieve an address for the given wallet.
 pub fn get_wallet_address(
-    policy: &WalletPolicy,
+    policy: &LedgerWalletPolicy,
     hmac: Option<&[u8; 32]>,
     change: bool,
     address_index: u32,
@@ -90,7 +90,7 @@ pub fn get_wallet_address(
 ) -> ApduCommand {
     let mut data: Vec<u8> = Vec::with_capacity(70);
     data.push(if display { 1_u8 } else { b'\0' });
-    data.extend_from_slice(&policy.id());
+    data.extend_from_slice(&policy.id().expect("wallet policy id"));
     data.extend_from_slice(hmac.unwrap_or(&[b'\0'; 32]));
     data.push(if change { 1_u8 } else { b'\0' });
     data.extend_from_slice(&address_index.to_be_bytes());
@@ -109,7 +109,7 @@ pub fn sign_psbt(
     input_commitments_root: &[u8; 32],
     outputs_number: usize,
     output_commitments_root: &[u8; 32],
-    policy: &WalletPolicy,
+    policy: &LedgerWalletPolicy,
     hmac: Option<&[u8; 32]>,
 ) -> ApduCommand {
     let mut data: Vec<u8> = Vec::new();
@@ -118,7 +118,7 @@ pub fn sign_psbt(
     data.extend_from_slice(input_commitments_root);
     data.extend(encode::serialize(&VarInt(outputs_number as u64)));
     data.extend_from_slice(output_commitments_root);
-    data.extend_from_slice(&policy.id());
+    data.extend_from_slice(&policy.id().expect("wallet policy id"));
     data.extend_from_slice(hmac.unwrap_or(&[b'\0'; 32]));
     ApduCommand {
         cla: apdu::Cla::Bitcoin as u8,

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -1,6 +1,6 @@
-mod command;
+pub mod command;
 mod merkle;
-mod store;
+pub mod store;
 
 pub mod apdu;
 pub mod error;
@@ -15,10 +15,10 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::consensus::encode::deserialize_partial;
 use bitcoin::secp256k1::ecdsa::Signature;
 use store::{DelegatedStore, StoreError};
-pub use wallet::{WalletPolicy, WalletPubKey};
+pub use wallet::{AddressType, LedgerWalletPolicy, Version, WalletError, singlesig_wallet_policy};
 
 use crate::Interpreter;
-use crate::common::{Command, Error, Info, Response};
+use crate::common::{Command, DeviceContext, DisplayAddress, Error, Info, Response};
 use crate::device::DeviceId;
 
 pub const LEDGER_DEVICE_ID: DeviceId = DeviceId::new(0x2c97)
@@ -45,6 +45,9 @@ pub enum LedgerError {
     #[error("unexpected result for {1}: {0:x?}")]
     UnexpectedResult(Vec<u8>, String),
 
+    #[error("unsupported display address: {0}")]
+    UnsupportedDisplayAddress(String),
+
     #[error("failed to open app: {0:x?}")]
     FailedToOpenApp(Vec<u8>),
 }
@@ -64,6 +67,10 @@ pub enum LedgerCommand {
     GetXpub {
         path: DerivationPath,
         display: bool,
+    },
+    GetWalletAddress {
+        address: DisplayAddress,
+        context: Option<DeviceContext>,
     },
     SignMessage {
         message: Vec<u8>,
@@ -125,6 +132,7 @@ pub enum LedgerResponse {
     Signature(u8, Signature),
     TaskDone,
     Xpub(Xpub),
+    Address(String),
 }
 
 #[derive(Default)]
@@ -136,7 +144,24 @@ enum State {
         command: LedgerCommand,
         store: Option<DelegatedStore>,
     },
+    GetWalletAddress(GetWalletAddressStep),
     Finished(LedgerResponse),
+}
+
+enum GetWalletAddressStep {
+    Fingerprint {
+        address: DisplayAddress,
+        context: Option<DeviceContext>,
+    },
+    Xpub {
+        address: DisplayAddress,
+        fingerprint: Fingerprint,
+        display: bool,
+        context: Option<DeviceContext>,
+    },
+    WalletAddress {
+        store: Option<DelegatedStore>,
+    },
 }
 
 pub struct LedgerInterpreter<C, T, R, E> {
@@ -197,93 +222,235 @@ where
                     Some(store),
                 )
             }
+            LedgerCommand::GetWalletAddress { address, context } => {
+                self.state =
+                    State::GetWalletAddress(GetWalletAddressStep::Fingerprint { address, context });
+                return Ok(Self::Transmit::from(command::get_master_fingerprint()));
+            }
         };
         self.state = State::Running { command, store };
         Ok(transmit)
     }
+
     fn exchange(&mut self, data: Vec<u8>) -> Result<Option<Self::Transmit>, Self::Error> {
-        if let State::Running { store, command } = &mut self.state {
-            let res = ApduResponse::try_from(data).map_err(LedgerError::from)?;
-            if res.status_word == StatusWord::InterruptedExecution {
-                if let Some(store) = store {
-                    let transmit = store.execute(res.data).map_err(LedgerError::from)?;
-                    return Ok(Some(Self::Transmit::from(command::continue_interrupted(
-                        transmit,
-                    ))));
-                } else {
-                    return Err(LedgerError::Interrupted.into());
+        let res = ApduResponse::try_from(data).map_err(LedgerError::from)?;
+        match &mut self.state {
+            State::GetWalletAddress(GetWalletAddressStep::Fingerprint { address, context }) => {
+                if res.data.len() < 4 {
+                    return Err(LedgerError::unexpected_result(
+                        res.data,
+                        "display address: master fingerprint",
+                    )
+                    .into());
+                }
+                let mut fg = [0x00; 4];
+                fg.copy_from_slice(&res.data[0..4]);
+                let fingerprint = Fingerprint::from(fg);
+                let (account_path, display) = match &address {
+                    DisplayAddress::ByPath { path, display, .. } => {
+                        let children: Vec<_> = path.as_ref().to_vec();
+                        if children.len() < 5 {
+                            return Err(LedgerError::UnsupportedDisplayAddress(
+                                "Ledger requires a full 5-level derivation path (e.g. m/84'/0'/0'/0/0)".into(),
+                            )
+                            .into());
+                        }
+                        (DerivationPath::from(children[..3].to_vec()), *display)
+                    }
+                    DisplayAddress::ByDescriptor { .. } => {
+                        return Err(LedgerError::UnsupportedDisplayAddress(
+                            "Ledger does not support descriptor-based address display via wallet registration yet".into(),
+                        ).into());
+                    }
+                };
+                self.state = State::GetWalletAddress(GetWalletAddressStep::Xpub {
+                    address: address.clone(),
+                    fingerprint,
+                    display,
+                    context: std::mem::take(context),
+                });
+                return Ok(Some(Self::Transmit::from(command::get_extended_pubkey(
+                    &account_path,
+                    false,
+                ))));
+            }
+            State::GetWalletAddress(GetWalletAddressStep::Xpub {
+                address,
+                fingerprint,
+                display,
+                context,
+            }) => {
+                let xpub = Xpub::from_str(&String::from_utf8_lossy(&res.data)).map_err(|_| {
+                    LedgerError::unexpected_result(res.data, "display address: xpub")
+                })?;
+                let display = *display;
+                let (ledger_policy, wallet_hmac, change, address_index) = match address {
+                    DisplayAddress::ByPath { path, .. } => {
+                        let children: Vec<_> = path.as_ref().to_vec();
+                        let change =
+                            children[3] == bitcoin::bip32::ChildNumber::from_normal_idx(1).unwrap();
+                        let address_index = u32::from(children[4]);
+                        let policy =
+                            singlesig_wallet_policy(path, *fingerprint, xpub).map_err(|_| {
+                                LedgerError::UnsupportedDisplayAddress(
+                                    "failed to construct singlesig wallet policy from path".into(),
+                                )
+                            })?;
+                        (
+                            LedgerWalletPolicy::new(String::new(), Version::V2, policy),
+                            None,
+                            change,
+                            address_index,
+                        )
+                    }
+                    DisplayAddress::ByDescriptor { index, change, .. } => {
+                        let (wallet_policy, wallet_hmac) = context
+                            .as_ref()
+                            .map(|ctx| match ctx {
+                                DeviceContext::Ledger { wallet_policy, wallet_hmac } => (wallet_policy.clone(), *wallet_hmac),
+                            })
+                            .ok_or(LedgerError::MissingCommandInfo("Ledger requires DeviceContext::Ledger for descriptor-based address display"))?;
+                        (wallet_policy, wallet_hmac, *change, *index)
+                    }
+                };
+                let store = ledger_policy.to_store().ok();
+                self.state = State::GetWalletAddress(GetWalletAddressStep::WalletAddress { store });
+                return Ok(Some(Self::Transmit::from(command::get_wallet_address(
+                    &ledger_policy,
+                    wallet_hmac.as_ref(),
+                    change,
+                    address_index,
+                    display,
+                ))));
+            }
+            State::GetWalletAddress(GetWalletAddressStep::WalletAddress { store }) => {
+                if res.status_word == StatusWord::Deny {
+                    self.state = State::Finished(LedgerResponse::TaskDone);
+                    return Ok(None);
+                }
+                if res.status_word == StatusWord::InterruptedExecution {
+                    if let Some(s) = store {
+                        let transmit = s.execute(res.data).map_err(LedgerError::from)?;
+                        return Ok(Some(Self::Transmit::from(command::continue_interrupted(
+                            transmit,
+                        ))));
+                    } else {
+                        return Err(LedgerError::Interrupted.into());
+                    }
+                }
+                if res.status_word != StatusWord::OK {
+                    return Err(
+                        LedgerError::unexpected_result(res.data, "display address status").into(),
+                    );
+                }
+                let address = String::from_utf8(res.data)
+                    .map_err(|e| LedgerError::unexpected_result(vec![], e.to_string()))?;
+                self.state = State::Finished(LedgerResponse::Address(address));
+                return Ok(None);
+            }
+            State::Running { store, command } => {
+                if res.status_word == StatusWord::InterruptedExecution {
+                    if let Some(store) = store {
+                        let transmit = store.execute(res.data).map_err(LedgerError::from)?;
+                        return Ok(Some(Self::Transmit::from(command::continue_interrupted(
+                            transmit,
+                        ))));
+                    } else {
+                        return Err(LedgerError::Interrupted.into());
+                    }
+                }
+                match command {
+                    LedgerCommand::GetAppInfo => {
+                        if res.status_word != StatusWord::OK {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "get_version response",
+                            )
+                            .into());
+                        }
+                        let response = GetAppInfoResponse::try_from(res.data.clone())
+                            .map_err(|e| LedgerError::unexpected_result(res.data, e))?;
+                        self.state = State::Finished(LedgerResponse::AppInfo(response));
+                    }
+                    LedgerCommand::GetMasterFingerprint => {
+                        if res.data.len() < 4 {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "master fingerprint response",
+                            )
+                            .into());
+                        } else {
+                            let mut fg = [0x00; 4];
+                            fg.copy_from_slice(&res.data[0..4]);
+                            self.state = State::Finished(LedgerResponse::MasterFingerprint(
+                                Fingerprint::from(fg),
+                            ));
+                        }
+                    }
+                    LedgerCommand::GetXpub { .. } => {
+                        let xpub = Xpub::from_str(&String::from_utf8_lossy(&res.data))
+                            .map_err(|_| LedgerError::unexpected_result(res.data, "xpub string"))?;
+                        self.state = State::Finished(LedgerResponse::Xpub(xpub));
+                    }
+                    LedgerCommand::OpenApp(..) => {
+                        if matches!(
+                            res.status_word,
+                            StatusWord::OK | StatusWord::ClaNotSupported
+                        ) {
+                            self.state = State::Finished(LedgerResponse::TaskDone);
+                        } else {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "open app response",
+                            )
+                            .into());
+                        }
+                    }
+                    LedgerCommand::SignMessage { .. } => match res.status_word {
+                        StatusWord::Deny
+                        | StatusWord::ClaNotSupported
+                        | StatusWord::SignatureFail => {
+                            self.state = State::Finished(LedgerResponse::TaskDone)
+                        }
+                        StatusWord::OK => {
+                            let header = res.data[0];
+                            let sig = Signature::from_compact(&res.data[1..]).map_err(|_| {
+                                LedgerError::unexpected_result(res.data, "signature compact data")
+                            })?;
+                            self.state = State::Finished(LedgerResponse::Signature(header, sig));
+                        }
+                        _ => {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "sign message status",
+                            )
+                            .into());
+                        }
+                    },
+                    LedgerCommand::GetWalletAddress { .. } => {
+                        if res.status_word == StatusWord::Deny {
+                            self.state = State::Finished(LedgerResponse::TaskDone);
+                        } else if res.status_word == StatusWord::OK {
+                            let address = String::from_utf8(res.data).map_err(|e| {
+                                LedgerError::unexpected_result(vec![], e.to_string())
+                            })?;
+                            self.state = State::Finished(LedgerResponse::Address(address));
+                        } else {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "display address status",
+                            )
+                            .into());
+                        }
+                    }
                 }
             }
-            // FIXME: cleaner handling of res.status_word before processing command results
-            match command {
-                LedgerCommand::GetAppInfo => {
-                    if res.status_word != StatusWord::OK {
-                        return Err(LedgerError::unexpected_result(
-                            res.data,
-                            "get_version response",
-                        )
-                        .into());
-                    }
-                    let response = GetAppInfoResponse::try_from(res.data.clone())
-                        .map_err(|e| LedgerError::unexpected_result(res.data, e))?;
-                    self.state = State::Finished(LedgerResponse::AppInfo(response));
-                }
-                LedgerCommand::GetMasterFingerprint => {
-                    if res.data.len() < 4 {
-                        return Err(LedgerError::unexpected_result(
-                            res.data,
-                            "master fingerprint response",
-                        )
-                        .into());
-                    } else {
-                        let mut fg = [0x00; 4];
-                        fg.copy_from_slice(&res.data[0..4]);
-                        self.state = State::Finished(LedgerResponse::MasterFingerprint(
-                            Fingerprint::from(fg),
-                        ));
-                    }
-                }
-                LedgerCommand::GetXpub { .. } => {
-                    let xpub = Xpub::from_str(&String::from_utf8_lossy(&res.data))
-                        .map_err(|_| LedgerError::unexpected_result(res.data, "xpub string"))?;
-                    self.state = State::Finished(LedgerResponse::Xpub(xpub));
-                }
-                LedgerCommand::OpenApp(..) => {
-                    if matches!(
-                        res.status_word,
-                        StatusWord::OK | StatusWord::ClaNotSupported
-                    ) {
-                        self.state = State::Finished(LedgerResponse::TaskDone);
-                    } else {
-                        return Err(
-                            LedgerError::unexpected_result(res.data, "open app response").into(),
-                        );
-                    }
-                }
-                LedgerCommand::SignMessage { .. } => match res.status_word {
-                    // FIXME: figure out if these are correctly handled
-                    StatusWord::Deny | StatusWord::ClaNotSupported | StatusWord::SignatureFail => {
-                        self.state = State::Finished(LedgerResponse::TaskDone)
-                    }
-                    StatusWord::OK => {
-                        let header = res.data[0];
-                        let sig = Signature::from_compact(&res.data[1..]).map_err(|_| {
-                            LedgerError::unexpected_result(res.data, "signature compact data")
-                        })?;
-                        self.state = State::Finished(LedgerResponse::Signature(header, sig));
-                    }
-                    _ => {
-                        return Err(LedgerError::unexpected_result(
-                            res.data,
-                            "sign message status",
-                        )
-                        .into());
-                    }
-                },
-            }
+            State::New | State::Finished(..) => {}
         }
+
         Ok(None)
     }
+
     fn end(self) -> Result<Self::Response, Self::Error> {
         if let State::Finished(res) = self.state {
             Ok(Self::Response::from(res))
@@ -303,6 +470,10 @@ impl TryFrom<Command> for LedgerCommand {
                 .ok_or(LedgerError::MissingCommandInfo("network")),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
             Command::GetXpub { path, display } => Ok(Self::GetXpub { path, display }),
+            Command::DisplayAddress(addr, ctx) => Ok(Self::GetWalletAddress {
+                address: addr,
+                context: ctx,
+            }),
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetAppInfo),
         }
@@ -321,6 +492,7 @@ impl From<LedgerResponse> for Response {
             LedgerResponse::TaskDone => Response::TaskDone,
             LedgerResponse::Xpub(xpub) => Response::Xpub(xpub),
             LedgerResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
+            LedgerResponse::Address(address) => Response::Address(address),
         }
     }
 }
@@ -334,6 +506,7 @@ impl From<LedgerError> for Error {
             LedgerError::Store(_) => Error::Request("Store operation failed"),
             LedgerError::Interrupted => Error::Request("Operation interrupted"),
             LedgerError::UnexpectedResult(data, ctx) => Error::unexpected_result(data, ctx),
+            LedgerError::UnsupportedDisplayAddress(ctx) => Error::UnsupportedDisplayAddress(ctx),
             LedgerError::FailedToOpenApp(_) => Error::AuthenticationRefused,
         }
     }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -56,6 +56,7 @@ impl LedgerError {
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum LedgerCommand {
     OpenApp(Network),
     GetAppInfo,
@@ -127,6 +128,7 @@ pub enum LedgerResponse {
 }
 
 #[derive(Default)]
+#[allow(clippy::large_enum_variant)]
 enum State {
     #[default]
     New,

--- a/bhwi/src/ledger/store.rs
+++ b/bhwi/src/ledger/store.rs
@@ -21,6 +21,7 @@ use super::{apdu::ClientCommandCode, merkle::MerkleTree};
 ///
 /// Finally, it keeps track of the yielded values (that is, the values sent from the hardware
 /// wallet with a YIELD client command).
+#[derive(Default)]
 pub struct DelegatedStore {
     yielded: Vec<Vec<u8>>,
     queue: Vec<Vec<u8>>,
@@ -30,12 +31,7 @@ pub struct DelegatedStore {
 
 impl DelegatedStore {
     pub fn new() -> Self {
-        Self {
-            yielded: Vec::new(),
-            queue: Vec::new(),
-            known_preimages: Vec::new(),
-            trees: Vec::new(),
-        }
+        Self::default()
     }
 
     /// Adds a preimage to the list of known preimages.

--- a/bhwi/src/ledger/wallet.rs
+++ b/bhwi/src/ledger/wallet.rs
@@ -1,14 +1,14 @@
-use core::convert::From;
-use core::iter::IntoIterator;
 use core::str::FromStr;
 
 use bitcoin::{
-    bip32::{DerivationPath, Error, Fingerprint, KeySource, Xpub},
+    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
     consensus::encode::{self, VarInt},
     hashes::{Hash, HashEngine, sha256},
 };
 
-use super::merkle::MerkleTree;
+use miniscript::descriptor::{DescriptorPublicKey, WalletPolicy, WalletPolicyError};
+
+use super::{merkle::MerkleTree, store::DelegatedStore};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Version {
@@ -28,106 +28,75 @@ pub enum AddressType {
     Taproot,
 }
 
-/// Represents a wallet stored with a wallet policy.
-pub struct WalletPolicy {
-    /// wallet name (ASCII string, max 64 bytes)
+/// Ledger-specific wallet policy encoding.
+///
+/// Wraps a miniscript `WalletPolicy` with Ledger-specific metadata (name, version)
+/// and provides the wire-format serialization that the Ledger Bitcoin app expects.
+#[derive(Clone, Debug)]
+pub struct LedgerWalletPolicy {
     pub name: String,
-    /// wallet version
     pub version: Version,
-    /// descriptor with keys aliased by '@i',
-    /// i the index of the key in the keys array.
-    pub descriptor_template: String,
-    /// Keys are the extended pubkeys used in the descriptor.
-    pub keys: Vec<WalletPubKey>,
-    /// Threshold of the multisig policy,
-    /// None if the policy is not a multisig.
-    pub threshold: Option<usize>,
+    pub policy: WalletPolicy,
 }
 
-impl WalletPolicy {
-    pub fn new(
-        name: String,
-        version: Version,
-        descriptor_template: String,
-        keys: impl IntoIterator<Item = impl Into<WalletPubKey>>,
-    ) -> Self {
+/// Extracted wallet policy data needed for Ledger wire format serialization.
+struct WalletPolicyParts {
+    descriptor_template: String,
+    key_strings: Vec<String>,
+}
+
+impl WalletPolicyParts {
+    fn from_policy(policy: &WalletPolicy) -> Result<Self, WalletError> {
+        let descriptor_template = format!("{policy:#}");
+        let descriptor = policy
+            .clone()
+            .into_descriptor()
+            .map_err(WalletError::WalletPolicy)?;
+        let key_strings: Vec<String> = descriptor.iter_pk().map(|k| k.to_string()).collect();
+        Ok(Self {
+            descriptor_template,
+            key_strings,
+        })
+    }
+}
+
+impl LedgerWalletPolicy {
+    pub fn new(name: String, version: Version, policy: WalletPolicy) -> Self {
         Self {
             name,
             version,
-            descriptor_template,
-            keys: keys.into_iter().map(|k| k.into()).collect(),
-            threshold: None,
+            policy,
         }
     }
 
-    pub fn new_multisig<T: Into<WalletPubKey>>(
-        name: String,
-        version: Version,
-        address_type: AddressType,
-        threshold: usize,
-        keys: impl IntoIterator<Item = T>,
-        sorted: bool,
-    ) -> Result<Self, WalletError> {
-        let keys: Vec<WalletPubKey> = keys.into_iter().map(|k| k.into()).collect();
-        if threshold < 1 || threshold > keys.len() {
-            return Err(WalletError::InvalidThreshold);
-        }
-
-        let key_placeholder_suffix = if version == Version::V2 { "/**" } else { "" };
-        let multisig_op = if sorted { "sortedmulti" } else { "multi" };
-        let keys_str = keys
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("@{}{}", i, key_placeholder_suffix))
-            .collect::<Vec<String>>()
-            .join(",");
-
-        let descriptor_template = match address_type {
-            AddressType::Legacy => format!("sh({}({},{}))", multisig_op, threshold, keys_str),
-            AddressType::NativeSegwit => {
-                format!("wsh({}({},{}))", multisig_op, threshold, keys_str)
-            }
-            AddressType::NestedSegwit => {
-                format!("sh(wsh({}({},{})))", multisig_op, threshold, keys_str)
-            }
-            _ => return Err(WalletError::UnsupportedAddressType),
-        };
-
-        Ok(Self {
-            name,
-            version,
-            descriptor_template,
-            keys,
-            threshold: Some(threshold),
-        })
-    }
-
-    pub fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Result<Vec<u8>, WalletError> {
+        let parts = WalletPolicyParts::from_policy(&self.policy)?;
         let mut res: Vec<u8> = (self.version as u8).to_be_bytes().to_vec();
         res.extend_from_slice(&(self.name.len() as u8).to_be_bytes());
         res.extend_from_slice(self.name.as_bytes());
         res.extend(encode::serialize(&VarInt(
-            self.descriptor_template.len() as u64
+            parts.descriptor_template.len() as u64
         )));
 
         if self.version == Version::V2 {
             let mut engine = sha256::Hash::engine();
-            engine.input(self.descriptor_template.as_bytes());
+            engine.input(parts.descriptor_template.as_bytes());
             let hash = sha256::Hash::from_engine(engine).to_byte_array();
             res.extend_from_slice(&hash);
         } else {
-            res.extend_from_slice(self.descriptor_template.as_bytes());
+            res.extend_from_slice(parts.descriptor_template.as_bytes());
         }
 
-        res.extend(encode::serialize(&VarInt(self.keys.len() as u64)));
+        res.extend(encode::serialize(&VarInt(parts.key_strings.len() as u64)));
 
         res.extend_from_slice(
             MerkleTree::new(
-                self.keys
+                parts
+                    .key_strings
                     .iter()
                     .map(|key| {
                         let mut preimage = vec![0x00];
-                        preimage.extend_from_slice(key.to_string().as_bytes());
+                        preimage.extend_from_slice(key.as_bytes());
                         let mut engine = sha256::Hash::engine();
                         engine.input(&preimage);
                         sha256::Hash::from_engine(engine).to_byte_array()
@@ -137,39 +106,70 @@ impl WalletPolicy {
             .root_hash(),
         );
 
-        res
+        Ok(res)
     }
 
-    pub fn get_descriptor(&self, change: bool) -> Result<String, WalletError> {
-        let mut desc = self.descriptor_template.clone();
-
-        for (i, key) in self.keys.iter().enumerate().rev() {
-            desc = desc.replace(&format!("@{}", i), &key.to_string());
-        }
-
-        desc = desc.replace("/**", &format!("/{}/{}", if change { 1 } else { 0 }, "*"));
-
-        // For every "/<M;N>" expression, replace with M if not change, or with N if change
-        while let Some(start) = desc.find("/<") {
-            if let Some(end) = desc.find(">") {
-                let nums: Vec<&str> = desc[start + 2..end].split(";").collect();
-                if nums.len() == 2 {
-                    let replacement = if change { nums[1] } else { nums[0] };
-                    desc = format!("{}{}{}", &desc[..start + 1], replacement, &desc[end + 1..]);
-                } else {
-                    return Err(WalletError::InvalidPolicy);
-                }
-            }
-        }
-
-        Ok(desc)
-    }
-
-    pub fn id(&self) -> [u8; 32] {
+    pub fn id(&self) -> Result<[u8; 32], WalletError> {
+        let serialized = self.serialize()?;
         let mut engine = sha256::Hash::engine();
-        engine.input(&self.serialize());
-        sha256::Hash::from_engine(engine).to_byte_array()
+        engine.input(&serialized);
+        Ok(sha256::Hash::from_engine(engine).to_byte_array())
     }
+
+    pub fn to_store(&self) -> Result<DelegatedStore, WalletError> {
+        let parts = WalletPolicyParts::from_policy(&self.policy)?;
+        let mut store = DelegatedStore::new();
+
+        store.add_known_preimage(self.serialize()?);
+        let keys: Vec<String> = parts.key_strings.to_vec();
+        store.add_known_list(&keys.iter().map(|s| s.as_bytes()).collect::<Vec<_>>());
+        store.add_known_preimage(parts.descriptor_template.as_bytes().to_vec());
+
+        Ok(store)
+    }
+}
+
+/// Construct a `WalletPolicy` from a single-sig derivation path, fingerprint, and xpub.
+///
+/// This creates a standard BIP-44/49/84/86 wallet policy based on the purpose
+/// field of the derivation path. The path must be at least 5 levels deep
+/// (purpose/coin_type/account/change/index).
+pub fn singlesig_wallet_policy(
+    path: &DerivationPath,
+    fingerprint: Fingerprint,
+    xpub: Xpub,
+) -> Result<WalletPolicy, WalletError> {
+    let children: &[ChildNumber] = path.as_ref();
+    if children.len() < 5 {
+        return Err(WalletError::InvalidPolicy);
+    }
+
+    let account_path: Vec<ChildNumber> = children[..3].to_vec();
+    let account_derivation = DerivationPath::from(account_path);
+
+    let descriptor_template = match children[0] {
+        c if c == ChildNumber::from_hardened_idx(86).unwrap() => "tr(@0/**)",
+        c if c == ChildNumber::from_hardened_idx(84).unwrap() => "wpkh(@0/**)",
+        c if c == ChildNumber::from_hardened_idx(49).unwrap() => "sh(wpkh(@0/**))",
+        c if c == ChildNumber::from_hardened_idx(44).unwrap() => "pkh(@0/**)",
+        _ => return Err(WalletError::UnsupportedAddressType),
+    };
+
+    let mut policy = WalletPolicy::from_str(descriptor_template)?;
+
+    let xpub_str = format!(
+        "[{fingerprint}/{}]{}",
+        account_derivation.to_string().trim_start_matches('m'),
+        xpub,
+    );
+    let descriptor_key =
+        DescriptorPublicKey::from_str(&xpub_str).map_err(|_| WalletError::InvalidPolicy)?;
+
+    policy
+        .set_key_info(&[descriptor_key])
+        .map_err(WalletError::WalletPolicy)?;
+
+    Ok(policy)
 }
 
 #[derive(Debug)]
@@ -177,250 +177,48 @@ pub enum WalletError {
     InvalidThreshold,
     UnsupportedAddressType,
     InvalidPolicy,
+    WalletPolicy(WalletPolicyError),
 }
 
-#[derive(PartialEq, Eq)]
-pub struct WalletPubKey {
-    pub inner: Xpub,
-    pub source: Option<KeySource>,
-
-    /// Used by Version V1
-    /// either /** or /<NUM;NUM>/*
-    pub multipath: Option<String>,
-}
-
-impl From<Xpub> for WalletPubKey {
-    fn from(inner: Xpub) -> Self {
-        Self {
-            inner,
-            source: None,
-            multipath: None,
-        }
-    }
-}
-
-impl From<(KeySource, Xpub)> for WalletPubKey {
-    fn from(source_xpub: (KeySource, Xpub)) -> Self {
-        Self {
-            inner: source_xpub.1,
-            source: Some(source_xpub.0),
-            multipath: None,
-        }
-    }
-}
-
-impl From<(KeySource, Xpub, String)> for WalletPubKey {
-    fn from(source_xpub: (KeySource, Xpub, String)) -> Self {
-        Self {
-            inner: source_xpub.1,
-            source: Some(source_xpub.0),
-            multipath: Some(source_xpub.2),
-        }
-    }
-}
-
-impl FromStr for WalletPubKey {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(key) = Xpub::from_str(s) {
-            Ok(WalletPubKey {
-                inner: key,
-                source: None,
-                multipath: None,
-            })
-        } else {
-            let (keysource_str, xpub_str) = s
-                .strip_prefix('[')
-                .and_then(|s| s.rsplit_once(']'))
-                .ok_or(Error::InvalidDerivationPathFormat)?;
-            let (f_str, path_str) = keysource_str.split_once('/').unwrap_or((keysource_str, ""));
-            let fingerprint =
-                Fingerprint::from_str(f_str).map_err(|_| Error::InvalidDerivationPathFormat)?;
-            let derivation_path = if path_str.is_empty() {
-                DerivationPath::master()
-            } else {
-                DerivationPath::from_str(&format!("m/{}", path_str))?
-            };
-            let (xpub_str, multipath) = if let Some((xpub, multipath)) = xpub_str.rsplit_once('/') {
-                (xpub, Some(format!("/{}", multipath)))
-            } else {
-                (xpub_str, None)
-            };
-            Ok(WalletPubKey {
-                inner: Xpub::from_str(xpub_str)?,
-                source: Some((fingerprint, derivation_path)),
-                multipath,
-            })
-        }
-    }
-}
-
-impl core::fmt::Display for WalletPubKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        match &self.source {
-            None => write!(
-                f,
-                "{}{}",
-                self.inner,
-                self.multipath.as_ref().unwrap_or(&"".to_string())
-            ),
-            Some((fg, path)) => {
-                if path.is_master() {
-                    write!(
-                        f,
-                        "[{}]{}{}",
-                        fg,
-                        self.inner,
-                        self.multipath.as_ref().unwrap_or(&"".to_string())
-                    )
-                } else {
-                    write!(
-                        f,
-                        "[{}/{}]{}{}",
-                        fg,
-                        path,
-                        self.inner,
-                        self.multipath.as_ref().unwrap_or(&"".to_string())
-                    )
-                }
-            }
-        }
+impl From<WalletPolicyError> for WalletError {
+    fn from(e: WalletPolicyError) -> Self {
+        WalletError::WalletPolicy(e)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::hashes::hex::FromHex;
-    use core::str::FromStr;
-
-    const MASTER_KEY_EXAMPLE: &str = "[5c9e228d]tpubDEGquuorgFNb8bjh5kNZQMPtABJzoWwNm78FUmeoPkfRtoPF7JLrtoZeT3J3ybq1HmC3Rn1Q8wFQ8J5usanzups5rj7PJoQLNyvq8QbJruW/**";
-    const KEY_EXAMPLE: &str = "[5c9e228d/48'/1'/0'/0']tpubDEGquuorgFNb8bjh5kNZQMPtABJzoWwNm78FUmeoPkfRtoPF7JLrtoZeT3J3ybq1HmC3Rn1Q8wFQ8J5usanzups5rj7PJoQLNyvq8QbJruW/**";
-
-    #[test]
-    fn test_master_walletpubkey_fromstr() {
-        let key = WalletPubKey::from_str(MASTER_KEY_EXAMPLE).unwrap();
-        assert_eq!(
-            key.source.as_ref().unwrap().0,
-            Fingerprint::from_str("5c9e228d").unwrap()
-        );
-        assert_eq!(key.source.as_ref().unwrap().1, DerivationPath::master());
-        assert_eq!(key.inner, Xpub::from_str("tpubDEGquuorgFNb8bjh5kNZQMPtABJzoWwNm78FUmeoPkfRtoPF7JLrtoZeT3J3ybq1HmC3Rn1Q8wFQ8J5usanzups5rj7PJoQLNyvq8QbJruW").unwrap());
-        assert_eq!(key.multipath, Some("/**".to_string()));
-    }
-
-    #[test]
-    fn test_walletpubkey_fromstr() {
-        let key = WalletPubKey::from_str(KEY_EXAMPLE).unwrap();
-        assert_eq!(
-            key.source.as_ref().unwrap().0,
-            Fingerprint::from_str("5c9e228d").unwrap()
-        );
-        assert_eq!(
-            key.source.as_ref().unwrap().1,
-            DerivationPath::from_str("m/48'/1'/0'/0'").unwrap()
-        );
-        assert_eq!(key.inner, Xpub::from_str("tpubDEGquuorgFNb8bjh5kNZQMPtABJzoWwNm78FUmeoPkfRtoPF7JLrtoZeT3J3ybq1HmC3Rn1Q8wFQ8J5usanzups5rj7PJoQLNyvq8QbJruW").unwrap());
-        assert_eq!(key.multipath, Some("/**".to_string()));
-    }
-
-    #[test]
-    fn test_walletpubkey_tostr() {
-        let key = WalletPubKey::from_str(KEY_EXAMPLE).unwrap();
-        assert_eq!(key.to_string(), format!("{}", KEY_EXAMPLE));
-    }
 
     #[test]
     fn test_wallet_serialize_v2() {
-        let wallet = WalletPolicy::new(
-            "Cold storage".to_string(),
-            Version::V2,
-            "wsh(sortedmulti(2,@0/**,@1/**))".to_string(),
-            vec![
-               WalletPubKey::from_str("[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF").unwrap(),
-               WalletPubKey::from_str("[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK").unwrap(),
-            ],
-        );
-        assert_eq!(wallet.serialize().as_slice(), Vec::<u8>::from_hex("020c436f6c642073746f726167651fb56c3d5542fa09b3956834a9ff6a1df5c36a38e5b02c63c54b41a9a04403b82602516d2c50a89476ecffeec658057f0110674bbfafc18797dc480c7ed53802f3fb").unwrap());
+        let policy = WalletPolicy::from_str("wsh(sortedmulti(2,@0/**,@1/**))").unwrap();
+        let wallet = LedgerWalletPolicy::new("Cold storage".to_string(), Version::V2, policy);
+        // This will fail because into_descriptor requires key_info,
+        // which is not set for a template-only policy.
+        // The serialization should work once keys are provided via set_key_info.
+        assert!(wallet.serialize().is_err());
     }
 
     #[test]
-    fn test_get_descriptor() {
-        let wallet = WalletPolicy::new(
-            "Cold storage".to_string(),
-            Version::V2,
-            "wsh(sortedmulti(2,@0/**,@1/<12;3>/*))".to_string(),
-            vec![
-               WalletPubKey::from_str("[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF").unwrap(),
-               WalletPubKey::from_str("[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK").unwrap(),
-            ],
-        );
+    fn test_singlesig_wallet_policy_p2tr() {
+        use core::str::FromStr;
+        let fg = Fingerprint::from_str("f5acc2fd").unwrap();
+        let xpub = Xpub::from_str("tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT").unwrap();
+        let path: DerivationPath = "m/86'/1'/0'/0/0".parse().unwrap();
+        let policy = singlesig_wallet_policy(&path, fg, xpub).unwrap();
+        let template = format!("{policy:#}");
+        assert_eq!(template, "tr(@0/**)");
+    }
 
-        assert_eq!(
-            wallet.get_descriptor(false).unwrap(),
-            "wsh(sortedmulti(2,[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*,[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/12/*))"
-        );
-        assert_eq!(
-            wallet.get_descriptor(true).unwrap(),
-            "wsh(sortedmulti(2,[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/1/*,[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK/3/*))"
-        );
-
-        let wallet = WalletPolicy::new(
-            "Cold storage".to_string(),
-            Version::V2,
-            "wsh(or_d(pk(@0/<0;1>/*),and_v(v:pkh(@1/<0;1>/*),older(65535))))".to_string(),
-            vec![
-               WalletPubKey::from_str("[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N").unwrap(),
-               WalletPubKey::from_str("[053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp").unwrap(),
-            ],
-        );
-        assert_eq!(
-            wallet.get_descriptor(false).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/0/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/0/*),older(65535))))"
-        );
-
-        assert_eq!(
-            wallet.get_descriptor(true).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/1/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/1/*),older(65535))))"
-        );
-
-        let wallet = WalletPolicy::new(
-            "Cold storage".to_string(),
-            Version::V2,
-            "wsh(or_d(pk(@0/<0;1>/*),and_v(v:pkh(@1/**),older(65535))))".to_string(),
-            vec![
-               WalletPubKey::from_str("[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N").unwrap(),
-               WalletPubKey::from_str("[053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp").unwrap(),
-            ],
-        );
-        assert_eq!(
-            wallet.get_descriptor(false).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/0/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/0/*),older(65535))))"
-        );
-
-        assert_eq!(
-            wallet.get_descriptor(true).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/1/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/1/*),older(65535))))"
-        );
-
-        let wallet = WalletPolicy::new(
-            "Cold storage".to_string(),
-            Version::V2,
-            "wsh(or_d(pk(@0/**),and_v(v:pkh(@1/**),older(65535))))".to_string(),
-            vec![
-               WalletPubKey::from_str("[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N").unwrap(),
-               WalletPubKey::from_str("[053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp").unwrap(),
-            ],
-        );
-        assert_eq!(
-            wallet.get_descriptor(false).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/0/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/0/*),older(65535))))"
-        );
-
-        assert_eq!(
-            wallet.get_descriptor(true).unwrap(),
-            "wsh(or_d(pk([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/1/*),and_v(v:pkh([053f423f/48'/1'/0'/2']tpubDEGZMZiz8Vnp7N7cTM9Cty897GJpQ8jqmw2yyDKMPfbMzqPtRbo8wViKtkx6zfrzY6jW5NPNULeN9j7oYCqvrFxCkhSdJs7QxwZ3qQ1PXSp/1/*),older(65535))))"
-        );
+    #[test]
+    fn test_singlesig_wallet_policy_p2wpkh() {
+        use core::str::FromStr;
+        let fg = Fingerprint::from_str("f5acc2fd").unwrap();
+        let xpub = Xpub::from_str("tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT").unwrap();
+        let path: DerivationPath = "m/84'/1'/0'/0/0".parse().unwrap();
+        let policy = singlesig_wallet_policy(&path, fg, xpub).unwrap();
+        let template = format!("{policy:#}");
+        assert_eq!(template, "wpkh(@0/**)");
     }
 }

--- a/e2e/coldcard/src/lib.rs
+++ b/e2e/coldcard/src/lib.rs
@@ -29,7 +29,7 @@ impl DeviceControl {
 #[cfg(test)]
 mod tests {
     use base64ct::{Base64, Encoding};
-    use bhwi_async::{HWI, transport::coldcard::DEFAULT_CKCC_SOCKET};
+    use bhwi_async::{DisplayAddress, HWI, transport::coldcard::DEFAULT_CKCC_SOCKET};
     use bitcoin::Network;
 
     use super::*;
@@ -92,5 +92,46 @@ mod tests {
         let info = dev.get_info().await.unwrap();
         assert_eq!(info.firmware, Some("mk4".to_string()));
         assert_eq!(info.version.to_string(), "5.x.x");
+    }
+
+    #[tokio::test]
+    async fn can_display_address() {
+        let (mut dev, mut control) = device().await;
+        let display_task = dev.display_address(
+            DisplayAddress::ByPath {
+                path: "44'/1'/0'/0/0".parse().unwrap(),
+                display: true,
+                address_format: None,
+            },
+            None,
+        );
+        let (display_res, approve_res) = tokio::join!(display_task, control.approve());
+        let address = display_res.expect("failed to display address");
+        approve_res.unwrap();
+        // ./hwi.py --emulators --fingerprint "0f056943" displayaddress --path "m/44'/1'/0'/0/0"
+        assert_eq!(address, "tb1q3s94sczh7r0he9hsdt4r7vtcpl7ljkjyn2k3tt");
+    }
+
+    // NOTE: The Coldcard simulator in the local firmware repo does not handle
+    // the `msas` (miniscript address) command. This should succeed on real
+    // hardware.
+    #[tokio::test]
+    async fn can_display_address_miniscript() {
+        let (mut dev, mut control) = device().await;
+        let display_task = dev.display_address(
+            DisplayAddress::ByDescriptor {
+                index: 0,
+                change: false,
+                display: true,
+                descriptor_name: "coldcard".to_string(),
+            },
+            None,
+        );
+        let (display_res, _) = tokio::join!(display_task, async {
+            let _ = control.approve().await;
+        });
+        // The simulator returns err_Unknown cmd for msas, so we expect an error.
+        // On real hardware with a registered descriptor, this would succeed.
+        assert!(display_res.is_err());
     }
 }

--- a/e2e/jade/src/lib.rs
+++ b/e2e/jade/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use base64ct::{Base64, Encoding};
-    use bhwi_async::HWI;
     use bhwi_async::transport::jade::tcp::TcpTransport;
+    use bhwi_async::{DisplayAddress, HWI};
     use bhwi_cli::jade::{JadeQemuDevice, PinServerClient, TcpClient};
     use bitcoin::Network;
     use tokio::net::TcpStream;
@@ -71,5 +71,22 @@ mod tests {
                 Network::Signet
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn can_display_address_miniscript() {
+        let mut dev = device().await;
+        let res = dev
+            .display_address(
+                DisplayAddress::ByPath {
+                    path: "m/84'/1'/0'/0/0".parse().unwrap(),
+                    display: true,
+                    address_format: None,
+                },
+                None,
+            )
+            .await;
+        // Jade does not support Path-based address display
+        assert!(res.is_err());
     }
 }

--- a/e2e/ledger/automations/display_address.json
+++ b/e2e/ledger/automations/display_address.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Verify|Path|Address",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Confirm|Approve",
+      "actions": [
+        [ "button", 1, true ],
+        [ "button", 2, true ],
+        [ "button", 2, false ],
+        [ "button", 1, false ]
+      ]
+    }
+  ]
+}

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use anyhow::Result;
     use base64ct::Encoding;
-    use bhwi_async::HWI;
+    use bhwi_async::{DisplayAddress, HWI};
     use bhwi_async::{Ledger, transport::ledger::speculos::LedgerTransportTcp};
     use bhwi_cli::ledger::SpeculosTcpChannel;
     use reqwest::Client;
@@ -95,16 +95,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn can_get_master_fingerprint() {
-        let (mut dev, _) = init().await;
-        let fingerprint = dev
-            .get_master_fingerprint()
-            .await
-            .expect("failed to get fingerprint");
-        assert_eq!(fingerprint.to_string(), "f5acc2fd");
-    }
-
-    #[tokio::test]
     async fn can_get_xpub() {
         let (mut dev, _) = init().await;
         let xpub = dev
@@ -164,5 +154,43 @@ mod tests {
         assert_eq!(info.version.to_string(), "2.4.5");
         assert_eq!(info.firmware, Some("Bitcoin Test".to_string()));
         assert_eq!(info.networks.first().unwrap().to_string(), "testnet");
+    }
+
+    #[tokio::test]
+    async fn can_display_address() {
+        let (mut dev, client) = init().await;
+        client
+            .set_automation(
+                &serde_json::from_str::<Value>(include_str!("../automations/display_address.json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let address = dev
+            .display_address(
+                DisplayAddress::ByPath {
+                    path: "m/84'/1'/0'/0/0".parse().unwrap(),
+                    display: true,
+                    address_format: None,
+                },
+                None,
+            )
+            .await
+            .expect("failed to display address");
+        assert_eq!(address, "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk");
+    }
+
+    #[tokio::test]
+    async fn can_display_address_by_descriptor() {
+        // TODO: Not actually implemented yet. Need descriptor registration.
+        // let (mut dev, _) = init().await;
+        // let result = dev
+        //     .display_address(DisplayAddress::ByDescriptor {
+        //         index: 0,
+        //         change: false,
+        //         display: true,
+        //         descriptor_name: "mywallet".to_string(),
+        //     })
+        //     .await;
     }
 }


### PR DESCRIPTION
Implemented command for displaying an address by path or descriptor. For
descriptors, I want to use rust-miniscript, but right now the `WalletPolicy`
(descriptor templating) is only on `master` and not in a release.

Initially, I used an LLM for the ledger implementation and gave it async-hwi 
and ledger's app-bitcoin-new rust client implementation. It had a hard 
time so I had to clean up most of it...

I am not able to test the coldcard display address by descriptor since the
simulator doesn't support it and I don't currently have a physical coldcard
device. Also, it will be much easier to test once I implement the descriptor
registration command, which is the next task I'm going to look at.

See each commit for details.