### PR TITLE
test(e2e): add CLI emulator coverage

### DIFF
--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -52,6 +52,15 @@ jobs:
             exit 1
           }
           kill "$(cat coldcard-tail.pid)" || true
+      - name: Run Coldcard CLI e2e
+        run: |
+          set -o pipefail
+          nix develop .#coldcard -c cargo build -p bhwi-cli --bin bhwi
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#coldcard -c cargo test -p bhwi-e2e-cli coldcard -- --test-threads=1 2>&1 | tee coldcard-cli-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Coldcard CLI e2e log" coldcard-cli-e2e.log
+            cat coldcard-cli-e2e.log || true
+            exit 1
+          }
       - name: Run Coldcard e2e
         run: |
           set -o pipefail
@@ -96,6 +105,15 @@ jobs:
             exit 1
           }
           kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger CLI e2e
+        run: |
+          set -o pipefail
+          nix develop .#ledger -c cargo build -p bhwi-cli --bin bhwi
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --test-threads=1 2>&1 | tee ledger-cli-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger CLI e2e log" ledger-cli-e2e.log
+            cat ledger-cli-e2e.log || true
+            exit 1
+          }
       - name: Run Ledger e2e
         run: |
           set -o pipefail
@@ -152,6 +170,15 @@ jobs:
           nix run .#jade-init > jade-init.log 2>&1 || {
             bash nix/scripts/emit-gh-error-log.sh "Jade init log" jade-init.log
             cat jade-init.log || true
+            exit 1
+          }
+      - name: Run Jade CLI e2e
+        run: |
+          set -o pipefail
+          nix develop .#jade -c cargo build -p bhwi-cli --bin bhwi
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#jade -c cargo test -p bhwi-e2e-cli jade -- --test-threads=1 2>&1 | tee jade-cli-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade CLI e2e log" jade-cli-e2e.log
+            cat jade-cli-e2e.log || true
             exit 1
           }
       - name: Run Jade e2e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bhwi-e2e-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "hex",
