### PR TITLE
feat(jade): add PSBT signing

### DIFF
--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -60,9 +60,7 @@ pub trait HWI {
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
-        policy_name: Option<&str>,
-        policy: Option<&str>,
-        hmac: Option<[u8; 32]>,
+        context: Option<common::DeviceContext>,
     ) -> Result<Psbt, Self::Error>;
 }
 
@@ -97,9 +95,7 @@ pub trait HWIDevice {
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
-        policy_name: Option<&str>,
-        policy: Option<&str>,
-        hmac: Option<[u8; 32]>,
+        context: Option<common::DeviceContext>,
     ) -> Result<Psbt, HWIDeviceError>;
 }
 
@@ -235,24 +231,10 @@ where
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
-        policy_name: Option<&str>,
-        policy: Option<&str>,
-        hmac: Option<[u8; 32]>,
+        context: Option<common::DeviceContext>,
     ) -> Result<Psbt, Self::Error> {
-        let policy = policy
-            .map(WalletPolicy::from_str)
-            .transpose()
-            .map_err(|e| common::Error::Serialization(e.to_string()))?;
-        if let common::Response::SignedPsbt(psbt) = run_command(
-            self,
-            common::Command::SignTx {
-                policy_name: policy_name.map(ToString::to_string),
-                psbt,
-                policy,
-                hmac,
-            },
-        )
-        .await?
+        if let common::Response::SignedPsbt(psbt) =
+            run_command(self, common::Command::SignTx(psbt, context)).await?
         {
             Ok(psbt)
         } else {
@@ -326,11 +308,9 @@ where
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
-        policy_name: Option<&str>,
-        policy: Option<&str>,
-        hmac: Option<[u8; 32]>,
+        context: Option<common::DeviceContext>,
     ) -> Result<Psbt, HWIDeviceError> {
-        HWI::sign_tx(self, psbt, policy_name, policy, hmac)
+        HWI::sign_tx(self, psbt, context)
             .await
             .map_err(HWIDeviceError::new)
     }

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use bhwi::ledger::{LedgerWalletPolicy, Version};
+use bhwi_async::DeviceContext;
 use bhwi_cli::{DeviceManager, OutputFormat, address::AddressTarget, config::Config};
 
 use std::path::PathBuf;
@@ -70,9 +72,9 @@ enum Commands {
         /// PSBT file in base64 text format
         #[arg(long)]
         psbt: PathBuf,
-        /// Ledger wallet policy name
-        #[arg(long = "policy-name", alias = "name", alias = "wallet-name")]
-        policy_name: Option<String>,
+        /// Wallet name
+        #[arg(long, alias = "wallet-name")]
+        name: Option<String>,
         /// Miniscript wallet policy descriptor
         #[arg(long, value_parser = clap::value_parser!(WalletPolicy))]
         descriptor: Option<WalletPolicy>,
@@ -234,7 +236,7 @@ async fn main() -> Result<()> {
         }
         Commands::SignPsbt {
             psbt,
-            policy_name,
+            name,
             descriptor,
             hmac,
             output,
@@ -242,12 +244,21 @@ async fn main() -> Result<()> {
             let psbt_text = std::fs::read_to_string(psbt)?;
             let psbt = Psbt::from_str(psbt_text.trim())?;
             let hmac = hmac.as_deref().map(parse_hmac).transpose()?;
-            let descriptor = descriptor.as_ref().map(ToString::to_string);
+            let context = match (name, descriptor, hmac) {
+                (Some(name), Some(policy), hmac) => Some(DeviceContext::Ledger {
+                    wallet_policy: LedgerWalletPolicy::new(name, Version::V2, policy),
+                    wallet_hmac: hmac,
+                }),
+                (None, None, None) => None,
+                (None, None, Some(_)) => {
+                    anyhow::bail!("--hmac requires --name and --descriptor for Ledger signing")
+                }
+                _ => anyhow::bail!(
+                    "--name and --descriptor must be provided together for Ledger signing"
+                ),
+            };
             if let Some(mut d) = dev_man.get_device_with_fingerprint().await? {
-                let signed = d
-                    .device()
-                    .sign_tx(psbt, policy_name.as_deref(), descriptor.as_deref(), hmac)
-                    .await?;
+                let signed = d.device().sign_tx(psbt, context).await?;
                 let signed = signed.to_string();
                 if let Some(output) = output {
                     std::fs::write(output, signed)?;

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -267,7 +267,7 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::RegisterWallet { .. } => Err(ColdcardError::MissingCommandInfo(
                 "RegisterWallet not supported by Coldcard",
             )),
-            Command::SignTx { .. } => Err(ColdcardError::MissingCommandInfo(
+            Command::SignTx(_, _) => Err(ColdcardError::MissingCommandInfo(
                 "SignTx not supported by Coldcard",
             )),
         }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -1,11 +1,10 @@
+use crate::miniscript::descriptor::WalletPolicy;
+use crate::{coldcard, jade, ledger};
 use bitcoin::Network;
 use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
-use miniscript::descriptor::WalletPolicy;
-
-use crate::{coldcard, jade, ledger};
 
 #[derive(Default)]
 pub struct UnlockOptions {
@@ -40,12 +39,7 @@ pub enum Command {
         name: String,
         policy: WalletPolicy,
     },
-    SignTx {
-        policy_name: Option<String>,
-        psbt: Psbt,
-        policy: Option<WalletPolicy>,
-        hmac: Option<[u8; 32]>,
-    },
+    SignTx(Psbt, Option<DeviceContext>),
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use base64ct::{Base64, Encoding};
 use bitcoin::Network;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
+use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -52,6 +53,9 @@ pub enum JadeCommand {
         message: Vec<u8>,
         path: DerivationPath,
     },
+    SignPsbt {
+        psbt: Psbt,
+    },
 }
 
 pub enum JadeResponse {
@@ -61,6 +65,7 @@ pub enum JadeResponse {
     TaskDone,
     Xpub(Xpub),
     Address(String),
+    SignedPsbt(Psbt),
 }
 
 pub enum JadeRecipient {
@@ -78,6 +83,13 @@ enum State {
     Running(JadeCommand),
     WaitingPinServer,
     WaitingFinalHandshake,
+    GettingExtendedData {
+        origid: String,
+        orig: String,
+        next_seqnum: u32,
+        seqlen: u32,
+        chunks: Vec<u8>,
+    },
 }
 
 pub struct JadeInterpreter<C, T, R, E> {
@@ -140,6 +152,16 @@ fn from_response<D: DeserializeOwned>(buffer: &[u8]) -> Result<api::Response<D>,
     serde_cbor::from_slice(buffer).map_err(|_| JadeError::Cbor)
 }
 
+fn from_response_bytes(buffer: &[u8]) -> Result<api::ResponseBytes, JadeError> {
+    serde_cbor::from_slice(buffer).map_err(|_| JadeError::Cbor)
+}
+
+fn parse_signed_psbt(bytes: &[u8]) -> Result<JadeResponse, JadeError> {
+    Psbt::deserialize(bytes)
+        .map(JadeResponse::SignedPsbt)
+        .map_err(|e| JadeError::Serialization(e.to_string()))
+}
+
 impl<C, T, R, E> Interpreter for JadeInterpreter<C, T, R, E>
 where
     C: TryInto<JadeCommand, Error = E>,
@@ -184,6 +206,13 @@ where
                         .map_err(|e| JadeError::Serialization(e.to_string()))?,
                 }),
             ),
+            JadeCommand::SignPsbt { psbt } => request(
+                "sign_psbt",
+                Some(api::SignPsbtParams {
+                    network: self.network,
+                    psbt: psbt.serialize(),
+                }),
+            ),
             JadeCommand::GetReceiveAddress {
                 index,
                 change,
@@ -204,20 +233,61 @@ where
         req
     }
     fn exchange(&mut self, data: Vec<u8>) -> Result<Option<Self::Transmit>, Self::Error> {
-        match self.state {
-            State::New => Ok(None),
+        if let State::GettingExtendedData {
+            origid,
+            orig,
+            next_seqnum,
+            seqlen,
+            chunks,
+        } = &mut self.state
+        {
+            let res = from_response_bytes(&data)?;
+            if let Some(e) = res.error {
+                return Err(JadeError::Rpc(e).into());
+            }
+            let chunk = res.result.ok_or(JadeError::NoErrorOrResult)?;
+            let seqnum = res.seqnum.unwrap_or(*next_seqnum);
+            if seqnum != *next_seqnum {
+                return Err(JadeError::UnexpectedResult(format!(
+                    "unexpected sign_psbt fragment {seqnum}, wanted {next_seqnum}"
+                ))
+                .into());
+            }
+            chunks.extend_from_slice(&chunk);
+            if seqnum >= *seqlen {
+                self.response = Some(parse_signed_psbt(chunks)?);
+                return Ok(None);
+            }
+
+            *next_seqnum = seqnum + 1;
+            return Ok(Some(request(
+                "get_extended_data",
+                Some(api::GetExtendedDataParams {
+                    origid,
+                    orig,
+                    seqnum: *next_seqnum,
+                    seqlen: *seqlen,
+                }),
+            )?));
+        }
+
+        let mut next_state = None;
+        let mut response = None;
+
+        let transmit = match &self.state {
+            State::New => None,
             State::Running(JadeCommand::Auth) => {
                 let res: api::AuthUserResponse = from_response(&data)?.into_result()?;
                 match res {
                     api::AuthUserResponse::PinServerRequired { http_request } => {
-                        self.state = State::WaitingPinServer;
+                        next_state = Some(State::WaitingPinServer);
                         let url = match &http_request.params.urls {
                             api::PinServerUrls::Array(urls) => urls.first().ok_or(
                                 JadeError::UnexpectedResult("No url provided".to_string()),
                             )?,
                             api::PinServerUrls::Object { url, .. } => url,
                         };
-                        Ok(Some(
+                        Some(
                             JadeTransmit {
                                 recipient: JadeRecipient::PinServer {
                                     url: url.to_string(),
@@ -226,11 +296,11 @@ where
                                     .map_err(|e| JadeError::Serialization(e.to_string()))?,
                             }
                             .into(),
-                        ))
+                        )
                     }
                     api::AuthUserResponse::Authenticated(_) => {
-                        self.response = Some(JadeResponse::TaskDone);
-                        Ok(None)
+                        response = Some(JadeResponse::TaskDone);
+                        None
                     }
                 }
             }
@@ -238,32 +308,30 @@ where
                 let pin_params: api::PinParams = serde_json::from_slice(&data).map_err(|_| {
                     JadeError::Serialization("Wrong response from pin server".to_string())
                 })?;
-                let transmit = request("pin", Some(pin_params))?;
-                self.state = State::WaitingFinalHandshake;
-                Ok(Some(transmit))
+                next_state = Some(State::WaitingFinalHandshake);
+                Some(request("pin", Some(pin_params))?)
             }
             State::WaitingFinalHandshake => {
                 let handshake_completed: bool = from_response(&data)?.into_result()?;
-                if handshake_completed {
-                    self.response = Some(JadeResponse::TaskDone);
-                    Ok(None)
-                } else {
-                    Err(JadeError::HandshakeRefused.into())
+                if !handshake_completed {
+                    return Err(JadeError::HandshakeRefused.into());
                 }
+                response = Some(JadeResponse::TaskDone);
+                None
             }
             State::Running(JadeCommand::GetMasterFingerprint) => {
                 let s: String = from_response(&data)?.into_result()?;
                 let xpub =
                     Xpub::from_str(&s).map_err(|e| JadeError::Serialization(e.to_string()))?;
-                self.response = Some(JadeResponse::MasterFingerprint(xpub.fingerprint()));
-                Ok(None)
+                response = Some(JadeResponse::MasterFingerprint(xpub.fingerprint()));
+                None
             }
             State::Running(JadeCommand::GetXpub(..)) => {
                 let s: String = from_response(&data)?.into_result()?;
                 let xpub =
                     Xpub::from_str(&s).map_err(|e| JadeError::Serialization(e.to_string()))?;
-                self.response = Some(JadeResponse::Xpub(xpub));
-                Ok(None)
+                response = Some(JadeResponse::Xpub(xpub));
+                None
             }
             State::Running(JadeCommand::SignMessage { .. }) => {
                 let s: String = from_response(&data)?.into_result()?;
@@ -271,20 +339,66 @@ where
                     Base64::decode_vec(&s).map_err(|e| JadeError::Serialization(e.to_string()))?;
                 let sig = Signature::from_compact(&sig_bytes[1..])
                     .map_err(|e| JadeError::Serialization(e.to_string()))?;
-                self.response = Some(JadeResponse::Signature(sig_bytes[0], sig));
-                Ok(None)
+                response = Some(JadeResponse::Signature(sig_bytes[0], sig));
+                None
             }
+            State::Running(JadeCommand::SignPsbt { .. }) => {
+                let res = from_response_bytes(&data)?;
+                if let Some(e) = res.error {
+                    return Err(JadeError::Rpc(e).into());
+                }
+                let chunk = res.result.ok_or(JadeError::NoErrorOrResult)?;
+                let seqnum = res.seqnum.unwrap_or(1);
+                let seqlen = res.seqlen.unwrap_or(1);
+                if seqnum != 1 {
+                    return Err(JadeError::UnexpectedResult(format!(
+                        "unexpected first sign_psbt fragment {seqnum}"
+                    ))
+                    .into());
+                }
+                if seqlen <= 1 {
+                    response = Some(parse_signed_psbt(&chunk)?);
+                    None
+                } else {
+                    let next_seqnum = seqnum + 1;
+                    next_state = Some(State::GettingExtendedData {
+                        origid: res.id.clone(),
+                        orig: "sign_psbt".to_string(),
+                        next_seqnum,
+                        seqlen,
+                        chunks: chunk,
+                    });
+                    Some(request(
+                        "get_extended_data",
+                        Some(api::GetExtendedDataParams {
+                            origid: &res.id,
+                            orig: "sign_psbt",
+                            seqnum: next_seqnum,
+                            seqlen,
+                        }),
+                    )?)
+                }
+            }
+            State::GettingExtendedData { .. } => unreachable!("handled before immutable match"),
             State::Running(JadeCommand::GetReceiveAddress { .. }) => {
                 let address: String = from_response(&data)?.into_result()?;
-                self.response = Some(JadeResponse::Address(address));
-                Ok(None)
+                response = Some(JadeResponse::Address(address));
+                None
             }
             State::Running(JadeCommand::GetInfo) => {
                 let info: GetInfoResponse = from_response(&data)?.into_result()?;
-                self.response = Some(JadeResponse::GetInfo(info));
-                Ok(None)
+                response = Some(JadeResponse::GetInfo(info));
+                None
             }
+        };
+
+        if let Some(state) = next_state {
+            self.state = state;
         }
+        if response.is_some() {
+            self.response = response;
+        }
+        Ok(transmit)
     }
     fn end(self) -> Result<Self::Response, Self::Error> {
         self.response
@@ -324,9 +438,7 @@ impl TryFrom<Command> for JadeCommand {
             Command::RegisterWallet { .. } => Err(Error::MissingCommandInfo(
                 "RegisterWallet not supported by Jade",
             )),
-            Command::SignTx { .. } => {
-                Err(Error::MissingCommandInfo("SignTx not supported by Jade"))
-            }
+            Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
         }
     }
 }
@@ -344,6 +456,7 @@ impl From<JadeResponse> for Response {
                 firmware: None,
             }),
             JadeResponse::Address(address) => Response::Address(address),
+            JadeResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
         }
     }
 }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -773,21 +773,19 @@ impl TryFrom<Command> for LedgerCommand {
             Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
                 policy: LedgerWalletPolicy::new(name, Version::V2, policy),
             }),
-            Command::SignTx {
-                policy_name,
-                psbt,
-                policy,
-                hmac,
-            } => {
-                let policy_name = policy_name.ok_or(LedgerError::MissingCommandInfo(
-                    "ledger sign_tx policy_name",
-                ))?;
-                let policy =
-                    policy.ok_or(LedgerError::MissingCommandInfo("ledger sign_tx policy"))?;
+            Command::SignTx(psbt, context) => {
+                let (ledger_policy, wallet_hmac) = context
+                    .map(|ctx| match ctx {
+                        DeviceContext::Ledger {
+                            wallet_policy,
+                            wallet_hmac,
+                        } => (wallet_policy, wallet_hmac),
+                    })
+                    .ok_or(LedgerError::MissingCommandInfo("ledger sign tx context"))?;
                 Ok(Self::SignPsbt {
                     psbt,
-                    policy: LedgerWalletPolicy::new(policy_name, Version::V2, policy),
-                    hmac,
+                    policy: ledger_policy,
+                    hmac: wallet_hmac,
                 })
             }
         }

--- a/bhwi/src/ledger/psbt.rs
+++ b/bhwi/src/ledger/psbt.rs
@@ -524,6 +524,7 @@ mod serialize {
     }
 
     /// A trait for deserializing a value from raw data in PSBT key-value maps.
+    #[allow(dead_code)]
     pub(crate) trait Deserialize: Sized {
         /// Deserialize a value from raw data.
         fn deserialize(bytes: &[u8]) -> Result<Self, Error>;

--- a/e2e/jade/src/lib.rs
+++ b/e2e/jade/src/lib.rs
@@ -4,7 +4,16 @@ mod tests {
     use bhwi_async::transport::jade::tcp::TcpTransport;
     use bhwi_async::{DisplayAddress, HWI};
     use bhwi_cli::jade::{JadeQemuDevice, PinServerClient, TcpClient};
-    use bitcoin::Network;
+    use bitcoin::{
+        Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
+        absolute::LockTime,
+        address::Address,
+        bip32::{ChildNumber, DerivationPath},
+        psbt::{Input, Psbt},
+        secp256k1::Secp256k1,
+        transaction::Version as TxVersion,
+    };
     use tokio::net::TcpStream;
 
     async fn device() -> JadeQemuDevice {
@@ -88,5 +97,82 @@ mod tests {
             .await;
         // Jade does not support Path-based address display
         assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn can_sign_psbt() {
+        let mut dev = device().await;
+        let fingerprint = dev.get_master_fingerprint().await.unwrap();
+        let xpub = dev
+            .get_extended_pubkey("m/84'/1'/0'".parse().unwrap(), false)
+            .await
+            .unwrap();
+        let secp = Secp256k1::verification_only();
+        let input_path: DerivationPath = "m/84'/1'/0'/0/0".parse().unwrap();
+        let change_path: DerivationPath = "m/84'/1'/0'/1/0".parse().unwrap();
+        let input_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        let change_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(1).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        let input_xpub = xpub.derive_pub(&secp, &input_child_path).unwrap();
+        let change_xpub = xpub.derive_pub(&secp, &change_child_path).unwrap();
+        let input_pubkey = PublicKey::new(input_xpub.public_key);
+        let change_pubkey = PublicKey::new(change_xpub.public_key);
+        let input_script = Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let change_script =
+            Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let prev_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script.clone(),
+            }],
+        };
+        let unsigned_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(49_000),
+                script_pubkey: change_script,
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(prev_tx),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script,
+            }),
+            bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
+            ..Default::default()
+        };
+        psbt.outputs[0].bip32_derivation =
+            [(change_pubkey.inner, (fingerprint, change_path))].into();
+
+        let signed = dev.sign_tx(psbt, None).await.expect("failed to sign psbt");
+
+        assert_eq!(signed.inputs.len(), 1);
+        assert_eq!(signed.inputs[0].partial_sigs.len(), 1);
+        assert!(signed.inputs[0].partial_sigs.contains_key(&input_pubkey));
     }
 }

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -313,7 +313,17 @@ mod tests {
             .await
             .unwrap();
         let signed = dev
-            .sign_tx(psbt, Some(name), Some(&policy), Some(hmac))
+            .sign_tx(
+                psbt,
+                Some(DeviceContext::Ledger {
+                    wallet_policy: LedgerWalletPolicy::new(
+                        name.to_string(),
+                        Version::V2,
+                        WalletPolicy::from_str(&policy).unwrap(),
+                    ),
+                    wallet_hmac: Some(hmac),
+                }),
+            )
             .await
             .expect("failed to sign psbt");
 


### PR DESCRIPTION
- Add a device-neutral SignTxRequest with Ledger-specific signing options.
- Wire up Jade sign_psbt support
- Add e2e for Jade and updated Ledger e2e with the new request API.