### PR TITLE
fix(nix): update website npmDepsHash for updated lockfile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
           name = "bhwi-website";
           src = ./website;
           nodejs = nodejs_20;
-          npmDepsHash = "sha256-B+hl2uXdXBV9N99+RDSRzwO4xvpr8l+l2RU7MO2OyWA=";
+          npmDepsHash = "sha256-N2Uxh6567ry8CSZyBWWIg8yDJEqQXFtToKi4hVBr8Hk=";
           postPatch = ''
             cp -rL --no-preserve=mode,ownership ${bhwi-wasm-pkg} pkg
           '';


### PR DESCRIPTION
PR #46 added a `license` field to `website/package-lock.json`'s local `pkg` entry, which changed the fixed-output derivation hash for `fetchNpmDeps` but did not update `npmDepsHash` in `flake.nix`. This broke the Pages build with a hash mismatch.

Recomputed locally with `prefetch-npm-deps website/package-lock.json`:

```
specified: sha256-B+hl2uXdXBV9N99+RDSRzwO4xvpr8l+l2RU7MO2OyWA=
got:       sha256-N2Uxh6567ry8CSZyBWWIg8yDJEqQXFtToKi4hVBr8Hk=
```

Bumps `npmDepsHash` to the new value.