### PR TITLE
Add Ledger PSBT Signing Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -353,6 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32",
  "bitcoin-internals",
  "bitcoin-io",
@@ -1141,7 +1148,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1775,7 +1782,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -15,6 +15,7 @@ use bhwi::{
     bitcoin::{
         Network,
         bip32::{DerivationPath, Fingerprint, Xpub},
+        psbt::Psbt,
         secp256k1::ecdsa::Signature,
     },
     common::{self},
@@ -56,6 +57,13 @@ pub trait HWI {
         context: Option<common::DeviceContext>,
     ) -> Result<String, Self::Error>;
     async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<[u8; 32], Self::Error>;
+    async fn sign_tx(
+        &mut self,
+        psbt: Psbt,
+        policy_name: Option<&str>,
+        policy: Option<&str>,
+        hmac: Option<[u8; 32]>,
+    ) -> Result<Psbt, Self::Error>;
 }
 
 // TODO: this will become a pain to maintain, but we can have a proc-macro
@@ -86,6 +94,13 @@ pub trait HWIDevice {
         name: &str,
         policy: &str,
     ) -> Result<[u8; 32], HWIDeviceError>;
+    async fn sign_tx(
+        &mut self,
+        psbt: Psbt,
+        policy_name: Option<&str>,
+        policy: Option<&str>,
+        hmac: Option<[u8; 32]>,
+    ) -> Result<Psbt, HWIDeviceError>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -216,6 +231,34 @@ where
             Err(common::Error::NoErrorOrResult.into())
         }
     }
+
+    async fn sign_tx(
+        &mut self,
+        psbt: Psbt,
+        policy_name: Option<&str>,
+        policy: Option<&str>,
+        hmac: Option<[u8; 32]>,
+    ) -> Result<Psbt, Self::Error> {
+        let policy = policy
+            .map(WalletPolicy::from_str)
+            .transpose()
+            .map_err(|e| common::Error::Serialization(e.to_string()))?;
+        if let common::Response::SignedPsbt(psbt) = run_command(
+            self,
+            common::Command::SignTx {
+                policy_name: policy_name.map(ToString::to_string),
+                psbt,
+                policy,
+                hmac,
+            },
+        )
+        .await?
+        {
+            Ok(psbt)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -276,6 +319,18 @@ where
         policy: &str,
     ) -> Result<[u8; 32], HWIDeviceError> {
         HWI::register_wallet(self, name, policy)
+            .await
+            .map_err(HWIDeviceError::new)
+    }
+
+    async fn sign_tx(
+        &mut self,
+        psbt: Psbt,
+        policy_name: Option<&str>,
+        policy: Option<&str>,
+        hmac: Option<[u8; 32]>,
+    ) -> Result<Psbt, HWIDeviceError> {
+        HWI::sign_tx(self, psbt, policy_name, policy, hmac)
             .await
             .map_err(HWIDeviceError::new)
     }

--- a/bhwi-cli/Cargo.toml
+++ b/bhwi-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/bhwi.rs"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-bitcoin = { workspace = true, features = ["serde"] }
+bitcoin = { workspace = true, features = ["base64", "serde"] }
 bhwi-async = { workspace = true, features = ["emulators"] }
 bhwi.workspace = true
 futures.workspace = true

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,10 +1,14 @@
 use anyhow::Result;
 use bhwi_cli::{DeviceManager, OutputFormat, address::AddressTarget, config::Config};
 
+use std::path::PathBuf;
+use std::str::FromStr;
+
 use bitcoin::{
     Network,
     address::AddressType,
     bip32::{DerivationPath, Fingerprint},
+    psbt::Psbt,
 };
 use clap::{Parser, Subcommand};
 use miniscript::descriptor::WalletPolicy;
@@ -60,6 +64,24 @@ enum Commands {
         /// Miniscript wallet policy descriptor (e.g. "wpkh(@0/**)")
         #[arg(long, value_parser = clap::value_parser!(WalletPolicy))]
         descriptor: WalletPolicy,
+    },
+    /// Sign a PSBT with the selected device
+    SignPsbt {
+        /// PSBT file in base64 text format
+        #[arg(long)]
+        psbt: PathBuf,
+        /// Ledger wallet policy name
+        #[arg(long = "policy-name", alias = "name", alias = "wallet-name")]
+        policy_name: Option<String>,
+        /// Miniscript wallet policy descriptor
+        #[arg(long, value_parser = clap::value_parser!(WalletPolicy))]
+        descriptor: Option<WalletPolicy>,
+        /// HMAC from wallet registration (hex-encoded 64 chars)
+        #[arg(long)]
+        hmac: Option<String>,
+        /// Output file. Defaults to stdout.
+        #[arg(long, short)]
+        output: Option<PathBuf>,
     },
 }
 
