### PR TITLE
ci: add nix-backed emulator e2e workflow

### DIFF
--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -1,0 +1,171 @@
+name: Emulator CI
+
+on:
+  push:
+    branches:
+      - main
+      - feat/nix-emulator-ci
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TEST_THREADS: "1"
+  XDG_CACHE_HOME: ${{ github.workspace }}/.cache
+
+jobs:
+  nix-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Show flake outputs
+        run: nix flake show --allow-import-from-derivation
+      - name: Build script check
+        run: nix build .#checks.x86_64-linux.emulator-scripts
+
+  coldcard-e2e:
+    needs: nix-flake
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}/bhwi/coldcard
+          key: coldcard-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/scripts/start-coldcard.sh') }}
+          restore-keys: |
+            coldcard-${{ runner.os }}-
+      - name: Start Coldcard simulator
+        run: |
+          nix run .#coldcard > coldcard.log 2>&1 &
+          echo $! > coldcard.pid
+          tail -n +1 -F coldcard.log &
+          echo $! > coldcard-tail.pid
+          bash nix/scripts/wait-for-socket.sh /tmp/ckcc-simulator.sock 1800 "$(cat coldcard.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Coldcard startup log" coldcard.log
+            cat coldcard.log || true
+            exit 1
+          }
+          kill "$(cat coldcard-tail.pid)" || true
+      - name: Run Coldcard e2e
+        run: |
+          set -o pipefail
+          nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1 2>&1 | tee coldcard-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Coldcard e2e log" coldcard-e2e.log
+            cat coldcard-e2e.log || true
+            exit 1
+          }
+      - name: Coldcard logs
+        if: always()
+        run: |
+          cat coldcard.log || true
+          if [ -f coldcard.pid ]; then kill "$(cat coldcard.pid)" || true; fi
+
+  ledger-e2e:
+    needs: nix-flake
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}/bhwi/ledger
+          key: ledger-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/scripts/build-ledger-app.sh', 'nix/scripts/start-ledger.sh') }}
+          restore-keys: |
+            ledger-${{ runner.os }}-
+      - name: Start Ledger Speculos
+        run: |
+          nix run .#ledger > ledger.log 2>&1 &
+          echo $! > ledger.pid
+          tail -n +1 -F ledger.log &
+          echo $! > ledger-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger startup log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          bash nix/scripts/wait-for-port.sh localhost 5000 300 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger startup log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger e2e
+        run: |
+          set -o pipefail
+          nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1 2>&1 | tee ledger-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger e2e log" ledger-e2e.log
+            cat ledger-e2e.log || true
+            exit 1
+          }
+      - name: Ledger logs
+        if: always()
+        run: |
+          cat ledger.log || true
+          if [ -f ledger.pid ]; then kill "$(cat ledger.pid)" || true; fi
+
+  jade-e2e:
+    needs: nix-flake
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}/bhwi/jade
+          key: jade-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/scripts/start-jade.sh', 'nix/scripts/start-jade-pinserver.sh', 'nix/scripts/init-jade.sh') }}
+          restore-keys: |
+            jade-${{ runner.os }}-
+      - name: Start Jade pinserver
+        run: |
+          nix run .#jade-pinserver > jade-pinserver.log 2>&1 &
+          echo $! > jade-pinserver.pid
+          tail -n +1 -F jade-pinserver.log &
+          echo $! > jade-pinserver-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 8096 1800 "$(cat jade-pinserver.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade pinserver startup log" jade-pinserver.log
+            cat jade-pinserver.log || true
+            exit 1
+          }
+          kill "$(cat jade-pinserver-tail.pid)" || true
+      - name: Start Jade QEMU
+        run: |
+          nix run .#jade > jade.log 2>&1 &
+          echo $! > jade.pid
+          tail -n +1 -F jade.log &
+          echo $! > jade-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 30121 1800 "$(cat jade.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade QEMU startup log" jade.log
+            cat jade.log || true
+            exit 1
+          }
+          kill "$(cat jade-tail.pid)" || true
+      - name: Initialize Jade
+        run: |
+          nix run .#jade-init > jade-init.log 2>&1 || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade init log" jade-init.log
+            cat jade-init.log || true
+            exit 1
+          }
+      - name: Run Jade e2e
+        run: |
+          set -o pipefail
+          nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1 2>&1 | tee jade-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade e2e log" jade-e2e.log
+            cat jade-e2e.log || true
+            exit 1
+          }
+      - name: Jade logs
+        if: always()
+        run: |
+          cat jade-pinserver.log || true
+          cat jade.log || true
+          if [ -f jade.pid ]; then kill "$(cat jade.pid)" || true; fi
+          if [ -f jade-pinserver.pid ]; then kill "$(cat jade-pinserver.pid)" || true; fi

--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.XDG_CACHE_HOME }}/bhwi/ledger
-          key: ledger-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/scripts/build-ledger-app.sh', 'nix/scripts/start-ledger.sh') }}
+          key: ledger-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/speculos.nix', 'nix/scripts/build-ledger-app.sh', 'nix/scripts/start-ledger.sh') }}
           restore-keys: |
             ledger-${{ runner.os }}-
       - name: Start Ledger Speculos

--- a/docs/COLDCARD.md
+++ b/docs/COLDCARD.md
@@ -1,5 +1,19 @@
 # Coldcard Emulation
 
