### PR TITLE
feat(bhwi-cli): add descriptor keypool command

### DIFF
--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
 use bhwi_async::DeviceContext;
-use bhwi_cli::{DeviceManager, OutputFormat, address::AddressTarget, config::Config};
+use bhwi_cli::{
+    DeviceManager, OutputFormat, address::AddressTarget, config::Config,
+    get_descriptors::GetKeypoolOptions,
+};
 
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -13,8 +16,8 @@ use bitcoin::{
     bip32::{DerivationPath, Fingerprint},
     psbt::Psbt,
 };
-use clap::{Parser, Subcommand};
-use miniscript::descriptor::WalletPolicy;
+use clap::{Parser, Subcommand, ValueEnum};
+use miniscript::descriptor::{DescriptorType, WalletPolicy};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -139,6 +142,25 @@ enum DeviceCommands {
     List,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum KeypoolAddressFormat {
+    P2pkh,
+    P2sh,
+    P2wpkh,
+    P2tr,
+}
+
+impl From<KeypoolAddressFormat> for DescriptorType {
+    fn from(format: KeypoolAddressFormat) -> Self {
+        match format {
+            KeypoolAddressFormat::P2pkh => DescriptorType::Pkh,
+            KeypoolAddressFormat::P2sh => DescriptorType::ShWpkh,
+            KeypoolAddressFormat::P2wpkh => DescriptorType::Wpkh,
+            KeypoolAddressFormat::P2tr => DescriptorType::Tr,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Subcommand)]
 enum XpubCommands {
     Get {
@@ -147,13 +169,31 @@ enum XpubCommands {
     },
 }
 
-#[derive(Debug, Clone, Copy, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 enum DescriptorCommands {
     /// Get pubkey descriptors from device
     #[command()]
     Pubkeys {
         #[arg(long, short)]
         account: Option<u32>,
+    },
+    /// Get a ranged keypool descriptor from the selected device
+    Keypool {
+        /// BIP account or parent derivation path (e.g. m/84'/0'/0')
+        #[arg(long, value_parser = clap::value_parser!(DerivationPath))]
+        path: DerivationPath,
+        /// First child index included in this keypool range
+        #[arg(long)]
+        start: u32,
+        /// Last child index included in this keypool range
+        #[arg(long)]
+        end: u32,
+        /// Address format for the descriptor (p2pkh, p2sh, p2wpkh, p2tr)
+        #[arg(long, value_enum, default_value_t = KeypoolAddressFormat::P2wpkh)]
+        address_format: KeypoolAddressFormat,
+        /// Use the internal/change branch
+        #[arg(long, default_value_t = false)]
+        internal: bool,
     },
 }
 
@@ -198,6 +238,23 @@ async fn main() -> Result<()> {
         },
         Commands::Descriptor(DescriptorCommands::Pubkeys { account }) => {
             dev_man.get_pubkey_descriptors(account).await?
+        }
+        Commands::Descriptor(DescriptorCommands::Keypool {
+            path,
+            start,
+            end,
+            address_format,
+            internal,
+        }) => {
+            let options = GetKeypoolOptions {
+                path,
+                start,
+                end,
+                internal,
+                descriptor_type: address_format.into(),
+                network: dev_man.config.network,
+            };
+            dev_man.get_keypool(options).await?;
         }
         Commands::Device(DeviceCommands::List) => {
             let mut devices = dev_man.enumerate().await?;

--- a/bhwi-cli/src/get_descriptors.rs
+++ b/bhwi-cli/src/get_descriptors.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use bhwi_async::HWIDevice;
 use bitcoin::{
     Network,
@@ -8,6 +8,7 @@ use miniscript::{
     Descriptor, DescriptorPublicKey,
     descriptor::{DescriptorType, DescriptorXKey, Wildcard, Wpkh},
 };
+use serde::{Serialize, Serializer};
 
 use crate::{DeviceManager, OutputFormat};
 
@@ -32,6 +33,31 @@ pub enum DescriptorTarget {
     Path(DerivationPath),
     /// BIP-44 account index
     Account(u32),
+}
+
+#[derive(Debug, Clone)]
+pub struct GetKeypoolOptions {
+    /// BIP account or parent path to derive the keypool branch from
+    pub path: DerivationPath,
+    /// First child index included in this keypool range
+    pub start: u32,
+    /// Last child index included in this keypool range
+    pub end: u32,
+    /// Whether this keypool is for change/internal addresses
+    pub internal: bool,
+    /// The address type to use for the descriptor
+    pub descriptor_type: DescriptorType,
+    /// The Bitcoin network to use in descriptor paths
+    pub network: Network,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeypoolDescriptor {
+    #[serde(serialize_with = "serialize_descriptor")]
+    pub descriptor: Descriptor<DescriptorPublicKey>,
+    pub range: [u32; 2],
+    pub internal: bool,
+    pub keypool: bool,
 }
 
 impl GetDescriptorOptions {
@@ -119,6 +145,52 @@ impl DeviceManager {
         })
     }
 
+    /// Gets a ranged keypool descriptor from an account/parent path.
+    pub async fn get_keypool_descriptor(
+        &self,
+        device: &mut Box<dyn HWIDevice>,
+        master_fingerprint: Fingerprint,
+        options: GetKeypoolOptions,
+    ) -> Result<KeypoolDescriptor> {
+        let descriptor_options = options.descriptor_options(master_fingerprint)?;
+        let descriptor = self.get_descriptor(device, descriptor_options).await?;
+        Ok(KeypoolDescriptor {
+            descriptor,
+            range: [options.start, options.end],
+            internal: options.internal,
+            keypool: true,
+        })
+    }
+
+    /// Output a ranged descriptor suitable for Bitcoin Core keypool import.
+    pub async fn get_keypool(&self, options: GetKeypoolOptions) -> Result<()> {
+        let Some(mut device) = self.get_device_with_fingerprint().await? else {
+            return Ok(());
+        };
+        let master_fingerprint = device.fingerprint().await?;
+        let keypool = self
+            .get_keypool_descriptor(device.device(), master_fingerprint, options)
+            .await?;
+        match self.config.format {
+            Some(OutputFormat::Json) => println!("{}", serde_json::to_string(&keypool)?),
+            Some(OutputFormat::Pretty) => {
+                println!("{:<9} | {:<8} | {:<10}", "Range", "Internal", "Descriptor");
+                println!("{}", "-".repeat(120));
+                println!(
+                    "{}-{} | {:<8} | {}",
+                    keypool.range[0], keypool.range[1], keypool.internal, keypool.descriptor
+                );
+            }
+            None => {
+                println!(
+                    "{:#} range={}-{} internal={} keypool=true",
+                    keypool.descriptor, keypool.range[0], keypool.range[1], keypool.internal
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Output all supported pubkey output descriptors for a device. Analogous
     /// to the Python HWI when uses with JSON formatting.
     // TODO: Python HWI outputs using h instead of ' for hardened paths but
@@ -189,6 +261,46 @@ impl DeviceManager {
     }
 }
 
+impl GetKeypoolOptions {
+    fn descriptor_options(&self, master_fingerprint: Fingerprint) -> Result<GetDescriptorOptions> {
+        validate_keypool_range(self.start, self.end)?;
+        let path = keypool_descriptor_path(&self.path, self.internal)?;
+        Ok(GetDescriptorOptions::with_path(
+            master_fingerprint,
+            path,
+            self.internal,
+            self.descriptor_type,
+            self.network,
+        ))
+    }
+}
+
+fn validate_keypool_range(start: u32, end: u32) -> Result<()> {
+    if start > end {
+        bail!("keypool start index must be less than or equal to end index");
+    }
+    Ok(())
+}
+
+fn keypool_descriptor_path(path: &DerivationPath, internal: bool) -> Result<DerivationPath> {
+    if has_hardened_child_after_unhardened(path) {
+        bail!("keypool path cannot contain hardened children after an unhardened child");
+    }
+
+    let branch = ChildNumber::from_normal_idx(internal.into())?;
+    let mut children = path.as_ref().to_vec();
+    children.push(branch);
+    Ok(children.into())
+}
+
+fn has_hardened_child_after_unhardened(path: &DerivationPath) -> bool {
+    let mut seen_unhardened = false;
+    path.as_ref().iter().any(|child| {
+        seen_unhardened |= !child.is_hardened();
+        seen_unhardened && child.is_hardened()
+    })
+}
+
 fn bip44_purpose(desc_type: DescriptorType) -> Result<u32> {
     Ok(match desc_type {
         DescriptorType::Sh | DescriptorType::Pkh => 44,
@@ -201,4 +313,79 @@ fn bip44_purpose(desc_type: DescriptorType) -> Result<u32> {
 
 fn bip44_chain(network: Network) -> u32 {
     if let Network::Bitcoin = network { 0 } else { 1 }
+}
+
+fn serialize_descriptor<S>(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+    ser: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    ser.serialize_str(&format!("{descriptor:#}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::bip32::DerivationPath;
+    use miniscript::{Descriptor, DescriptorPublicKey};
+
+    use super::{KeypoolDescriptor, keypool_descriptor_path, validate_keypool_range};
+
+    #[test]
+    fn keypool_path_appends_receive_branch() {
+        let path = DerivationPath::from_str("m/84'/0'/0'").unwrap();
+
+        let path = keypool_descriptor_path(&path, false).unwrap();
+
+        assert_eq!(path.to_string(), "84'/0'/0'/0");
+    }
+
+    #[test]
+    fn keypool_path_appends_internal_branch() {
+        let path = DerivationPath::from_str("m/84'/0'/0'").unwrap();
+
+        let path = keypool_descriptor_path(&path, true).unwrap();
+
+        assert_eq!(path.to_string(), "84'/0'/0'/1");
+    }
+
+    #[test]
+    fn keypool_range_rejects_start_after_end() {
+        let err = validate_keypool_range(10, 9).unwrap_err();
+
+        assert!(err.to_string().contains("start index"));
+    }
+
+    #[test]
+    fn keypool_path_rejects_hardened_children_after_unhardened() {
+        let path = DerivationPath::from_str("m/84'/0'/0'/0/1'").unwrap();
+
+        let err = keypool_descriptor_path(&path, false).unwrap_err();
+
+        assert!(err.to_string().contains("hardened children"));
+    }
+
+    #[test]
+    fn keypool_descriptor_serializes_json_shape() {
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(
+            "wpkh([e3ebcc79/84'/1'/0']tpubDCKD5cdxMEFd2i4cNa3PJUbUHMsGDxsnfqjxVpMoG1ymWYUQUaZzTcHQo3JwYgaKe2FyKGA2FzGPSVczBoAiHGyERuA1mZ2UkGKufEnUxKk/0/*)",
+        )
+        .unwrap();
+        let keypool = KeypoolDescriptor {
+            descriptor,
+            range: [7, 11],
+            internal: false,
+            keypool: true,
+        };
+
+        let json = serde_json::to_value(keypool).unwrap();
+
+        assert_eq!(json["range"], serde_json::json!([7, 11]));
+        assert_eq!(json["internal"], false);
+        assert_eq!(json["keypool"], true);
+        assert!(json["descriptor"].as_str().unwrap().starts_with("wpkh("));
+    }
 }

--- a/e2e/cli/src/coldcard.rs
+++ b/e2e/cli/src/coldcard.rs
@@ -37,3 +37,30 @@ fn coldcard_descriptor_pubkeys() -> Result<()> {
         },
     })
 }
+
+#[test]
+fn coldcard_keypool_get() -> Result<()> {
+    assert_command(CommandCase {
+        name: "descriptor keypool m/84'/1'/0' 0-4",
+        cli: Cli::for_device(COLDCARD_FINGERPRINT),
+        args: &[
+            "descriptor",
+            "keypool",
+            "--path",
+            "m/84'/1'/0'",
+            "--start",
+            "0",
+            "--end",
+            "4",
+        ],
+        expected: ExpectedOutput::Keypool {
+            fingerprint: COLDCARD_FINGERPRINT,
+            purpose: 84,
+            account: 0,
+            branch: 0,
+            start: 0,
+            end: 4,
+            internal: false,
+        },
+    })
+}

--- a/e2e/cli/src/jade.rs
+++ b/e2e/cli/src/jade.rs
@@ -39,6 +39,33 @@ fn jade_descriptor_pubkeys() -> Result<()> {
 }
 
 #[test]
+fn jade_keypool_get() -> Result<()> {
+    assert_command(CommandCase {
+        name: "descriptor keypool m/84'/1'/0' 0-4",
+        cli: Cli::for_device(JADE_FINGERPRINT),
+        args: &[
+            "descriptor",
+            "keypool",
+            "--path",
+            "m/84'/1'/0'",
+            "--start",
+            "0",
+            "--end",
+            "4",
+        ],
+        expected: ExpectedOutput::Keypool {
+            fingerprint: JADE_FINGERPRINT,
+            purpose: 84,
+            account: 0,
+            branch: 0,
+            start: 0,
+            end: 4,
+            internal: false,
+        },
+    })
+}
+
+#[test]
 fn jade_sign_message() -> Result<()> {
     assert_command(CommandCase {
         name: "sign message hello",

--- a/e2e/cli/src/ledger.rs
+++ b/e2e/cli/src/ledger.rs
@@ -58,6 +58,33 @@ fn ledger_descriptor_pubkeys() -> Result<()> {
 }
 
 #[test]
+fn ledger_keypool_get() -> Result<()> {
+    assert_command(CommandCase {
+        name: "descriptor keypool m/84'/1'/0' 0-4",
+        cli: Cli::for_device(LEDGER_FINGERPRINT),
+        args: &[
+            "descriptor",
+            "keypool",
+            "--path",
+            "m/84'/1'/0'",
+            "--start",
+            "0",
+            "--end",
+            "4",
+        ],
+        expected: ExpectedOutput::Keypool {
+            fingerprint: LEDGER_FINGERPRINT,
+            purpose: 84,
+            account: 0,
+            branch: 0,
+            start: 0,
+            end: 4,
+            internal: false,
+        },
+    })
+}
+
+#[test]
 fn ledger_address_by_path() -> Result<()> {
     assert_command(CommandCase {
         name: "address get from path",

--- a/e2e/cli/src/support.rs
+++ b/e2e/cli/src/support.rs
@@ -59,7 +59,19 @@ pub(crate) struct CommandCase<'a> {
 
 pub(crate) enum ExpectedOutput<'a> {
     Exact(&'a str),
-    DescriptorPubkeys { fingerprint: &'a str, account: u32 },
+    DescriptorPubkeys {
+        fingerprint: &'a str,
+        account: u32,
+    },
+    Keypool {
+        fingerprint: &'a str,
+        purpose: u32,
+        account: u32,
+        branch: u32,
+        start: u32,
+        end: u32,
+        internal: bool,
+    },
 }
 
 impl ExpectedOutput<'_> {
@@ -70,6 +82,27 @@ impl ExpectedOutput<'_> {
                 fingerprint,
                 account,
             } => assert_descriptor_pubkeys(name, stdout, fingerprint, *account)?,
+            Self::Keypool {
+                fingerprint,
+                purpose,
+                account,
+                branch,
+                start,
+                end,
+                internal,
+            } => assert_keypool(
+                name,
+                stdout,
+                KeypoolExpectation {
+                    fingerprint,
+                    purpose: *purpose,
+                    account: *account,
+                    branch: *branch,
+                    start: *start,
+                    end: *end,
+                    internal: *internal,
+                },
+            )?,
         }
         Ok(())
     }
@@ -200,4 +233,56 @@ fn descriptor_xpub(fingerprint: &str, purpose: u32, account: u32) -> Result<Stri
         .run_ok(["xpub", "get", &format!("m/{purpose}'/1'/{account}'")])?
         .trim()
         .to_string())
+}
+
+struct KeypoolExpectation<'a> {
+    fingerprint: &'a str,
+    purpose: u32,
+    account: u32,
+    branch: u32,
+    start: u32,
+    end: u32,
+    internal: bool,
+}
+
+fn assert_keypool(name: &str, stdout: &str, expected: KeypoolExpectation<'_>) -> Result<()> {
+    let xpub = descriptor_xpub(expected.fingerprint, expected.purpose, expected.account)?;
+    let origin = format!(
+        "[{}/{}'/1'/{}']",
+        expected.fingerprint, expected.purpose, expected.account
+    );
+    let suffix = format!("/{branch}/*", branch = expected.branch);
+    let metadata = format!(
+        " range={}-{} internal={} keypool=true",
+        expected.start, expected.end, expected.internal
+    );
+
+    assert!(
+        stdout.ends_with('\n'),
+        "{name}: stdout should end with newline"
+    );
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "{name}: keypool descriptor count");
+    let line = lines[0];
+    assert!(
+        line.starts_with("wpkh("),
+        "{name}: keypool descriptor `{line}` should start with `wpkh(`"
+    );
+    assert!(
+        line.contains(&origin),
+        "{name}: keypool descriptor `{line}` should contain origin `{origin}`"
+    );
+    assert!(
+        line.contains(&xpub),
+        "{name}: keypool descriptor `{line}` should contain xpub `{xpub}`"
+    );
+    assert!(
+        line.contains(&suffix),
+        "{name}: keypool descriptor `{line}` should contain suffix `{suffix}`"
+    );
+    assert!(
+        line.ends_with(&metadata),
+        "{name}: keypool descriptor `{line}` should end with metadata `{metadata}`"
+    );
+    Ok(())
 }


### PR DESCRIPTION
Part 1 of working down the list of implementing HWI CLI commands.

First all implemented commands will be per our command structure, i.e `descriptor
keypool`.
Then, once everything is done we will have the special compatibility binary where all commands will be identical (hopefully) to HWI.

Analogous to HWI https://hwi.readthedocs.io/en/latest/usage/cli-usage.html#hwi-getkeypool