@@ -210,6 +232,38 @@ async fn main() -> Result<()> {
                 println!("{}", hex::encode(hmac));
             }
         }
+        Commands::SignPsbt {
+            psbt,
+            policy_name,
+            descriptor,
+            hmac,
+            output,
+        } => {
+            let psbt_text = std::fs::read_to_string(psbt)?;
+            let psbt = Psbt::from_str(psbt_text.trim())?;
+            let hmac = hmac.as_deref().map(parse_hmac).transpose()?;
+            let descriptor = descriptor.as_ref().map(ToString::to_string);
+            if let Some(mut d) = dev_man.get_device_with_fingerprint().await? {
+                let signed = d
+                    .device()
+                    .sign_tx(psbt, policy_name.as_deref(), descriptor.as_deref(), hmac)
+                    .await?;
+                let signed = signed.to_string();
+                if let Some(output) = output {
+                    std::fs::write(output, signed)?;
+                } else {
+                    println!("{signed}");
+                }
+            }
+        }
     }
     Ok(())
+}
+
+fn parse_hmac(hmac: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(hmac)?;
+    let hmac: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("hmac must be 32 bytes / 64 hex characters"))?;
+    Ok(hmac)
 }

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -267,6 +267,9 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::RegisterWallet { .. } => Err(ColdcardError::MissingCommandInfo(
                 "RegisterWallet not supported by Coldcard",
             )),
+            Command::SignTx { .. } => Err(ColdcardError::MissingCommandInfo(
+                "SignTx not supported by Coldcard",
+            )),
         }
     }
 }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -1,6 +1,7 @@
 use bitcoin::Network;
 use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
+use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 use miniscript::descriptor::WalletPolicy;
 
@@ -39,6 +40,12 @@ pub enum Command {
         name: String,
         policy: WalletPolicy,
     },
+    SignTx {
+        policy_name: Option<String>,
+        psbt: Psbt,
+        policy: Option<WalletPolicy>,
+        hmac: Option<[u8; 32]>,
+    },
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
@@ -66,6 +73,7 @@ pub enum Response {
     Xpub(Xpub),
     EncryptionKey([u8; 64]),
     Signature(u8, Signature),
+    SignedPsbt(Psbt),
     Address(String),
     WalletHmac([u8; 32]),
 }

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -324,6 +324,9 @@ impl TryFrom<Command> for JadeCommand {
             Command::RegisterWallet { .. } => Err(Error::MissingCommandInfo(
                 "RegisterWallet not supported by Jade",
             )),
+            Command::SignTx { .. } => {
+                Err(Error::MissingCommandInfo("SignTx not supported by Jade"))
+            }
         }
     }
 }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -13,6 +13,7 @@ use apdu::{ApduCommand, ApduError, ApduResponse, StatusWord};
 use bitcoin::Network;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::consensus::encode::deserialize_partial;
+use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 use store::{DelegatedStore, StoreError};
 pub use wallet::{AddressType, LedgerWalletPolicy, Version, WalletError, singlesig_wallet_policy};
@@ -53,6 +54,9 @@ pub enum LedgerError {
 
     #[error("failed to open app: {0:x?}")]
     FailedToOpenApp(Vec<u8>),
+
+    #[error("invalid psbt: {0}")]
+    InvalidPsbt(String),
 }
 
 impl LedgerError {
@@ -81,6 +85,11 @@ pub enum LedgerCommand {
     },
     RegisterWallet {
         policy: LedgerWalletPolicy,
+    },
+    SignPsbt {
+        psbt: Psbt,
+        policy: LedgerWalletPolicy,
+        hmac: Option<[u8; 32]>,
     },
 }
 