+## Nix
+
+The recommended local e2e path is the Nix runner documented in
+[`docs/NIX.md`](NIX.md). It builds the pinned Coldcard simulator under
+`$XDG_CACHE_HOME/bhwi/coldcard` and exposes `/tmp/ckcc-simulator.sock`.
+
+```sh
+# Terminal 1
+nix run .#coldcard
+
+# Terminal 2
+nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1
+```
+
 ## Installation
 
 Follow instructions [here](https://github.com/Coldcard/firmware/blob/master/README.md) to build

--- a/docs/JADE.md
+++ b/docs/JADE.md
@@ -1,5 +1,23 @@
 # Jade Emulation
 
+## Nix
+
+The recommended local e2e path is the Nix runner documented in
+[`docs/NIX.md`](NIX.md). It starts the Jade pinserver, runs the pinned Jade QEMU
+image, and uses `jade-init` to configure the emulator for tests.
+
+```sh
+# Terminal 1
+nix run .#jade-pinserver
+
+# Terminal 2
+nix run .#jade
+
+# Terminal 3, after QEMU is listening
+nix run .#jade-init
+nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1
+```
+
 ## Docker/Podman
 
 https://github.com/Blockstream/Jade/blob/1ca0a0a475f227153070bc00e56734e0ca1fe6c2/README.md?plain=1#L257

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -2,6 +2,20 @@
 
 ## Simulating Ledger Devices
 
+## Nix
+
+The recommended local e2e path is the Nix runner documented in
+[`docs/NIX.md`](NIX.md). It builds the pinned Ledger Bitcoin app when needed and
+starts Speculos on APDU `localhost:9999` and API `localhost:5000`.
+
+```sh
+# Terminal 1
+nix run .#ledger
+
+# Terminal 2
+nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1
+```
+
 ## Installing
 
 ### Install the Speculos emulator

--- a/docs/NIX-EMULATORS-PLAN.md
+++ b/docs/NIX-EMULATORS-PLAN.md
@@ -1,0 +1,114 @@
+# Nix Emulator CI
+
+BHWI uses Nix flake outputs to run emulator-backed e2e tests for the currently
+supported devices: Coldcard, Ledger, and Jade.
+
+The emulator outputs are Linux-only and intended for GitHub Actions first, with
+the same commands available locally.
+
+## CI
+
+`.github/workflows/emulators.yml` runs:
+
+- `nix flake show --allow-import-from-derivation`
+- `nix build .#checks.x86_64-linux.emulator-scripts`
+- `cargo test -p bhwi-e2e-coldcard -- --test-threads=1`
+- `cargo test -p bhwi-e2e-ledger -- --test-threads=1`
+- `cargo test -p bhwi-e2e-jade -- --test-threads=1`
+
+CI uses:
+
+- Determinate Systems Nix installer
+- `actions/cache` for mutable emulator build caches under
+  `$XDG_CACHE_HOME/bhwi`
+
+This avoids committing firmware binaries while preventing heavy emulator
+artifacts from rebuilding on every PR once the cache is warm. Nix store paths
+come from the public binary caches configured by the installer.
+
+## Flake Outputs
+
+Apps:
+
+- `nix run .#coldcard`
+- `nix run .#ledger`
+- `nix run .#ledger-build-app`
+- `nix run .#jade-pinserver`
+- `nix run .#jade`
+- `nix run .#jade-init`
+
+Development shells:
+
+- `nix develop .#coldcard`
+- `nix develop .#ledger`
+- `nix develop .#jade`
+
+Packages/checks:
+
+- `nix build .#speculos`
+- `nix build .#coldcard-simulator`
+- `nix build .#ledger-app`
+- `nix build .#jade-qemu`
+- `nix build .#checks.x86_64-linux.emulator-scripts`
+
+## Local E2E
+
+Coldcard:
+
+```sh
+nix run .#coldcard
+nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1
+```
+
+Ledger:
+
+```sh
+nix run .#ledger
+nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1
+```
+
+Jade:
+
+```sh
+nix run .#jade-pinserver
+nix run .#jade
+nix run .#jade-init
+nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1
+```
+
+## Device Details
+
+Coldcard:
+
+- Uses pinned `Coldcard/firmware`.
+- Builds the Unix simulator in `$XDG_CACHE_HOME/bhwi/coldcard`.
+- Starts `simulator.py --headless`.
+- Exposes `/tmp/ckcc-simulator.sock`.
+
+Ledger:
+
+- Uses pinned `LedgerHQ/app-bitcoin-new`.
+- Builds the Nano X Bitcoin app ELF through Ledger's app-builder container and
+  caches it under `$XDG_CACHE_HOME/bhwi/ledger`.
+- Starts Speculos through Ledger's app-builder container on APDU
+  `localhost:9999` and API `localhost:5000`.
+- `LEDGER_APP_ELF=/path/to/app.elf` can override the cached build.
+
+Jade:
+
+- Uses pinned `Blockstream/Jade`.
+- Uses `nixpkgs-esp-dev` for ESP-IDF and Espressif QEMU.
+- Runs the Jade pinserver directly from the pinned `blind_pin_server`
+  submodule with a cached Python venv.
+- Builds/caches `flash_image.bin` under `$XDG_CACHE_HOME/bhwi/jade`.
+- Starts QEMU TCP serial on `localhost:30121` and web display on
+  `localhost:30122`.
+- `jade-init` sets the e2e mnemonic and configures the local pinserver.
+
+## Notes
+
+- Emulator tests must run serially. Pass `-- --test-threads=1`; this is not set
+  in `.cargo/config.toml`.
+- Emulator outputs are restricted to `x86_64-linux`.
+- The first CI run for a changed emulator source may be slow. Follow-up runs
+  should hit Magic Nix Cache and the `$XDG_CACHE_HOME/bhwi` artifact cache.

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -1,4 +1,4 @@
-# Nix Emulator CI
+# Nix
 
 BHWI uses Nix flake outputs to run emulator-backed e2e tests for the currently
 supported devices: Coldcard, Ledger, and Jade.
@@ -53,27 +53,52 @@ Packages/checks:
 
 ## Local E2E
 
+Run each emulator in its own terminal, then run the matching test command from
+another terminal after the emulator is ready. The first run may take a while
+because firmware and Python environments are built under `$XDG_CACHE_HOME/bhwi`.
+
 Coldcard:
 
 ```sh
+# Terminal 1
 nix run .#coldcard
+
+# Terminal 2
 nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1
 ```
 
 Ledger:
 
 ```sh
+# Terminal 1
 nix run .#ledger
+
+# Terminal 2
 nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1
 ```
 
 Jade:
 
 ```sh
+# Terminal 1
 nix run .#jade-pinserver
+
+# Terminal 2
 nix run .#jade
+
+# Terminal 3, after QEMU is listening
 nix run .#jade-init
+
+# Terminal 3
 nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1
+```
+
+Useful readiness checks:
+
+```sh
+test -S /tmp/ckcc-simulator.sock
+nc -z localhost 9999 && nc -z localhost 5000
+nc -z localhost 8096 && nc -z localhost 30121
 ```
 
 ## Device Details

--- a/e2e/coldcard/src/lib.rs
+++ b/e2e/coldcard/src/lib.rs
@@ -90,7 +90,7 @@ mod tests {
     async fn can_get_info() {
         let (mut dev, _) = device().await;
         let info = dev.get_info().await.unwrap();
-        assert_eq!(info.firmware, Some("mk4".to_string()));
+        assert_eq!(info.firmware, Some("mk5".to_string()));
         assert_eq!(info.version.to_string(), "5.x.x");
     }
 

--- a/e2e/jade/src/lib.rs
+++ b/e2e/jade/src/lib.rs
@@ -67,8 +67,8 @@ mod tests {
                 Network::Bitcoin,
                 Network::Testnet,
                 Network::Testnet4,
-                Network::Regtest,
-                Network::Signet
+                Network::Signet,
+                Network::Regtest
             ]
         );
     }

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -155,7 +155,7 @@ mod tests {
     async fn can_get_version() {
         let (mut dev, _) = init().await;
         let info = dev.get_info().await.unwrap();
-        assert_eq!(info.version.to_string(), "2.4.5");
+        assert_eq!(info.version.to_string(), "2.4.6");
         assert_eq!(info.firmware, Some("Bitcoin Test".to_string()));
         assert_eq!(info.networks.first().unwrap().to_string(), "testnet");
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,37 @@
 {
   "nodes": {
+    "app-bitcoin-new": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778169666,
+        "narHash": "sha256-5cKGK8NRmSHzBEb9gCR3u7Yh6G/r9QZCrqpAVbdZPRg=",
+        "owner": "LedgerHQ",
+        "repo": "app-bitcoin-new",
+        "rev": "d03ad67b243d424595c32df60a385f5aa575b912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LedgerHQ",
+        "repo": "app-bitcoin-new",
+        "type": "github"
+      }
+    },
+    "coldcard-firmware": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777127775,
+        "narHash": "sha256-Zw1jd4/LN55/o4462wtEJMUEOH4OjD3CVGPOZFpmO1c=",
+        "owner": "Coldcard",
+        "repo": "firmware",
+        "rev": "ca06dfd2509eacfad333be9d35ed274559915d0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Coldcard",
+        "repo": "firmware",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,6 +50,58 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "jade-firmware": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772102672,
+        "narHash": "sha256-Aahk6zMMyxMIPl18RjoJsjLjV7Yunuer+1SSiWlBs6g=",
+        "owner": "Blockstream",
+        "repo": "Jade",
+        "rev": "1ca0a0a475f227153070bc00e56734e0ca1fe6c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Blockstream",
+        "repo": "Jade",
+        "rev": "1ca0a0a475f227153070bc00e56734e0ca1fe6c2",
+        "type": "github"
+      }
+    },
+    "jade-pinserver": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770970125,
+        "narHash": "sha256-GrbwOHOOgNbh4398Tva31QFaZFIR4d6IHdAD+gnXt0I=",
+        "owner": "Blockstream",
+        "repo": "blind_pin_server",
+        "rev": "0205d38e75cb47f187db2efda5846cc898a85039",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Blockstream",
+        "repo": "blind_pin_server",
+        "rev": "0205d38e75cb47f187db2efda5846cc898a85039",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773282481,
@@ -33,10 +117,67 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-coldcard": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-esp-dev": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1767865407,
+        "narHash": "sha256-QWF1rZYd+HvNzLIeRS+OEBX7HF0EhWCGeLbMkgtbsIo=",
+        "owner": "mirrexagon",
+        "repo": "nixpkgs-esp-dev",
+        "rev": "5287d6e1ca9e15ebd5113c41b9590c468e1e001b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mirrexagon",
+        "repo": "nixpkgs-esp-dev",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "app-bitcoin-new": "app-bitcoin-new",
+        "coldcard-firmware": "coldcard-firmware",
         "flake-utils": "flake-utils",