+ "miniscript",
+ "reqwest",
+ "serde_json",
+]
+
+[[package]]
 name = "bhwi-e2e-coldcard"
 version = "0.1.0"
 dependencies = [
@@ -1779,7 +1791,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -64,9 +64,9 @@ enum Commands {
         /// Name of the wallet
         #[arg(long)]
         name: String,
-        /// Miniscript wallet policy descriptor (e.g. "wpkh(@0/**)")
-        #[arg(long, value_parser = clap::value_parser!(WalletPolicy))]
-        descriptor: WalletPolicy,
+        /// Miniscript wallet policy descriptor
+        #[arg(long)]
+        descriptor: String,
     },
     /// Sign a PSBT with the selected device
     SignPsbt {
@@ -240,10 +240,7 @@ async fn main() -> Result<()> {
         }
         Commands::RegisterWallet { name, descriptor } => {
             if let Some(mut d) = dev_man.get_device_with_fingerprint().await? {
-                let hmac = d
-                    .device()
-                    .register_wallet(&name, &descriptor.to_string())
-                    .await?;
+                let hmac = d.device().register_wallet(&name, &descriptor).await?;
                 println!("{}", hex::encode(hmac));
             }
         }

--- a/e2e/cli/Cargo.toml
+++ b/e2e/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bhwi-e2e-cli"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+license-file.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bitcoin = { workspace = true, features = ["base64"] }
+hex.workspace = true
+miniscript.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde_json.workspace = true

--- a/e2e/cli/src/coldcard.rs
+++ b/e2e/cli/src/coldcard.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+
+use crate::support::{basic_cli_cases, run_command_cases};
+
+const COLDCARD_FINGERPRINT: &str = "0f056943";
+const COLDCARD_XPUB_44: &str = "tpubDCiHGUNYdRRBPNYm7CqeeLwPWfeb2ZT2rPsk4aEW3eUoJM93jbBa7hPpB1T9YKtigmjpxHrB1522kSsTxGm9V6cqKqrp1EDaYaeJZqcirYB";
+
+#[test]
+fn coldcard_basic_cli_commands() -> Result<()> {
+    run_command_cases(&basic_cli_cases(COLDCARD_FINGERPRINT, COLDCARD_XPUB_44))
+}

--- a/e2e/cli/src/jade.rs
+++ b/e2e/cli/src/jade.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+
+use crate::support::{Cli, CommandCase, ExpectedOutput, basic_cli_cases, run_command_cases};
+
+const JADE_FINGERPRINT: &str = "e3ebcc79";
+const JADE_XPUB_44: &str = "tpubDCKD5cdxMEFd2i4cNa3PJUbUHMsGDxsnfqjxVpMoG1ymWYUQUaZzTcHQo3JwYgaKe2FyKGA2FzGPSVczBoAiHGyERuA1mZ2UkGKufEnUxKk";
+
+#[test]
+fn jade_basic_cli_commands() -> Result<()> {
+    run_command_cases(&basic_cli_cases(JADE_FINGERPRINT, JADE_XPUB_44))
+}
+
+#[test]
+fn jade_sign_message() -> Result<()> {
+    run_command_cases(&[CommandCase {
+        name: "sign message hello",
+        cli: Cli::for_device(JADE_FINGERPRINT),
+        args: &[
+            "sign-message",
+            "--message",
+            "hello",
+            "--path",
+            "m/44'/1'/0'",
+        ],
+        expected: ExpectedOutput::Static(
+            "H+SvKg15TSz+2C5ra6Q8/e8BaImOZVEeS0rOL6GCEt4vO+4xRRt+YYKavSqgAJBYZaGEiTqr7f9imyyElMNhYXU=",
+        ),
+    }])
+}
+
+#[test]
+fn jade_address_by_path_is_unsupported() -> Result<()> {
+    Cli::for_device(JADE_FINGERPRINT).assert_failure_contains(
+        ["address", "get", "--from-path", "m/84'/1'/0'/0/0"],
+        "Jade does not support path-based address display",
+    )
+}

--- a/e2e/cli/src/ledger.rs
+++ b/e2e/cli/src/ledger.rs
@@ -1,0 +1,278 @@
+use std::{
+    env, fs,
+    path::PathBuf,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use bitcoin::{
+    Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    absolute::LockTime,
+    address::Address,
+    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
+    psbt::{Input, Output as PsbtOutput, Psbt},
+    secp256k1::Secp256k1,
+    transaction::Version as TxVersion,
+};
+
+use crate::support::{Cli, CommandCase, ExpectedOutput, basic_cli_cases, run_command_cases};
+
+const LEDGER_FINGERPRINT: &str = "f5acc2fd";
+const LEDGER_XPUB_44: &str = "tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT";
+const LEDGER_ADDRESS_84_0: &str = "tb1qzdr7s2sr0dwmkwx033r4nujzk86u0cy6fmzfjk";
+const LEDGER_SIGN_MESSAGE_HELLO: &str =
+    "IL3u9GLAzgG5BdtSBqUe0Fo2Zx0UlKwSsYx2TbuVX0VULFgZYRBQCW0W7QOlsB/JgGwWNhl3eYYjXtdfyR7pM+Y=";
+
+#[test]
+fn ledger_basic_cli_commands() -> Result<()> {
+    run_command_cases(&basic_cli_cases(LEDGER_FINGERPRINT, LEDGER_XPUB_44))
+}
+
+#[test]
+fn ledger_address_by_path() -> Result<()> {
+    run_command_cases(&[CommandCase {
+        name: "address get from path",
+        cli: Cli::for_device(LEDGER_FINGERPRINT),
+        args: &["address", "get", "--from-path", "m/84'/1'/0'/0/0"],
+        expected: ExpectedOutput::Static(LEDGER_ADDRESS_84_0),
+    }])
+}
+
+#[test]
+fn ledger_display_address_by_path() -> Result<()> {
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/display_address.json"
+    )))?;
+    run_command_cases(&[CommandCase {
+        name: "address get from path with display",
+        cli: Cli::for_device(LEDGER_FINGERPRINT),
+        args: &[
+            "address",
+            "get",
+            "--from-path",
+            "m/84'/1'/0'/0/0",
+            "--display",
+        ],
+        expected: ExpectedOutput::Static(LEDGER_ADDRESS_84_0),
+    }])
+}
+
+#[test]
+fn ledger_sign_message() -> Result<()> {
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/sign_message.json"
+    )))?;
+    run_command_cases(&[CommandCase {
+        name: "sign message hello",
+        cli: Cli::for_device(LEDGER_FINGERPRINT),
+        args: &[
+            "sign-message",
+            "--message",
+            "hello",
+            "--path",
+            "m/44'/1'/0'/0",
+        ],
+        expected: ExpectedOutput::Static(LEDGER_SIGN_MESSAGE_HELLO),
+    }])
+}
+
+#[test]
+fn ledger_sign_message_json() -> Result<()> {
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/sign_message.json"
+    )))?;
+    let expected = serde_json::json!({ "signature": LEDGER_SIGN_MESSAGE_HELLO }).to_string();
+    run_command_cases(&[CommandCase {
+        name: "sign message hello as json",
+        cli: Cli::for_device(LEDGER_FINGERPRINT).json(),
+        args: &[
+            "sign-message",
+            "--message",
+            "hello",
+            "--path",
+            "m/44'/1'/0'/0",
+        ],
+        expected: ExpectedOutput::Static(&expected),
+    }])
+}
+
+#[test]
+fn ledger_register_wallet_and_descriptor_address() -> Result<()> {
+    let policy = wallet_policy()?;
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/register_wallet_accept.json"
+    )))?;
+    let hmac = Cli::for_device(LEDGER_FINGERPRINT).run_ok([
+        "register-wallet",
+        "--name",
+        "clitestwallet",
+        "--descriptor",
+        &policy,
+    ])?;
+    let hmac = hmac.trim();
+    assert_eq!(hmac.len(), 64);
+    hex::decode(hmac)?;
+
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/register_wallet_accept.json"
+    )))?;
+    run_command_cases(&[CommandCase {
+        name: "address get from registered descriptor",
+        cli: Cli::for_device(LEDGER_FINGERPRINT),
+        args: &[
+            "address",
+            "get",
+            "--from-descriptor",
+            "clitestwallet",
+            "--wallet-descriptor",
+            &policy,
+            "--hmac",
+            hmac,
+            "--display",
+        ],
+        expected: ExpectedOutput::Static(LEDGER_ADDRESS_84_0),
+    }])
+}
+
+#[test]
+fn ledger_sign_psbt() -> Result<()> {
+    let policy = wallet_policy()?;
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/register_wallet_accept.json"
+    )))?;
+    let hmac = Cli::for_device(LEDGER_FINGERPRINT).run_ok([
+        "register-wallet",
+        "--name",
+        "clipsbttest",
+        "--descriptor",
+        &policy,
+    ])?;
+    let hmac = hmac.trim().to_string();
+    let psbt = ledger_psbt()?;
+    let psbt_file = temp_file("ledger-sign-psbt", psbt.to_string())?;
+
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/sign_psbt.json"
+    )))?;
+    let signed = Cli::for_device(LEDGER_FINGERPRINT).run_ok([
+        "sign-psbt",
+        "--psbt",
+        psbt_file.to_str().context("utf-8 temp path")?,
+        "--name",
+        "clipsbttest",
+        "--descriptor",
+        &policy,
+        "--hmac",
+        &hmac,
+    ])?;
+    fs::remove_file(psbt_file)?;
+
+    let signed = Psbt::from_str(signed.trim())?;
+    assert_eq!(signed.inputs.len(), 1);
+    assert_eq!(signed.inputs[0].partial_sigs.len(), 1);
+    Ok(())
+}
+
+fn wallet_policy() -> Result<String> {
+    let xpub = Cli::for_device(LEDGER_FINGERPRINT).run_ok(["xpub", "get", "m/84'/1'/0'"])?;
+    Ok(format!(
+        "wpkh([{LEDGER_FINGERPRINT}/84'/1'/0']{}/<0;1>/*)",
+        xpub.trim()
+    ))
+}
+
+fn set_ledger_automation(automation: &serde_json::Value) -> Result<()> {
+    reqwest::blocking::Client::new()
+        .post("http://localhost:5000/automation")
+        .json(automation)
+        .send()?
+        .error_for_status()?;
+    Ok(())
+}
+
+fn automation(json: &str) -> serde_json::Value {
+    serde_json::from_str(json).expect("valid automation json")
+}
+
+fn temp_file(name: &str, contents: impl AsRef<[u8]>) -> Result<PathBuf> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let path = env::temp_dir().join(format!("bhwi-e2e-cli-{name}-{unique}"));
+    fs::write(&path, contents)?;
+    Ok(path)
+}
+
+fn ledger_psbt() -> Result<Psbt> {
+    let fingerprint = Fingerprint::from_str(LEDGER_FINGERPRINT)?;
+    let xpub = Xpub::from_str(
+        Cli::for_device(LEDGER_FINGERPRINT)
+            .run_ok(["xpub", "get", "m/84'/1'/0'"])?
+            .trim(),
+    )?;
+    let secp = Secp256k1::verification_only();
+    let input_path: DerivationPath = "m/84'/1'/0'/0/0".parse()?;
+    let change_path: DerivationPath = "m/84'/1'/0'/1/0".parse()?;
+    let input_child_path = DerivationPath::from(vec![
+        ChildNumber::from_normal_idx(0)?,
+        ChildNumber::from_normal_idx(0)?,
+    ]);
+    let change_child_path = DerivationPath::from(vec![
+        ChildNumber::from_normal_idx(1)?,
+        ChildNumber::from_normal_idx(0)?,
+    ]);
+    let input_xpub = xpub.derive_pub(&secp, &input_child_path)?;
+    let change_xpub = xpub.derive_pub(&secp, &change_child_path)?;
+    let input_pubkey = PublicKey::new(input_xpub.public_key);
+    let change_pubkey = PublicKey::new(change_xpub.public_key);
+    let input_script = Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey();
+    let change_script = Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey();
+    let prev_tx = Transaction {
+        version: TxVersion::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: input_script.clone(),
+        }],
+    };
+    let unsigned_tx = Transaction {
+        version: TxVersion::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: prev_tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(49_000),
+            script_pubkey: change_script,
+        }],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx)?;
+    psbt.inputs[0] = Input {
+        non_witness_utxo: Some(prev_tx),
+        witness_utxo: Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: input_script,
+        }),
+        bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
+        ..Default::default()
+    };
+    psbt.outputs[0] = PsbtOutput {
+        bip32_derivation: [(change_pubkey.inner, (fingerprint, change_path))].into(),
+        ..Default::default()
+    };
+    Ok(psbt)
+}

