### PR TITLE
chore: add direnv setup for nix devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 result
 website/pkg
+.direnv/


### PR DESCRIPTION
Add .envrc with 'use flake' so direnv loads the nix devShell
automatically when you enter the directory.