+        "jade-firmware": "jade-firmware",
+        "jade-pinserver": "jade-pinserver",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-coldcard": "nixpkgs-coldcard",
+        "nixpkgs-esp-dev": "nixpkgs-esp-dev",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -61,6 +202,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "app-bitcoin-new": {
       "flake": false,
       "locked": {
-        "lastModified": 1778169666,
-        "narHash": "sha256-5cKGK8NRmSHzBEb9gCR3u7Yh6G/r9QZCrqpAVbdZPRg=",
+        "lastModified": 1779205252,
+        "narHash": "sha256-LNvZm7ZpKO+ruHQPTcCkjoMT4dm8Tt45lI5VrN5ZQ0Y=",
         "owner": "LedgerHQ",
         "repo": "app-bitcoin-new",
-        "rev": "d03ad67b243d424595c32df60a385f5aa575b912",
+        "rev": "3ac253258f8cec4922255a0296eeb6119f72f572",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,25 @@
   description = "Minimal rust wasm32-unknown-unknown example";
 
   inputs = {
+    app-bitcoin-new = {
+      url = "github:LedgerHQ/app-bitcoin-new";
+      flake = false;
+    };
+    coldcard-firmware = {
+      url = "github:Coldcard/firmware";
+      flake = false;
+    };
     flake-utils.url = "github:numtide/flake-utils";
+    jade-firmware = {
+      url = "github:Blockstream/Jade/1ca0a0a475f227153070bc00e56734e0ca1fe6c2";
+      flake = false;
+    };
+    jade-pinserver = {
+      url = "github:Blockstream/blind_pin_server/0205d38e75cb47f187db2efda5846cc898a85039";
+      flake = false;
+    };
+    nixpkgs-esp-dev.url = "github:mirrexagon/nixpkgs-esp-dev";
+    nixpkgs-coldcard.url = "github:NixOS/nixpkgs/nixos-24.05";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -12,7 +30,13 @@
 
   outputs = {
     self,
+    app-bitcoin-new,
+    coldcard-firmware,
+    jade-firmware,
+    jade-pinserver,
     nixpkgs,
+    nixpkgs-coldcard,
+    nixpkgs-esp-dev,
     flake-utils,
     rust-overlay,
   }:
@@ -20,6 +44,22 @@
       system: let
         overlays = [rust-overlay.overlays.default];
         pkgs = import nixpkgs {inherit system overlays;};
+        coldcardPkgs = import nixpkgs-coldcard {inherit system;};
+        emulatorSystem = system == "x86_64-linux";
+        espPkgs = import nixpkgs-esp-dev.inputs.nixpkgs {
+          inherit system;
+          overlays = [nixpkgs-esp-dev.overlays.default];
+          config.permittedInsecurePackages = [
+            "python3.13-ecdsa-0.19.1"
+          ];
+        };
+        jadeEspIdf = espPkgs.esp-idf-xtensa.override {
+          rev = "v5.4.3";
+          sha256 = "sha256-sV/eL3jRG9GdaQNByBypmH5ZKmZoOnWCEY1ABySIeac=";
+        };
+        jadePython = pkgs.python3.withPackages (pythonPackages: [
+          pythonPackages.zopfli
+        ]);
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         inputs = [
           rust
@@ -35,39 +75,285 @@
           pkgs.corepack_20
           pkgs.nodejs_20
         ];
-      in {
-        packages.default = pkgs.rustPlatform.buildRustPackage {
-          name = "bhwi";
-          src = ./.;
-
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-          };
-
-          nativeBuildInputs = inputs;
-        };
-
-        devShells.default = pkgs.mkShell {
-          packages = inputs;
-          shellHook = ''
-            export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-            export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
-            export CC_wasm32_unknown_unknown=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
-            export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages.libclang.lib}/lib/clang/21.1.8/include/"
-          '';
-        };
-
-        apps.website = {
+        emulatorInputs = [
+          pkgs.bash
+          pkgs.cacert
+          pkgs.coreutils
+          pkgs.curl
+          pkgs.git
+          pkgs.gnumake
+          pkgs.gnused
+          pkgs.netcat-openbsd
+          pkgs.openssl
+          pkgs.pkg-config
+          pkgs.procps
+          pkgs.python3
+          pkgs.which
+        ];
+        coldcardEmulatorInputs = [
+          coldcardPkgs.bash
+          coldcardPkgs.cacert
+          coldcardPkgs.coreutils
+          coldcardPkgs.curl
+          coldcardPkgs.gawk
+          coldcardPkgs.git
+          coldcardPkgs.gnumake
+          coldcardPkgs.gnugrep
+          coldcardPkgs.gnused
+          coldcardPkgs.netcat-openbsd
+          coldcardPkgs.openssl
+          coldcardPkgs.pkg-config
+          coldcardPkgs.procps
+          coldcardPkgs.python312
+          coldcardPkgs.which
+        ];
+        coldcardInputs =
+          coldcardEmulatorInputs
+          ++ [
+            coldcardPkgs.autoconf
+            coldcardPkgs.automake
+            coldcardPkgs.binutils
+            coldcardPkgs.gcc13
+            coldcardPkgs.gcc-arm-embedded
+            coldcardPkgs.glibc.bin
+            coldcardPkgs.libffi
+            coldcardPkgs.libtool
+            coldcardPkgs.m4
+            coldcardPkgs.pcsclite
+            coldcardPkgs.python312Packages.virtualenv
+            coldcardPkgs.SDL2
+            coldcardPkgs.swig
+            coldcardPkgs.systemd
+            coldcardPkgs.xterm
+          ];
+        speculos = pkgs.callPackage ./nix/speculos.nix {};
+        ledgerInputs =
+          emulatorInputs
+          ++ [
+            pkgs.docker-client
+            pkgs.podman
+            speculos
+          ];
+        jadeQemuInputs =
+          emulatorInputs
+          ++ [
+            jadeEspIdf
+          ]
+          ++ builtins.attrValues jadeEspIdf.passthru.tools
+          ++ [
+            espPkgs.qemu-esp32
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.python3Packages.virtualenv
+          ];
+        jadeInitInputs =
+          emulatorInputs
+          ++ [
+            pkgs.python3Packages.virtualenv
+          ];
+        jadePinserverInputs =
+          emulatorInputs
+          ++ [
+            pkgs.gcc
+            pkgs.python311
+            pkgs.python311Packages.virtualenv
+          ];
+        jadeInputs = jadeQemuInputs ++ jadePinserverInputs;
+        mkApp = program: {
           type = "app";
-          program = toString (pkgs.writeShellScript "run-website" ''
-            export PATH="${pkgs.lib.makeBinPath inputs}:$PATH"
-            export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-            export CC_wasm32_unknown_unknown=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
-            export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages.libclang.lib}/lib/clang/21.1.8/include/"
-            wasm-pack build bhwi-wasm --out-dir ../website/pkg --target web
-            cd website && npm install && npm run dev
-          '');
+          program = pkgs.lib.getExe program;
         };
+        mkRunnerWith = runnerPkgs: name: runtimeInputs: env: script:
+          runnerPkgs.writeShellApplication {
+            inherit name runtimeInputs;
+            text =
+              env
+              + ''
+
+                exec ${runnerPkgs.bash}/bin/bash ${script} "$@"
+              '';
+          };
+        mkRunner = mkRunnerWith pkgs;
+        coldcardRunner = mkRunnerWith coldcardPkgs "bhwi-start-coldcard" coldcardInputs ''
+          unset LD_LIBRARY_PATH
+          unset C_INCLUDE_PATH
+          unset CPLUS_INCLUDE_PATH
+          unset LIBRARY_PATH
+          unset OBJC_INCLUDE_PATH
+          unset OBJCPLUS_INCLUDE_PATH
+          export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
+            coldcardPkgs.SDL2
+            coldcardPkgs.gcc13.cc.lib
+            coldcardPkgs.glibc
+            coldcardPkgs.libffi
+            coldcardPkgs.openssl.out
+            coldcardPkgs.pcsclite
+            coldcardPkgs.systemd
+          ]}"
+          export COLDCARD_FIRMWARE_SRC="${coldcard-firmware}"
+          export COLDCARD_FIRMWARE_REV="${coldcard-firmware.rev or "locked"}"
+          export COLDCARD_FIRMWARE_URL="https://github.com/Coldcard/firmware.git"
+          export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
+          export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+          export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
+          export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
+          export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
+        '' ./nix/scripts/start-coldcard.sh;
+        ledgerRunner = mkRunner "bhwi-start-ledger" ledgerInputs ''
+          export APP_BITCOIN_NEW_SRC="${app-bitcoin-new}"
+          export APP_BITCOIN_NEW_REV="${app-bitcoin-new.rev or "locked"}"
+          export APP_BITCOIN_NEW_URL="https://github.com/LedgerHQ/app-bitcoin-new.git"
+          export SPECULOS_BIN="${speculos}/bin/speculos"
+          export LEDGER_BUILD_APP_SCRIPT="${./nix/scripts/build-ledger-app.sh}"
+        '' ./nix/scripts/start-ledger.sh;
+        ledgerAppBuilder = mkRunner "bhwi-build-ledger-app" ledgerInputs ''
+          export APP_BITCOIN_NEW_SRC="${app-bitcoin-new}"
+          export APP_BITCOIN_NEW_REV="${app-bitcoin-new.rev or "locked"}"
+          export APP_BITCOIN_NEW_URL="https://github.com/LedgerHQ/app-bitcoin-new.git"
+        '' ./nix/scripts/build-ledger-app.sh;
+        jadeRunner = mkRunner "bhwi-start-jade" jadeQemuInputs ''
+          export JADE_FIRMWARE_SRC="${jade-firmware}"
+          export JADE_FIRMWARE_REV="${jade-firmware.rev or "locked"}"
+          export JADE_FIRMWARE_URL="https://github.com/Blockstream/Jade.git"
+          export PATH="${jadePython}/bin:$PATH"
+          export IDF_PATH="${jadeEspIdf}"
+          export IDF_TOOLS_PATH="$IDF_PATH/tools"
+          export IDF_PYTHON_CHECK_CONSTRAINTS=no
+          IDF_PYTHON_ENV_PATH="$(readlink "$IDF_PATH/python-env")"
+          export IDF_PYTHON_ENV_PATH
+          export PATH="$IDF_TOOLS_PATH:$IDF_PATH/components/espcoredump:$IDF_PATH/components/partition_table:$IDF_PATH/components/app_update:$PATH"
+          if [ -e "$IDF_PATH/.tool-env" ]; then
+            # shellcheck disable=SC1091
+            . "$IDF_PATH/.tool-env"
+          fi
+          if [ -e "$IDF_PATH/etc/gitconfig" ]; then
+            export GIT_CONFIG_SYSTEM="$IDF_PATH/etc/gitconfig"
+          fi
+        '' ./nix/scripts/start-jade.sh;
+        jadeInitRunner = mkRunner "bhwi-init-jade" jadeInitInputs ''
+          export JADE_FIRMWARE_SRC="${jade-firmware}"
+          export JADE_FIRMWARE_REV="${jade-firmware.rev or "locked"}"
+          export JADE_FIRMWARE_URL="https://github.com/Blockstream/Jade.git"
+        '' ./nix/scripts/init-jade.sh;
+        jadePinserverRunner = mkRunner "bhwi-start-jade-pinserver" jadePinserverInputs ''
+          export JADE_FIRMWARE_SRC="${jade-firmware}"
+          export JADE_FIRMWARE_REV="${jade-firmware.rev or "locked"}"
+          export JADE_FIRMWARE_URL="https://github.com/Blockstream/Jade.git"
+          export JADE_PINSERVER_SRC="${jade-pinserver}"
+          export JADE_PINSERVER_REV="${jade-pinserver.rev or "locked"}"
+          export JADE_PINSERVER_URL="https://github.com/Blockstream/blind_pin_server.git"
+          export JADE_PINSERVER_PYTHON="${pkgs.python311}/bin/python3"
+        '' ./nix/scripts/start-jade-pinserver.sh;
+        linuxPackages =
+          pkgs.lib.optionalAttrs emulatorSystem {
+            inherit speculos;
+            coldcard-simulator = coldcardRunner;
+            ledger-app = ledgerAppBuilder;
+            jade-qemu = jadeRunner;
+          };
+        linuxApps =
+          pkgs.lib.optionalAttrs emulatorSystem {
+            coldcard = mkApp coldcardRunner;
+            ledger = mkApp ledgerRunner;
+            ledger-build-app = mkApp ledgerAppBuilder;
+            jade = mkApp jadeRunner;
+            jade-init = mkApp jadeInitRunner;
+            jade-pinserver = mkApp jadePinserverRunner;
+          };
+        linuxShells =
+          pkgs.lib.optionalAttrs emulatorSystem {
+            coldcard = pkgs.mkShell {
+              packages = coldcardInputs ++ inputs;
+              shellHook = ''
+                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+                export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
+                  coldcardPkgs.SDL2
+                  coldcardPkgs.gcc13.cc.lib
+                  coldcardPkgs.glibc
+                  coldcardPkgs.libffi
+                  coldcardPkgs.openssl.out
+                  coldcardPkgs.pcsclite
+                  coldcardPkgs.systemd
+                ]}"
+                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+                export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
+                export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+                export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
+                export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
+                export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
+                export RUST_TEST_THREADS=1
+              '';
+            };
+            ledger = pkgs.mkShell {
+              packages = inputs ++ ledgerInputs;
+              shellHook = ''
+                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+                export RUST_TEST_THREADS=1
+              '';
+            };
+            jade = pkgs.mkShell {
+              packages = inputs ++ jadeInputs;
+              shellHook = ''
+                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+                export RUST_TEST_THREADS=1
+              '';
+            };
+          };
+        linuxChecks =
+          pkgs.lib.optionalAttrs emulatorSystem {
+            emulator-scripts = pkgs.runCommand "bhwi-emulator-scripts" {} ''
+              test -f ${./nix/scripts/start-coldcard.sh}
+              test -f ${./nix/scripts/start-ledger.sh}
+              test -f ${./nix/scripts/start-jade.sh}
+              test -f ${./nix/scripts/start-jade-pinserver.sh}
+              test -f ${./nix/scripts/init-jade.sh}
+              test -f ${./nix/scripts/emit-gh-error-log.sh}
+              touch $out
+            '';
+          };
+      in {
+        packages = {
+          default = pkgs.rustPlatform.buildRustPackage {
+            name = "bhwi";
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = inputs;
+          };
+        } // linuxPackages;
+
+        devShells = {
+          default = pkgs.mkShell {
+            packages = inputs;
+            shellHook = ''
+              export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+              export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+              export CC_wasm32_unknown_unknown=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
+              export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages.libclang.lib}/lib/clang/21.1.8/include/"
+            '';
+          };
+        } // linuxShells;
+
+        apps = {
+          website = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "run-website" ''
+              export PATH="${pkgs.lib.makeBinPath inputs}:$PATH"
+              export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+              export CC_wasm32_unknown_unknown=${pkgs.llvmPackages.clang-unwrapped}/bin/clang
+              export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages.libclang.lib}/lib/clang/21.1.8/include/"
+              wasm-pack build bhwi-wasm --out-dir ../website/pkg --target web
+              cd website && npm install && npm run dev
+            '');
+          };
+        } // linuxApps;
+
+        checks = linuxChecks;
       }
     );
 }

