### PR TITLE
fix(bhwi-cli): return first matching device in selection

### DIFF
--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -134,9 +134,11 @@ impl DeviceManager {
             if let Some(fingerprint) = self.config.fingerprint {
                 if fingerprint == d.fingerprint().await? {
                     target_dev = Some(d);
+                    break;
                 }
             } else {
                 target_dev = Some(d);
+                break;
             }
         }
         let Some(mut dev) = target_dev else {

--- a/e2e/cli/src/ledger.rs
+++ b/e2e/cli/src/ledger.rs
@@ -35,6 +35,16 @@ fn ledger_device_list() -> Result<()> {
 }
 
 #[test]
+fn ledger_no_matching_fingerprint_selects_no_device() -> Result<()> {
+    let stdout = Cli::for_device("ffffffff").run_ok(["xpub", "get", "m/84'/1'/0'"])?;
+    assert!(
+        stdout.is_empty(),
+        "expected no output when no device matches, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn ledger_xpub_get() -> Result<()> {
     assert_command(CommandCase {
         name: "xpub get m/44'/1'/0'",


### PR DESCRIPTION
Device scanning by fingerprint now exits early instead of continuing
to scan the other devices once found. If fingerprint isn't given then
first device is returned.