@@ -140,6 +149,7 @@ pub enum LedgerResponse {
     Xpub(Xpub),
     Address(String),
     WalletHmac([u8; 32]),
+    SignedPsbt(Psbt),
 }
 
 #[derive(Default)]
@@ -181,6 +191,112 @@ impl<C, T, R, E> Default for LedgerInterpreter<C, T, R, E> {
         Self {
             state: State::default(),
             _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+fn apply_psbt_signature(psbt: &mut Psbt, yielded: &[u8]) -> Result<(), LedgerError> {
+    let (input_index, yielded_object) = parse_sign_psbt_yielded(yielded)?;
+    let input = psbt
+        .inputs
+        .get_mut(input_index)
+        .ok_or_else(|| LedgerError::InvalidPsbt(format!("invalid input index {input_index}")))?;
+
+    let SignPsbtYieldedObject::Partial(partial_signature) = yielded_object else {
+        return Ok(());
+    };
+
+    match partial_signature {
+        psbt::PartialSignature::Sig(pubkey, sig) => {
+            input.partial_sigs.insert(pubkey, sig);
+        }
+        psbt::PartialSignature::TapScriptSig(pubkey, Some(leaf_hash), sig) => {
+            input.tap_script_sigs.insert((pubkey, leaf_hash), sig);
+        }
+        psbt::PartialSignature::TapScriptSig(_, None, sig) => {
+            input.tap_key_sig = Some(sig);
+        }
+    }
+    Ok(())
+}
+
+enum SignPsbtYieldedObject {
+    Partial(psbt::PartialSignature),
+    Ignored,
+}
+
+fn parse_sign_psbt_yielded(data: &[u8]) -> Result<(usize, SignPsbtYieldedObject), LedgerError> {
+    let (tag, read) = deserialize_unchecked_varint(data)?;
+    match tag {
+        // TODO: Parse and store MuSig2 yields once rust-bitcoin exposes the
+        // corresponding PSBT fields.
+        tag if tag >= 0x80000000 => {
+            let (input_index, _) = deserialize_unchecked_varint(&data[read..])?;
+            Ok((
+                input_index_to_usize(input_index)?,
+                SignPsbtYieldedObject::Ignored,
+            ))
+        }
+        input_index => {
+            let partial_signature =
+                psbt::PartialSignature::from_slice(&data[read..]).map_err(|_| {
+                    LedgerError::InvalidPsbt("invalid partial signature yield".to_string())
+                })?;
+            Ok((
+                input_index_to_usize(input_index)?,
+                SignPsbtYieldedObject::Partial(partial_signature),
+            ))
+        }
+    }
+}
+
+fn input_index_to_usize(input_index: u64) -> Result<usize, LedgerError> {
+    usize::try_from(input_index).map_err(|_| {
+        LedgerError::InvalidPsbt(format!("input index does not fit usize: {input_index}"))
+    })
+}
+
+fn deserialize_unchecked_varint(data: &[u8]) -> Result<(u64, usize), LedgerError> {
+    let first = data
+        .first()
+        .ok_or_else(|| LedgerError::InvalidPsbt("missing sign_psbt yield tag".to_string()))?;
+    match first {
+        0x00..=0xFC => Ok((*first as u64, 1)),
+        0xFD => {
+            let bytes = data.get(1..3).ok_or_else(|| {
+                LedgerError::InvalidPsbt("truncated sign_psbt yield varint".to_string())
+            })?;
+            let value = u16::from_le_bytes(bytes.try_into().expect("slice length checked")) as u64;
+            if value < 0xFD {
+                return Err(LedgerError::InvalidPsbt(
+                    "non-minimal sign_psbt yield varint".to_string(),
+                ));
+            }
+            Ok((value, 3))
+        }
+        0xFE => {
+            let bytes = data.get(1..5).ok_or_else(|| {
+                LedgerError::InvalidPsbt("truncated sign_psbt yield varint".to_string())
+            })?;
+            let value = u32::from_le_bytes(bytes.try_into().expect("slice length checked")) as u64;
+            if value < 0x10000 {
+                return Err(LedgerError::InvalidPsbt(
+                    "non-minimal sign_psbt yield varint".to_string(),
+                ));
+            }
+            Ok((value, 5))
+        }
+        0xFF => {
+            let bytes = data.get(1..9).ok_or_else(|| {
+                LedgerError::InvalidPsbt("truncated sign_psbt yield varint".to_string())
+            })?;
+            let value = u64::from_le_bytes(bytes.try_into().expect("slice length checked"));
+            if value < 0x1_0000_0000 {
+                return Err(LedgerError::InvalidPsbt(
+                    "non-minimal sign_psbt yield varint".to_string(),
+                ));
+            }
+            Ok((value, 9))
         }
     }
 }
@@ -238,6 +354,88 @@ where
                 Self::Transmit::from(command::register_wallet(policy).map_err(LedgerError::from)?),
                 Some(policy.to_store().map_err(LedgerError::from)?),
             ),
+            LedgerCommand::SignPsbt {
+                ref psbt,
+                ref policy,
+                ref hmac,
+            } => {
+                if psbt.inputs.len() != psbt.unsigned_tx.input.len() {
+                    return Err(LedgerError::InvalidPsbt(
+                        "psbt input count does not match unsigned transaction".to_string(),
+                    )
+                    .into());
+                }
+                if psbt.outputs.len() != psbt.unsigned_tx.output.len() {
+                    return Err(LedgerError::InvalidPsbt(
+                        "psbt output count does not match unsigned transaction".to_string(),
+                    )
+                    .into());
+                }
+
+                let global_map = psbt::get_v2_global_pairs(psbt)
+                    .into_iter()
+                    .map(psbt::deserialize_pair)
+                    .collect::<Vec<_>>();
+                let input_maps = psbt
+                    .inputs
+                    .iter()
+                    .zip(&psbt.unsigned_tx.input)
+                    .map(|(input, txin)| {
+                        psbt::get_v2_input_pairs(input, txin)
+                            .into_iter()
+                            .map(psbt::deserialize_pair)
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
+                let output_maps = psbt
+                    .outputs
+                    .iter()
+                    .zip(&psbt.unsigned_tx.output)
+                    .map(|(output, txout)| {
+                        psbt::get_v2_output_pairs(output, txout)
+                            .into_iter()
+                            .map(psbt::deserialize_pair)
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
+
+                let global_commitment = store::get_merkleized_map_commitment(&global_map);
+                let input_commitments = input_maps
+                    .iter()
+                    .map(|map| store::get_merkleized_map_commitment(map))
+                    .collect::<Vec<_>>();
+                let output_commitments = output_maps
+                    .iter()
+                    .map(|map| store::get_merkleized_map_commitment(map))
+                    .collect::<Vec<_>>();
+
+                let mut store = policy.to_store().map_err(LedgerError::from)?;
+                store.add_known_mapping(&global_map);
+                for map in &input_maps {
+                    store.add_known_mapping(map);
+                }
+                for map in &output_maps {
+                    store.add_known_mapping(map);
+                }
+                let input_commitments_root = store.add_known_list(&input_commitments);
+                let output_commitments_root = store.add_known_list(&output_commitments);
+
+                (
+                    Self::Transmit::from(
+                        command::sign_psbt(
+                            &global_commitment,
+                            psbt.inputs.len(),
+                            &input_commitments_root,
+                            psbt.outputs.len(),
+                            &output_commitments_root,
+                            policy,
+                            hmac.as_ref(),
+                        )
+                        .map_err(LedgerError::from)?,
+                    ),
+                    Some(store),
+                )
+            }
         };
         self.state = State::Running { command, store };
         Ok(transmit)
@@ -517,6 +715,27 @@ where
                         hmac.copy_from_slice(&res.data[32..64]);
                         (State::Finished(LedgerResponse::WalletHmac(hmac)), None)
                     }
+                    LedgerCommand::SignPsbt { mut psbt, .. } => match res.status_word {
+                        StatusWord::Deny
+                        | StatusWord::ClaNotSupported
+                        | StatusWord::SignatureFail => {
+                            (State::Finished(LedgerResponse::TaskDone), None)
+                        }
+                        StatusWord::OK => {
+                            let store = store.ok_or(LedgerError::Interrupted)?;
+                            for yielded in store.yielded() {
+                                apply_psbt_signature(&mut psbt, &yielded)?;
+                            }
+                            (State::Finished(LedgerResponse::SignedPsbt(psbt)), None)
+                        }
+                        _ => {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "sign psbt status",
+                            )
+                            .into());
+                        }
+                    },
                 }
             }
             State::New => (State::New, None),