--- a/nix/scripts/build-ledger-app.sh
+++ b/nix/scripts/build-ledger-app.sh
@@ -18,7 +18,7 @@ src_key="${rev//[^A-Za-z0-9_.-]/_}"
 work="$cache_root/app-bitcoin-new-$src_key"
 elf="$work/build/nanox/bin/app.elf"
 marker="$work/.bhwi-built"
-image="${LEDGER_APP_BUILDER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest}"
+image="${LEDGER_APP_BUILDER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools@sha256:811ed84d8f29d80a8469ac3b33ed5efcc3bef1605016a11a32b99475d91da3dc}"
 
 mkdir -p "$cache_root"
 

--- a/nix/scripts/build-ledger-app.sh
+++ b/nix/scripts/build-ledger-app.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/ledger"
+src="${APP_BITCOIN_NEW_SRC:?APP_BITCOIN_NEW_SRC must point to app-bitcoin-new source}"
+
+if [[ -n "${LEDGER_APP_ELF:-}" ]]; then
+  if [[ ! -f "$LEDGER_APP_ELF" ]]; then
+    echo "LEDGER_APP_ELF does not exist: $LEDGER_APP_ELF" >&2
+    exit 1
+  fi
+  printf '%s\n' "$LEDGER_APP_ELF"
+  exit 0
+fi
+
+rev="${APP_BITCOIN_NEW_REV:-$(basename "$src")}"
+src_key="${rev//[^A-Za-z0-9_.-]/_}"
+work="$cache_root/app-bitcoin-new-$src_key"
+elf="$work/build/nanox/bin/app.elf"
+marker="$work/.bhwi-built"
+image="${LEDGER_APP_BUILDER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest}"
+
+mkdir -p "$cache_root"
+
+if [[ ! -f "$elf" || ! -f "$marker" ]]; then
+  echo "Building Ledger Bitcoin app ELF in $work" >&2
+  rm -rf "$work"
+  if [[ -n "${APP_BITCOIN_NEW_URL:-}" && "$rev" != "locked" ]]; then
+    git clone --recursive "$APP_BITCOIN_NEW_URL" "$work"
+    git -C "$work" checkout "$rev"
+    git -C "$work" submodule update --init --recursive
+  else
+    mkdir -p "$work"
+    cp -R "$src"/. "$work"/
+  fi
+  chmod -R u+w "$work"
+
+  if command -v docker >/dev/null 2>&1; then
+    runner=(docker run --rm --user "$(id -u):$(id -g)" -v "$work:/app" -w /app "$image")
+  elif command -v podman >/dev/null 2>&1; then
+    runner=(podman run --rm --user "$(id -u):$(id -g)" -v "$work:/app:Z" -w /app "$image")
+  else
+    echo "Neither docker nor podman is available for Ledger app-builder" >&2
+    exit 1
+  fi
+
+  "${runner[@]}" bash -lc 'BOLOS_SDK=$NANOX_SDK make' >&2
+  test -f "$elf"
+  touch "$marker"
+fi
+
+printf '%s\n' "$elf"