--- a/e2e/cli/src/lib.rs
+++ b/e2e/cli/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod coldcard;
+#[cfg(test)]
+mod jade;
+#[cfg(test)]
+mod ledger;
+#[cfg(test)]
+mod support;

--- a/e2e/cli/src/support.rs
+++ b/e2e/cli/src/support.rs
@@ -1,0 +1,268 @@
+use std::{
+    env,
+    process::{Command, Output},
+    str::FromStr,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
+use miniscript::{
+    Descriptor, DescriptorPublicKey,
+    descriptor::{DescriptorType, DescriptorXKey, Wildcard, Wpkh},
+};
+#[derive(Clone, Debug)]
+pub(crate) struct Cli {
+    args: Vec<String>,
+}
+
+impl Cli {
+    pub(crate) fn global() -> Self {
+        Self {
+            args: vec!["--network".to_string(), "testnet".to_string()],
+        }
+    }
+
+    pub(crate) fn for_device(fingerprint: &str) -> Self {
+        Self::global().with_args(["--fingerprint", fingerprint])
+    }
+
+    pub(crate) fn json(&self) -> Self {
+        self.clone().with_args(["--format", "json"])
+    }
+
+    pub(crate) fn with_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.args
+            .extend(args.into_iter().map(|arg| arg.as_ref().to_string()));
+        self
+    }
+
+    fn command_args<I, S>(&self, args: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut command_args = self.args.clone();
+        command_args.extend(args.into_iter().map(|arg| arg.as_ref().to_string()));
+        command_args
+    }
+
+    pub(crate) fn run_ok<I, S>(&self, args: I) -> Result<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        run_ok(&self.command_args(args))
+    }
+
+    pub(crate) fn assert_failure_contains<I, S>(&self, args: I, needle: &str) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args = self.command_args(args);
+        let output = bhwi(&args)?;
+        assert!(
+            !output.status.success(),
+            "bhwi {args:?} unexpectedly succeeded with stdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let stderr = String::from_utf8(output.stderr)?;
+        assert!(
+            stderr.contains(needle),
+            "stderr did not contain {needle:?}\nstderr:\n{stderr}"
+        );
+        Ok(())
+    }
+}
+
+pub(crate) struct CommandCase<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) cli: Cli,
+    pub(crate) args: &'a [&'a str],
+    pub(crate) expected: ExpectedOutput<'a>,
+}
+
+pub(crate) enum ExpectedOutput<'a> {
+    Static(&'a str),
+    DescriptorPubkeys { fingerprint: &'a str },
+}
+
+impl ExpectedOutput<'_> {
+    fn render(&self) -> Result<String> {
+        match self {
+            Self::Static(output) => Ok((*output).to_string()),
+            Self::DescriptorPubkeys { fingerprint } => descriptor_stdout_for_device(fingerprint),
+        }
+    }
+}
+
+pub(crate) fn run_command_cases(cases: &[CommandCase<'_>]) -> Result<()> {
+    for case in cases {
+        let expected = case
+            .expected
+            .render()
+            .with_context(|| format!("failed to build expected output for {}", case.name))?;
+        let stdout = case
+            .cli
+            .run_ok(case.args)
+            .with_context(|| format!("failed to run {}", case.name))?;
+        assert_eq!(stdout, format!("{expected}\n"), "{}", case.name);
+    }
+    Ok(())
+}
+
+pub(crate) fn basic_cli_cases<'a>(fingerprint: &'a str, xpub: &'a str) -> Vec<CommandCase<'a>> {
+    vec![
+        CommandCase {
+            name: "device list",
+            cli: Cli::global(),
+            args: &["device", "list"],
+            expected: ExpectedOutput::Static(fingerprint),
+        },
+        CommandCase {
+            name: "xpub get m/44'/1'/0'",
+            cli: Cli::for_device(fingerprint),
+            args: &["xpub", "get", "m/44'/1'/0'"],
+            expected: ExpectedOutput::Static(xpub),
+        },
+        CommandCase {
+            name: "descriptor pubkeys account 0",
+            cli: Cli::for_device(fingerprint),
+            args: &["descriptor", "pubkeys", "--account", "0"],
+            expected: ExpectedOutput::DescriptorPubkeys { fingerprint },
+        },
+    ]
+}
+
+fn bhwi(args: &[String]) -> Result<Output> {
+    let bin = env::var("BHWI_BIN").context("BHWI_BIN must point to the built bhwi binary")?;
+    Command::new(bin)
+        .args(args)
+        .output()
+        .context("failed to spawn bhwi")
+}
+
+fn run_ok(args: &[String]) -> Result<String> {
+    let output = bhwi(args)?;
+    ensure_success(args, output)
+}
+
+fn ensure_success(args: &[String], output: Output) -> Result<String> {
+    if !output.status.success() {
+        bail!(
+            "bhwi {:?} failed with status {}\nstdout:\n{}\nstderr:\n{}",
+            args,
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stderr = String::from_utf8(output.stderr)?;
+    if !stderr.is_empty() {
+        bail!(
+            "bhwi {:?} succeeded with unexpected stderr\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            stderr
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn descriptor_stdout(fingerprint: &str, xpubs: [&str; 4]) -> Result<String> {
+    struct DescriptorCase {
+        desc_type: DescriptorType,
+        purpose: &'static str,
+        xpub_index: usize,
+    }
+
+    let cases = [
+        DescriptorCase {
+            desc_type: DescriptorType::Pkh,
+            purpose: "44",
+            xpub_index: 0,
+        },
+        DescriptorCase {
+            desc_type: DescriptorType::Wpkh,
+            purpose: "84",
+            xpub_index: 2,
+        },
+        DescriptorCase {
+            desc_type: DescriptorType::ShWpkh,
+            purpose: "49",
+            xpub_index: 1,
+        },
+        DescriptorCase {
+            desc_type: DescriptorType::Tr,
+            purpose: "86",
+            xpub_index: 3,
+        },
+    ];
+    let mut rendered = Vec::new();
+    for change in [0, 1] {
+        for case in &cases {
+            let origin = format!("m/{}'/1'/0'", case.purpose);
+            rendered.push(descriptor(
+                case.desc_type,
+                fingerprint,
+                &origin,
+                xpubs[case.xpub_index],
+                &format!("m/{change}"),
+            )?);
+        }
+    }
+    Ok(rendered.join("\n"))
+}
+
+fn descriptor_xpubs(fingerprint: &str) -> Result<[String; 4]> {
+    let cli = Cli::for_device(fingerprint);
+    Ok([
+        cli.run_ok(["xpub", "get", "m/44'/1'/0'"])?
+            .trim()
+            .to_string(),
+        cli.run_ok(["xpub", "get", "m/49'/1'/0'"])?
+            .trim()
+            .to_string(),
+        cli.run_ok(["xpub", "get", "m/84'/1'/0'"])?
+            .trim()
+            .to_string(),
+        cli.run_ok(["xpub", "get", "m/86'/1'/0'"])?
+            .trim()
+            .to_string(),
+    ])
+}
+
+fn descriptor_stdout_for_device(fingerprint: &str) -> Result<String> {
+    let xpubs = descriptor_xpubs(fingerprint)?;
+    descriptor_stdout(fingerprint, [&xpubs[0], &xpubs[1], &xpubs[2], &xpubs[3]])
+}
+
+fn descriptor(
+    desc_type: DescriptorType,
+    fingerprint: &str,
+    origin: &str,
+    xpub: &str,
+    suffix: &str,
+) -> Result<String> {
+    let key = DescriptorPublicKey::XPub(DescriptorXKey {
+        origin: Some((
+            Fingerprint::from_str(fingerprint)?,
+            DerivationPath::from_str(origin)?,
+        )),
+        xkey: Xpub::from_str(xpub)?,
+        derivation_path: DerivationPath::from_str(suffix)?,
+        wildcard: Wildcard::Unhardened,
+    });
+    let desc = match desc_type {
+        DescriptorType::Pkh => Descriptor::new_pkh(key)?,
+        DescriptorType::Wpkh => Descriptor::new_wpkh(key)?,
+        DescriptorType::ShWpkh => Descriptor::new_sh_with_wpkh(Wpkh::new(key)?),
+        DescriptorType::Tr => Descriptor::new_tr(key, None)?,
+        _ => return Err(anyhow!("unsupported descriptor type")),
+    };
+    Ok(format!("{desc:#}"))
+}


### PR DESCRIPTION
- add a bhwi-e2e-cli crate that runs the compiled bhwi binary against emulator-backed devices
- add CLI e2e steps to the existing emulator workflow jobs instead of duplicating simulator startup
- cover current main CLI commands, with Ledger Speculos automation for approval-heavy flows