@@ -554,6 +773,23 @@ impl TryFrom<Command> for LedgerCommand {
             Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
                 policy: LedgerWalletPolicy::new(name, Version::V2, policy),
             }),
+            Command::SignTx {
+                policy_name,
+                psbt,
+                policy,
+                hmac,
+            } => {
+                let policy_name = policy_name.ok_or(LedgerError::MissingCommandInfo(
+                    "ledger sign_tx policy_name",
+                ))?;
+                let policy =
+                    policy.ok_or(LedgerError::MissingCommandInfo("ledger sign_tx policy"))?;
+                Ok(Self::SignPsbt {
+                    psbt,
+                    policy: LedgerWalletPolicy::new(policy_name, Version::V2, policy),
+                    hmac,
+                })
+            }
         }
     }
 }
@@ -572,6 +808,7 @@ impl From<LedgerResponse> for Response {
             LedgerResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
             LedgerResponse::Address(address) => Response::Address(address),
             LedgerResponse::WalletHmac(hmac) => Response::WalletHmac(hmac),
+            LedgerResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
         }
     }
 }
@@ -588,6 +825,88 @@ impl From<LedgerError> for Error {
             LedgerError::UnexpectedResult(data, ctx) => Error::unexpected_result(data, ctx),
             LedgerError::UnsupportedDisplayAddress(ctx) => Error::UnsupportedDisplayAddress(ctx),
             LedgerError::FailedToOpenApp(_) => Error::AuthenticationRefused,
+            LedgerError::InvalidPsbt(e) => Error::Serialization(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const XONLY: [u8; 32] = [
+        0x4f, 0x35, 0x5b, 0xdc, 0xb7, 0xcc, 0x0a, 0xf7, 0x28, 0xef, 0x3c, 0xce, 0xb9, 0x61, 0x5d,
+        0x90, 0x68, 0x4b, 0xb5, 0xb2, 0xca, 0x5f, 0x85, 0x9a, 0xb0, 0xf0, 0xb7, 0x04, 0x07, 0x58,
+        0x71, 0xaa,
+    ];
+
+    fn encode_unchecked_varint(value: u64) -> Vec<u8> {
+        match value {
+            0..=0xFC => vec![value as u8],
+            0xFD..=0xFFFF => {
+                let mut out = vec![0xFD];
+                out.extend_from_slice(&(value as u16).to_le_bytes());
+                out
+            }
+            0x1_0000..=0xFFFF_FFFF => {
+                let mut out = vec![0xFE];
+                out.extend_from_slice(&(value as u32).to_le_bytes());
+                out
+            }
+            _ => {
+                let mut out = vec![0xFF];
+                out.extend_from_slice(&value.to_le_bytes());
+                out
+            }
+        }
+    }
+
+    fn assert_ignored(payload: &[u8], expected_input_index: usize) {
+        let (input_index, object) = parse_sign_psbt_yielded(payload).expect("payload should parse");
+        assert_eq!(input_index, expected_input_index);
+        assert!(matches!(object, SignPsbtYieldedObject::Ignored));
+    }
+
+    #[test]
+    fn parse_legacy_partial_taproot_without_tapleaf() {
+        let mut payload = encode_unchecked_varint(3);
+        payload.push(32);
+        payload.extend_from_slice(&XONLY);
+        payload.extend_from_slice(&[0xaa; 64]);
+
+        let (input_index, object) =
+            parse_sign_psbt_yielded(&payload).expect("payload should parse");
+        assert_eq!(input_index, 3);
+        assert!(matches!(
+            object,
+            SignPsbtYieldedObject::Partial(psbt::PartialSignature::TapScriptSig(_, None, _))
+        ));
+    }
+
+    #[test]
+    fn parse_reserved_musig_pubnonce_tag_is_ignored() {
+        let mut payload = encode_unchecked_varint(0xFFFF_FFFF);
+        payload.extend(encode_unchecked_varint(7));
+        payload.extend_from_slice(&[0xaa; 164]);
+
+        assert_ignored(&payload, 7);
+    }
+
+    #[test]
+    fn parse_reserved_musig_partial_signature_tag_is_ignored() {
+        let mut payload = encode_unchecked_varint(0xFFFF_FFFE);
+        payload.extend(encode_unchecked_varint(2));
+        payload.extend_from_slice(&[0xbb; 98]);
+
+        assert_ignored(&payload, 2);
+    }
+
+    #[test]
+    fn parse_unknown_reserved_tag_is_ignored() {
+        let mut payload = encode_unchecked_varint(0x89AB_CDEF);
+        payload.extend(encode_unchecked_varint(11));
+        payload.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        assert_ignored(&payload, 11);
     }
 }

--- a/e2e/ledger/automations/sign_psbt.json
+++ b/e2e/ledger/automations/sign_psbt.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "regexp": "Review|From|To|Amount|Address|Fees|Fee|Output|Transaction|Account|Security risk|Unverified inputs",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "Accept|Approve|Sign|Continue anyway",
+      "actions": [
+        ["button", 1, true],
+        ["button", 2, true],
+        ["button", 2, false],
+        ["button", 1, false]
+      ]
+    }
+  ]
+}

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -1,10 +1,19 @@
 #[cfg(test)]
 mod tests {
-    use std::fmt::Display;
     use std::str::FromStr;
 
     use anyhow::Result;
     use base64ct::Encoding;
+    use bhwi::bitcoin::{
+        Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
+        absolute::LockTime,
+        address::Address,
+        bip32::{ChildNumber, DerivationPath},
+        psbt::{Input, Output, Psbt},
+        secp256k1::Secp256k1,
+        transaction::Version as TxVersion,
+    };
     use bhwi::ledger::{LedgerWalletPolicy, Version};
     use bhwi_async::{DeviceContext, DisplayAddress, HWI};
     use bhwi_async::{Ledger, transport::ledger::speculos::LedgerTransportTcp};
@@ -23,32 +32,6 @@ mod tests {
         inner: Client,
     }
 
-    #[derive(Debug, Clone, Copy)]
-    pub enum Button {
-        Left,
-        Right,
-        Both,
-    }
-
-    impl Display for Button {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(
-                f,
-                "{}",
-                match self {
-                    Button::Left => "left",
-                    Button::Right => "right",
-                    Button::Both => "both",
-                }
-            )
-        }
-    }
-
-    #[derive(Serialize)]
-    struct ButtonRequest {
-        action: String,
-    }
-
     impl SpeculosReqwestClient {
         fn new(url: &str) -> SpeculosReqwestClient {
             SpeculosReqwestClient {
@@ -65,16 +48,6 @@ mod tests {
                 .await?
                 .error_for_status()?;
             Ok(())
-        }
-
-        async fn button_press(&self, button: Button) -> Result<()> {
-            self.post(
-                &format!("{}/button/{button}", self.endpoint),
-                &ButtonRequest {
-                    action: "press-and-release".into(),
-                },
-            )
-            .await
         }
 
         async fn set_automation<T: Serialize>(&self, automation_json: &T) -> Result<()> {
@@ -241,5 +214,111 @@ mod tests {
             .await
             .expect("failed to display address by descriptor");
         assert_eq!(address, "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk");
+    }
+
+    #[tokio::test]
+    async fn can_sign_psbt() {
+        let (mut dev, client) = init().await;
+        let fingerprint = dev.get_master_fingerprint().await.unwrap();
+        let xpub = dev
+            .get_extended_pubkey("m/84'/1'/0'".parse().unwrap(), false)
+            .await
+            .unwrap();
+        let secp = Secp256k1::verification_only();
+        let input_path: DerivationPath = "m/84'/1'/0'/0/0".parse().unwrap();
+        let change_path: DerivationPath = "m/84'/1'/0'/1/0".parse().unwrap();
+        let input_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        let change_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(1).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        let input_xpub = xpub.derive_pub(&secp, &input_child_path).unwrap();
+        let change_xpub = xpub.derive_pub(&secp, &change_child_path).unwrap();
+        let input_pubkey = PublicKey::new(input_xpub.public_key);
+        let change_pubkey = PublicKey::new(change_xpub.public_key);
+        let input_script = Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let change_script =
+            Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let prev_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script.clone(),
+            }],
+        };
+        let unsigned_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(49_000),
+                script_pubkey: change_script,
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(prev_tx),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script,
+            }),
+            bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
+            ..Default::default()
+        };
+        psbt.outputs[0] = Output {
+            bip32_derivation: [(change_pubkey.inner, (fingerprint, change_path))].into(),
+            ..Default::default()
+        };
+
+        let key_str = format!("[{fingerprint}/84'/1'/0']{xpub}");
+        let policy = format!("wpkh({key_str}/<0;1>/*)");
+        let name = "psbttest";
+        client
+            .set_automation(
+                &serde_json::from_str::<Value>(include_str!(
+                    "../automations/register_wallet_accept.json"
+                ))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let hmac = dev
+            .register_wallet(name, &policy)
+            .await
+            .expect("failed to register psbt wallet");
+
+        client
+            .set_automation(
+                &serde_json::from_str::<Value>(include_str!("../automations/sign_psbt.json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let signed = dev
+            .sign_tx(psbt, Some(name), Some(&policy), Some(hmac))
+            .await
+            .expect("failed to sign psbt");
+
+        assert_eq!(signed.inputs.len(), 1);
+        assert_eq!(signed.inputs[0].partial_sigs.len(), 1);
+        assert!(signed.inputs[0].partial_sigs.contains_key(&input_pubkey));
     }
 }

--- a/nix/scripts/build-ledger-app.sh
+++ b/nix/scripts/build-ledger-app.sh
@@ -35,10 +35,10 @@ if [[ ! -f "$elf" || ! -f "$marker" ]]; then
   fi
   chmod -R u+w "$work"
 
-  if command -v docker >/dev/null 2>&1; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
     runner=(docker run --rm --user "$(id -u):$(id -g)" -v "$work:/app" -w /app "$image")
   elif command -v podman >/dev/null 2>&1; then
-    runner=(podman run --rm --user "$(id -u):$(id -g)" -v "$work:/app:Z" -w /app "$image")
+    runner=(podman run --rm --userns=keep-id -v "$work:/app:Z" -w /app "$image")
   else
     echo "Neither docker nor podman is available for Ledger app-builder" >&2
     exit 1

--- a/nix/speculos.nix
+++ b/nix/speculos.nix
@@ -32,7 +32,7 @@ writeShellApplication {
     elf_dir="$(cd "$(dirname "$elf")" && pwd)"
     elf_name="$(basename "$elf")"
 
-    if command -v docker >/dev/null 2>&1; then
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
       exec docker run --rm --network host -v "$elf_dir:/app:ro" "$image" \
         speculos "/app/$elf_name" "$@"
     elif command -v podman >/dev/null 2>&1; then


### PR DESCRIPTION
- Add bhwi Ledger PSBT signing support.
- Add sign_tx() to bhwi-async traits.
- Add bhwi-cli sign-psbt for base64 PSBT input/output.
- Add Ledger e2e for signing a registered P2WPKH wallet PSBT.
- Update Nix Ledger scripts to check for Docker and fall back to Podman.

LLM assisted, self-reviewed