--- a/nix/scripts/emit-gh-error-log.sh
+++ b/nix/scripts/emit-gh-error-log.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+title="${1:?title required}"
+log="${2:?log path required}"
+bytes="${3:-3500}"
+
+if [[ -f "$log" ]]; then
+  message="$(tail -c "$bytes" "$log")"
+  if [[ -z "$message" ]]; then
+    message="<empty log: $log>"
+  fi
+else
+  message="<missing log: $log>"
+fi
+
+message="${message//'%'/'%25'}"
+message="${message//$'\r'/'%0D'}"
+message="${message//$'\n'/'%0A'}"
+
+echo "::error title=${title}::${message}"

--- a/nix/scripts/init-jade.sh
+++ b/nix/scripts/init-jade.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/jade"
+src="${JADE_FIRMWARE_SRC:?JADE_FIRMWARE_SRC must point to Jade source}"
+rev="${JADE_FIRMWARE_REV:-$(basename "$src")}"
+src_key="${rev//[^A-Za-z0-9_.-]/_}"
+work="$cache_root/source-$src_key"
+device="${JADE_DEVICE:-tcp:localhost:30121}"
+pinserver_url="${JADE_PINSERVER_URL:-http://localhost:8096}"
+mnemonic="${JADE_MNEMONIC:-fish inner face ginger orchard permit useful method fence kidney chuckle party favorite sunset draw limb science crane oval letter slot invite sadness banana}"
+
+mkdir -p "$cache_root"
+if [[ ! -d "$work" ]]; then
+  echo "Preparing Jade source in $work" >&2
+  mkdir -p "$work"
+  if [[ -n "${JADE_FIRMWARE_URL:-}" && "$rev" != "locked" ]]; then
+    git clone --recursive "$JADE_FIRMWARE_URL" "$work"
+    git -C "$work" checkout "$rev"
+    git -C "$work" submodule update --init --recursive
+  else
+    cp -R "$src"/. "$work"/
+  fi
+  chmod -R u+w "$work"
+fi
+
+cd "$work"
+if [[ ! -d venv ]]; then
+  python3 -m venv venv
+  venv/bin/pip install --upgrade pip setuptools
+  if [[ -f requirements.txt ]]; then
+    venv/bin/pip install -r requirements.txt
+  fi
+  venv/bin/pip install click
+  venv/bin/pip install -e .
+fi
+
+venv/bin/python - <<PY
+from jadepy.jade import JadeAPI
+
+jade = JadeAPI.create_serial(device="${device}")
+jade.connect()
+jade.set_mnemonic("${mnemonic}")
+jade.disconnect()
+PY
+
+if [[ -x ./jade_cli.py ]]; then
+  venv/bin/python ./jade_cli.py --device "$device" set-pinserver \
+    --pubkey server_public_key.pub \
+    "$pinserver_url"
+else
+  echo "jade_cli.py not found; mnemonic was set but pinserver was not configured" >&2
+  exit 1
+fi

--- a/nix/scripts/start-coldcard.sh
+++ b/nix/scripts/start-coldcard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/coldcard"
+src="${COLDCARD_FIRMWARE_SRC:?COLDCARD_FIRMWARE_SRC must point to Coldcard firmware source}"
+rev="${COLDCARD_FIRMWARE_REV:-$(basename "$src")}"
+src_key="${rev//[^A-Za-z0-9_.-]/_}"
+work="$cache_root/firmware-$src_key"
+marker="$work/.bhwi-built"
+build_key_file="$work/.bhwi-build-key"
+build_key="rev=$rev simulator=unpatched-mk5-v1"
+socket="${COLDCARD_SOCKET:-/tmp/ckcc-simulator.sock}"
+
+dump_build_logs() {
+  local status=$?
+  local config_log="$work/external/micropython/ports/unix/build-standard/lib/libffi/config.log"
+  if [[ $status -ne 0 && -f "$config_log" ]] && ! grep -q "configure: exit 0" "$config_log"; then
+    echo "Coldcard libffi configure log:" >&2
+    awk '
+      /checking whether the C compiler works/ { show = 1 }
+      show { print }
+      /configure: exit/ { exit }
+    ' "$config_log" >&2
+  fi
+  exit "$status"
+}
+trap dump_build_logs ERR
+
+if [[ -S "$socket" ]]; then
+  echo "Coldcard socket already exists: $socket" >&2
+  echo "Stop the existing simulator or remove the stale socket before starting a new one." >&2
+  exit 1
+fi
+
+mkdir -p "$cache_root"
+
+if [[ ! -f "$marker" || ! -f "$build_key_file" || "$(cat "$build_key_file")" != "$build_key" ]]; then
+  echo "Building Coldcard simulator in $work" >&2
+  rm -rf "$work"
+  if [[ -n "${COLDCARD_FIRMWARE_URL:-}" && "$rev" != "locked" ]]; then
+    git clone "$COLDCARD_FIRMWARE_URL" "$work"
+    git -C "$work" checkout "$rev"
+    git -C "$work" submodule update --init \
+      external/ckcc-protocol \
+      external/libngu \
+      external/micropython \
+      external/mpy-qr
+  else
+    mkdir -p "$work"
+    cp -R "$src"/. "$work"/
+  fi
+  chmod -R u+w "$work"
+
+  cd "$work"
+  if [[ -f ubuntu24_mpy.patch ]]; then
+    (cd external/micropython && git apply ../../ubuntu24_mpy.patch)
+  fi
+  mpy_cflags_extra="${MPY_CFLAGS_EXTRA:--Wno-error}"
+  python3 -m venv ENV
+  ENV/bin/pip install --upgrade pip setuptools
+  grep -v \
+    -e '^-r ./testing/requirements.txt$' \
+    -e '^-r ./misc/gpu/requirements.txt$' \
+    requirements.txt > .bhwi-simulator-requirements.txt
+  ENV/bin/pip install -r .bhwi-simulator-requirements.txt
+  ENV/bin/pip install pysdl2-dll
+  unset CFLAGS
+  unset LDFLAGS
+  make -C external/micropython/mpy-cross CFLAGS_EXTRA="$mpy_cflags_extra"
+  ln -sfn ../external/micropython/ports/unix unix/l-port
+  ln -sfn ../external/micropython unix/l-mpy
+  ln -sfn ../external/micropython/ports/unix/coldcard-mpy unix/coldcard-mpy
+  git -C external/micropython submodule update --init lib/axtls lib/berkeley-db-1.xx lib/libffi
+  make -C unix PWD="$work/unix" ngu-setup CFLAGS_EXTRA="$mpy_cflags_extra"
+  make -C unix PWD="$work/unix" PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}" CFLAGS_EXTRA="$mpy_cflags_extra"
+  printf '%s\n' "$build_key" > "$build_key_file"
+  touch "$marker"
+fi
+
+cd "$work/unix"
+if [[ -n "${COLDCARD_RUNTIME_LIBRARY_PATH:-}" ]]; then
+  export LD_LIBRARY_PATH="$COLDCARD_RUNTIME_LIBRARY_PATH"
+fi
+exec ../ENV/bin/python3 simulator.py --headless

--- a/nix/scripts/start-jade-pinserver.sh
+++ b/nix/scripts/start-jade-pinserver.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/jade"
+src="${JADE_FIRMWARE_SRC:?JADE_FIRMWARE_SRC must point to Jade source}"
+pinserver_src="${JADE_PINSERVER_SRC:?JADE_PINSERVER_SRC must point to the Jade pinserver source}"
+pinserver_rev="${JADE_PINSERVER_REV:-$(basename "$pinserver_src")}"
+pinserver_key="${pinserver_rev//[^A-Za-z0-9_.-]/_}"
+package_parent="$cache_root/pinserver-source-$pinserver_key"
+work="$package_parent/pinserver"
+pins_dir="${JADE_PINS_DIR:-$cache_root/pins}"
+port="${JADE_PINSERVER_PORT:-8096}"
+runtime_dir="$cache_root/pinserver-runtime-$pinserver_key"
+python="${JADE_PINSERVER_PYTHON:-python3}"
+server_key="${JADE_SERVER_PRIVATE_KEY:-$src/server_private_key.key}"
+
+mkdir -p "$cache_root" "$pins_dir"
+
+if [[ ! -d "$work" ]]; then
+  echo "Preparing Jade pinserver source in $work" >&2
+  rm -rf "$package_parent"
+  mkdir -p "$package_parent"
+  if [[ -n "${JADE_PINSERVER_URL:-}" && "$pinserver_rev" != "locked" ]]; then
+    git clone "$JADE_PINSERVER_URL" "$work"
+    git -C "$work" checkout "$pinserver_rev"
+  else
+    mkdir -p "$work"
+    cp -R "$pinserver_src"/. "$work"/
+  fi
+  chmod -R u+w "$package_parent"
+fi
+
+if [[ ! -f "$work/flaskserver.py" || ! -f "$work/requirements.txt" ]]; then
+  echo "Jade pinserver source is incomplete in $work" >&2
+  exit 1
+fi
+
+if [[ ! -f "$server_key" ]]; then
+  echo "Jade pinserver private key is missing at $server_key" >&2
+  exit 1
+fi
+
+cd "$work"
+if [[ ! -d venv-pinserver ]]; then
+  "$python" -m venv venv-pinserver
+  venv-pinserver/bin/pip install --upgrade pip setuptools wheel
+  venv-pinserver/bin/pip install --require-hashes -r requirements.txt
+fi
+
+mkdir -p "$runtime_dir"
+ln -sfn "$pins_dir" "$runtime_dir/pins"
+ln -sf "$server_key" "$runtime_dir/server_private_key.key"
+
+cd "$runtime_dir"
+export PYTHONPATH="$package_parent"
+exec "$work/venv-pinserver/bin/python" - <<PY
+from pinserver.flaskserver import app
+
+app.run(host="0.0.0.0", port=${port})
+PY

--- a/nix/scripts/start-jade.sh
+++ b/nix/scripts/start-jade.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/jade"
+src="${JADE_FIRMWARE_SRC:?JADE_FIRMWARE_SRC must point to Jade source}"
+rev="${JADE_FIRMWARE_REV:-$(basename "$src")}"
+src_key="${rev//[^A-Za-z0-9_.-]/_}"
+work="$cache_root/source-$src_key"
+flash="$cache_root/flash-image-$src_key.bin"
+marker="$cache_root/.flash-built-$src_key"
+
+mkdir -p "$cache_root"
+
+prepare_source() {
+  rm -rf "$work"
+  if [[ -n "${JADE_FIRMWARE_URL:-}" && "$rev" != "locked" ]]; then
+    git clone --recursive "$JADE_FIRMWARE_URL" "$work"
+    git -C "$work" checkout "$rev"
+    git -C "$work" submodule update --init --recursive
+  else
+    mkdir -p "$work"
+    cp -R "$src"/. "$work"/
+  fi
+  chmod -R u+w "$work"
+}
+
+if [[ ! -f "$flash" || ! -f "$marker" ]]; then
+  echo "Building Jade QEMU flash image in $work" >&2
+  prepare_source
+
+  cd "$work"
+  ./tools/switch_to.sh qemu --dev --ci --psram
+  idf.py all
+  ./tools/fwprep.py build/jade.bin build
+  python_bin="${IDF_PYTHON_ENV_PATH:+$IDF_PYTHON_ENV_PATH/bin/python}"
+  python_bin="${python_bin:-python3}"
+  "$python_bin" -m esptool \
+    --chip esp32 merge_bin \
+    --fill-flash-size 4MB \
+    -o "$flash" \
+    --flash_mode dio \
+    --flash_freq 40m \
+    --flash_size 4MB \
+    0x9000 build/partition_table/partition-table.bin \
+    0xe000 build/ota_data_initial.bin \
+    0x1000 build/bootloader/bootloader.bin \
+    0x10000 build/jade.bin
+  touch "$marker"
+elif [[ ! -d "$work" ]]; then
+  prepare_source
+fi
+
+exec qemu-system-xtensa \
+  -nographic \
+  -machine esp32 \
+  -m 4M \
+  -drive "file=$flash,if=mtd,format=raw" \
+  -drive "file=$work/main/qemu/qemu_efuse.bin,if=none,format=raw,id=efuse" \
+  -global driver=nvram.esp32.efuse,property=drive,value=efuse \
+  -nic user,model=open_eth,id=lo0,hostfwd=tcp:0.0.0.0:30122-:30122,hostfwd=tcp:0.0.0.0:30121-:30121

--- a/nix/scripts/start-ledger.sh
+++ b/nix/scripts/start-ledger.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+speculos="${SPECULOS_BIN:-speculos}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_script="${LEDGER_BUILD_APP_SCRIPT:-$script_dir/build-ledger-app.sh}"
+
+elf="$(bash "$build_script")"
+
+echo "Starting Speculos with $elf" >&2
+exec "$speculos" "$elf" \
+  --model nanox \
+  --display headless \
+  --apdu-port "${LEDGER_APDU_PORT:-9999}" \
+  --api-port "${LEDGER_API_PORT:-5000}"

--- a/nix/scripts/wait-for-port.sh
+++ b/nix/scripts/wait-for-port.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:?host required}"
+port="${2:?port required}"
+timeout="${3:-120}"
+pid="${4:-}"
+deadline=$((SECONDS + timeout))
+
+while (( SECONDS < deadline )); do
+  if nc -z "$host" "$port" >/dev/null 2>&1; then
+    exit 0
+  fi
+  if [[ -n "$pid" ]] && ! kill -0 "$pid" >/dev/null 2>&1; then
+    echo "Process $pid exited before $host:$port became reachable" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Timed out waiting for $host:$port after ${timeout}s" >&2
+exit 1

--- a/nix/scripts/wait-for-socket.sh
+++ b/nix/scripts/wait-for-socket.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+socket="${1:?socket path required}"
+timeout="${2:-120}"
+pid="${3:-}"
+deadline=$((SECONDS + timeout))
+
+while (( SECONDS < deadline )); do
+  if [[ -S "$socket" ]]; then
+    exit 0
+  fi
+  if [[ -n "$pid" ]] && ! kill -0 "$pid" >/dev/null 2>&1; then
+    echo "Process $pid exited before socket $socket was created" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Timed out waiting for socket $socket after ${timeout}s" >&2
+exit 1

--- a/nix/speculos.nix
+++ b/nix/speculos.nix
@@ -1,0 +1,46 @@
+{
+  docker-client,
+  podman,
+  writeShellApplication,
+}:
+
+writeShellApplication {
+  name = "speculos";
+
+  runtimeInputs = [
+    docker-client
+    podman
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    if [ "$#" -lt 1 ]; then
+      echo "usage: speculos <app.elf> [speculos args...]" >&2
+      exit 2
+    fi
+
+    elf="$1"
+    shift
+
+    if [ ! -f "$elf" ]; then
+      echo "Speculos app ELF does not exist: $elf" >&2
+      exit 1
+    fi
+
+    image="''${SPECULOS_CONTAINER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest}"
+    elf_dir="$(cd "$(dirname "$elf")" && pwd)"
+    elf_name="$(basename "$elf")"
+
+    if command -v docker >/dev/null 2>&1; then
+      exec docker run --rm --network host -v "$elf_dir:/app:ro" "$image" \
+        speculos "/app/$elf_name" "$@"
+    elif command -v podman >/dev/null 2>&1; then
+      exec podman run --rm --network host -v "$elf_dir:/app:ro,Z" "$image" \
+        speculos "/app/$elf_name" "$@"
+    else
+      echo "Neither docker nor podman is available for Speculos" >&2
+      exit 1
+    fi
+  '';
+}

--- a/nix/speculos.nix
+++ b/nix/speculos.nix
@@ -28,7 +28,7 @@ writeShellApplication {
       exit 1
     fi
 
-    image="''${SPECULOS_CONTAINER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest}"
+    image="''${SPECULOS_CONTAINER_IMAGE:-ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools@sha256:811ed84d8f29d80a8469ac3b33ed5efcc3bef1605016a11a32b99475d91da3dc}"
     elf_dir="$(cd "$(dirname "$elf")" && pwd)"
     elf_name="$(basename "$elf")"
 


### PR DESCRIPTION
Huge LLM slop generated so that we can have e2e tests run in the CI.
Unfortunate that Ledger is still using docker under the hood to build the bitcoin app. Maybe this can be iterated on later.

Nix users can also use these for local development:

```sh
# Terminal 1
nix run .#ledger

# Terminal 2
nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1
```

See doc commit for more usage details.

Closes #25 