### PR TITLE
Add HWI parity harness and enumerate compatibility

### DIFF
--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -58,10 +58,17 @@ jobs:
             exit 1
           }
           kill "$(cat coldcard-tail.pid)" || true
+      - name: Run HWI parity tests
+        run: |
+          set -o pipefail
+          nix run .#hwi-parity-coldcard 2>&1 | tee coldcard-hwi-parity.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Coldcard HWI parity log" coldcard-hwi-parity.log
+            cat coldcard-hwi-parity.log || true
+            exit 1
+          }
       - name: Run Coldcard CLI e2e
         run: |
           set -o pipefail
-          nix develop .#coldcard -c cargo build -p bhwi-cli --bin bhwi
           BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#coldcard -c cargo test -p bhwi-e2e-cli coldcard -- --test-threads=1 2>&1 | tee coldcard-cli-e2e.log || {
             bash nix/scripts/emit-gh-error-log.sh "Coldcard CLI e2e log" coldcard-cli-e2e.log
             cat coldcard-cli-e2e.log || true
@@ -111,10 +118,17 @@ jobs:
             exit 1
           }
           kill "$(cat ledger-tail.pid)" || true
+      - name: Run HWI parity tests
+        run: |
+          set -o pipefail
+          nix run .#hwi-parity-ledger 2>&1 | tee ledger-hwi-parity.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger HWI parity log" ledger-hwi-parity.log
+            cat ledger-hwi-parity.log || true
+            exit 1
+          }
       - name: Run Ledger CLI e2e
         run: |
           set -o pipefail
-          nix develop .#ledger -c cargo build -p bhwi-cli --bin bhwi
           BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --test-threads=1 2>&1 | tee ledger-cli-e2e.log || {
             bash nix/scripts/emit-gh-error-log.sh "Ledger CLI e2e log" ledger-cli-e2e.log
             cat ledger-cli-e2e.log || true
@@ -178,10 +192,17 @@ jobs:
             cat jade-init.log || true
             exit 1
           }
+      - name: Run HWI parity tests
+        run: |
+          set -o pipefail
+          nix run .#hwi-parity-jade 2>&1 | tee jade-hwi-parity.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Jade HWI parity log" jade-hwi-parity.log
+            cat jade-hwi-parity.log || true
+            exit 1
+          }
       - name: Run Jade CLI e2e
         run: |
           set -o pipefail
-          nix develop .#jade -c cargo build -p bhwi-cli --bin bhwi
           BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#jade -c cargo test -p bhwi-e2e-cli jade -- --test-threads=1 2>&1 | tee jade-cli-e2e.log || {
             bash nix/scripts/emit-gh-error-log.sh "Jade CLI e2e log" jade-cli-e2e.log
             cat jade-cli-e2e.log || true

--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -26,6 +26,12 @@ jobs:
         run: nix flake show --allow-import-from-derivation
       - name: Build script check
         run: nix build .#checks.x86_64-linux.emulator-scripts
+      - name: Run HWI parity tests
+        run: |
+          ref="$(nix build --no-link --print-out-paths .#hwi-reference-bhwi)"
+          nix develop -c cargo build -p bhwi-cli --bin hwi
+          REFERENCE_HWI_BIN="$ref/bin/hwi-reference-bhwi" HWI_BIN="$PWD/target/debug/hwi" \
+            nix develop -c cargo test -p bhwi-e2e-hwi-parity
 
   coldcard-e2e:
     needs: nix-flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bhwi-e2e-hwi-parity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+]
+
+[[package]]
 name = "bhwi-e2e-jade"
 version = "0.1.0"
 dependencies = [

--- a/bhwi-cli/Cargo.toml
+++ b/bhwi-cli/Cargo.toml
@@ -12,6 +12,10 @@ description = "cli tool to talk to hardware wallet"
 name = "bhwi"
 path = "src/bin/bhwi.rs"
 
+[[bin]]
+name = "hwi"
+path = "src/bin/hwi.rs"
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
 use bhwi_async::DeviceContext;
 use bhwi_cli::{
-    DeviceManager, OutputFormat, address::AddressTarget, config::Config,
+    DeviceManager, OutputFormat, address::AddressTarget, config::DeviceSelector,
     get_descriptors::GetKeypoolOptions,
 };
 
@@ -35,19 +35,20 @@ struct Args {
     format: Option<OutputFormat>,
 }
 
-impl From<Args> for Config {
-    fn from(args: Args) -> Self {
-        let Args {
-            network,
-            fingerprint,
-            format,
-            ..
-        } = args;
-        Self {
-            network,
-            fingerprint,
-            format,
+impl Args {
+    fn device_selector(&self) -> DeviceSelector {
+        DeviceSelector {
+            network: self.network,
+            fingerprint: self.fingerprint,
+            include_emulators: true,
+            ..DeviceSelector::default()
         }
+    }
+}
+
+impl From<&Args> for DeviceSelector {
+    fn from(args: &Args) -> Self {
+        args.device_selector()
     }
 }
 
@@ -202,8 +203,8 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let command = args.command.to_owned();
     let format = args.format;
-    let config: Config = args.into();
-    let dev_man = DeviceManager::new(config);
+    let selector = DeviceSelector::from(&args);
+    let dev_man = DeviceManager::new(selector);
     match command {
         Commands::Address(AddressCommands::Get {
             from_path,
@@ -237,7 +238,7 @@ async fn main() -> Result<()> {
             _ => anyhow::bail!("either --from-path or --from-descriptor must be specified"),
         },
         Commands::Descriptor(DescriptorCommands::Pubkeys { account }) => {
-            dev_man.get_pubkey_descriptors(account).await?
+            dev_man.get_pubkey_descriptors(account, format).await?
         }
         Commands::Descriptor(DescriptorCommands::Keypool {
             path,
@@ -252,15 +253,15 @@ async fn main() -> Result<()> {
                 end,
                 internal,
                 descriptor_type: address_format.into(),
-                network: dev_man.config.network,
+                network: dev_man.selector.network,
             };
-            dev_man.get_keypool(options).await?;
+            dev_man.get_keypool(options, format).await?;
         }
         Commands::Device(DeviceCommands::List) => {
             let mut devices = dev_man.enumerate().await?;
             for (i, device) in devices.iter_mut().enumerate() {
                 // XXX: Coldcard always needs unlocking
-                device.device().unlock(dev_man.config.network).await?;
+                device.device().unlock(dev_man.selector.network).await?;
                 let fingerprint = device.fingerprint().await?;
                 let name = device.name().to_string();
                 let is_emulated = device.is_emulated();
@@ -453,6 +454,20 @@ mod tests {
                 output: None,
             } if message == "hello" && path.to_string() == "44'/1'/0'/0"
         ));
+    }
+
+    #[test]
+    fn native_cli_rejects_hwi_only_selector_flags() {
+        let error = Args::try_parse_from([
+            "bhwi",
+            "--device-path",
+            "tcp:localhost:9999",
+            "device",
+            "list",
+        ])
+        .expect_err("native CLI must not accept HWI compatibility flags");
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
     }
 
     #[test]

--- a/bhwi-cli/src/bin/hwi.rs
+++ b/bhwi-cli/src/bin/hwi.rs
@@ -1,0 +1,6 @@
+use std::process::ExitCode;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    bhwi_cli::hwi::run_cli(std::env::args()).await
+}

--- a/bhwi-cli/src/coldcard.rs
+++ b/bhwi-cli/src/coldcard.rs
@@ -50,7 +50,7 @@ impl ColdcardDevice {
                 "Coldcard Emulator",
                 DeviceType::Coldcard,
                 path,
-                "coldcard",
+                "coldcard_simulator",
                 Box::new(Coldcard::new(ColdcardTransportHID::new(client), rng)),
                 true,
             )

--- a/bhwi-cli/src/coldcard.rs
+++ b/bhwi-cli/src/coldcard.rs
@@ -12,10 +12,9 @@ use bhwi_async::{
 };
 use futures::StreamExt;
 use futures::TryStreamExt;
-use futures::stream::iter;
 use rand_core::OsRng;
 
-use crate::{Device, DeviceEnumerator, config::Config, hid::HidChannel};
+use crate::{Device, DeviceEnumerator, DeviceType, config::DeviceSelector, hid::HidChannel};
 
 pub type ColdcardHidDevice = Coldcard<ColdcardTransportHID<HidChannel>>;
 
@@ -23,9 +22,14 @@ pub struct ColdcardDevice;
 
 impl ColdcardDevice {
     async fn hid_device(hid_dev: HidDevice, rng: &mut OsRng) -> Result<Option<Device>> {
+        let path = hid_path(&hid_dev);
+        let name = hid_dev.name.clone();
         Ok(Some(
             Device::new(
-                &hid_dev.name,
+                &name,
+                DeviceType::Coldcard,
+                path,
+                "coldcard",
                 Box::new(Coldcard::new(
                     ColdcardTransportHID::new(HidChannel::new(hid_dev.open().await?)),
                     rng,
@@ -44,6 +48,9 @@ impl ColdcardDevice {
             };
             let device = Device::new(
                 "Coldcard Emulator",
+                DeviceType::Coldcard,
+                path,
+                "coldcard",
                 Box::new(Coldcard::new(ColdcardTransportHID::new(client), rng)),
                 true,
             )
@@ -62,7 +69,7 @@ impl ColdcardDevice {
 
 #[async_trait(?Send)]
 impl DeviceEnumerator for ColdcardDevice {
-    async fn enumerate(_config: &Config) -> Result<Vec<Device>> {
+    async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>> {
         let DeviceId {
             vid,
             pid,
@@ -70,26 +77,37 @@ impl DeviceEnumerator for ColdcardDevice {
             ..
         } = COLDCARD_DEVICE_ID;
         let mut rng = OsRng;
-        let devices = HidBackend::default()
+        let mut devices: Vec<Device> = HidBackend::default()
             .enumerate()
             .await?
             .map(Ok)
             .try_filter_map(|dev| async move {
-                if dev.vendor_id == vid && dev.product_id == pid.context("coldcard pid not set")? {
+                let path = hid_path(&dev);
+                if selector.matches(DeviceType::Coldcard, &path)
+                    && dev.vendor_id == vid
+                    && dev.product_id == pid.context("coldcard pid not set")?
+                {
                     Self::hid_device(dev, &mut rng).await
                 } else {
                     Ok(None)
                 }
             })
-            .chain(
-                iter(emulator_path.map(Ok).into_iter()).try_filter_map(|path| async move {
-                    Self::emulator_device(path, &mut rng).await
-                }),
-            )
             .try_collect()
             .await?;
+        if selector.include_emulators
+            && let Some(path) = emulator_path
+            && selector.matches(DeviceType::Coldcard, path)
+            && let Some(device) = Self::emulator_device(path, &mut rng).await?
+        {
+            devices.push(device);
+        }
         Ok(devices)
     }
+}
+
+fn hid_path(dev: &HidDevice) -> String {
+    let suffix = dev.serial_number.as_deref().unwrap_or(&dev.name);
+    format!("hid:{:04x}:{:04x}:{suffix}", dev.vendor_id, dev.product_id)
 }
 
 #[cfg(unix)]

--- a/bhwi-cli/src/config.rs
+++ b/bhwi-cli/src/config.rs
@@ -1,11 +1,34 @@
 use bitcoin::{Network, bip32::Fingerprint};
 
-use crate::OutputFormat;
+use crate::DeviceType;
 
-// TODO: eventually have this be parsable by toml/yaml, env vars
-#[derive(Debug)]
-pub struct Config {
+#[derive(Debug, Clone)]
+pub struct DeviceSelector {
     pub network: Network,
     pub fingerprint: Option<Fingerprint>,
-    pub format: Option<OutputFormat>,
+    pub device_type: Option<DeviceType>,
+    pub device_path: Option<String>,
+    pub include_emulators: bool,
+}
+
+impl Default for DeviceSelector {
+    fn default() -> Self {
+        Self {
+            network: Network::Bitcoin,
+            fingerprint: None,
+            device_type: None,
+            device_path: None,
+            include_emulators: false,
+        }
+    }
+}
+
+impl DeviceSelector {
+    pub fn matches(&self, device_type: DeviceType, path: &str) -> bool {
+        self.device_type.is_none_or(|target| target == device_type)
+            && self
+                .device_path
+                .as_ref()
+                .is_none_or(|target| target == path)
+    }
 }

--- a/bhwi-cli/src/get_descriptors.rs
+++ b/bhwi-cli/src/get_descriptors.rs
@@ -163,7 +163,11 @@ impl DeviceManager {
     }
 
     /// Output a ranged descriptor suitable for Bitcoin Core keypool import.
-    pub async fn get_keypool(&self, options: GetKeypoolOptions) -> Result<()> {
+    pub async fn get_keypool(
+        &self,
+        options: GetKeypoolOptions,
+        format: Option<OutputFormat>,
+    ) -> Result<()> {
         let Some(mut device) = self.get_device_with_fingerprint().await? else {
             return Ok(());
         };
@@ -171,7 +175,7 @@ impl DeviceManager {
         let keypool = self
             .get_keypool_descriptor(device.device(), master_fingerprint, options)
             .await?;
-        match self.config.format {
+        match format {
             Some(OutputFormat::Json) => println!("{}", serde_json::to_string(&keypool)?),
             Some(OutputFormat::Pretty) => {
                 println!("{:<9} | {:<8} | {:<10}", "Range", "Internal", "Descriptor");
@@ -195,12 +199,15 @@ impl DeviceManager {
     /// to the Python HWI when uses with JSON formatting.
     // TODO: Python HWI outputs using h instead of ' for hardened paths but
     // rust-miniscript doesn't allow this when displaying an entire Descriptor.
-    pub async fn get_pubkey_descriptors(&self, account: Option<u32>) -> Result<()> {
+    pub async fn get_pubkey_descriptors(
+        &self,
+        account: Option<u32>,
+        format: Option<OutputFormat>,
+    ) -> Result<()> {
         let Some(mut device) = self.get_device_with_fingerprint().await? else {
             return Ok(());
         };
-        let network = self.config.network;
-        let format = self.config.format;
+        let network = self.selector.network;
         let fingerprint = device.fingerprint().await?;
         let dev = device.device();
         let mut receive = vec![];

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -1,0 +1,331 @@
+use std::{ffi::OsString, process::ExitCode, str::FromStr};
+
+use bitcoin::{Network, bip32::Fingerprint};
+use clap::{Parser, Subcommand, error::ErrorKind};
+use serde::{Serialize, Serializer};
+
+use crate::{DeviceManager, DeviceType, config::DeviceSelector};
+
+type HwiResult<T> = std::result::Result<T, HwiError>;
+
+#[derive(Debug, Clone, Parser)]
+#[command(author, version, about = "Python HWI compatible interface")]
+pub struct HwiCli {
+    #[command(subcommand)]
+    command: HwiCliCommand,
+    #[arg(long = "device-type")]
+    device_type: Option<String>,
+    #[arg(long = "device-path")]
+    device_path: Option<String>,
+    #[arg(long, alias = "fingerprint")]
+    fingerprint: Option<Fingerprint>,
+    #[arg(long, default_value = "main")]
+    chain: String,
+    #[arg(long)]
+    emulators: bool,
+    #[arg(long, hide = true)]
+    stdinpass: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum HwiCliCommand {
+    Enumerate,
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+#[derive(Debug, Clone)]
+pub struct HwiRequest {
+    pub selector: DeviceSelector,
+    pub command: HwiCommand,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum HwiCommand {
+    Enumerate,
+    Unsupported(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct HwiError {
+    pub error: String,
+    pub code: i32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HwiErrorCode {
+    BadArgument,
+    UnsupportedCommand,
+    DeviceConnectionError,
+}
+
+impl HwiErrorCode {
+    fn code(self) -> i32 {
+        match self {
+            HwiErrorCode::BadArgument => -7,
+            HwiErrorCode::UnsupportedCommand => -9,
+            HwiErrorCode::DeviceConnectionError => -10,
+        }
+    }
+}
+
+impl HwiError {
+    fn new(code: HwiErrorCode, error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+            code: code.code(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiEnumeratedDevice {
+    #[serde(rename = "type")]
+    pub device_type: String,
+    pub model: String,
+    pub path: String,
+    #[serde(default, serialize_with = "option_fingerprint")]
+    pub fingerprint: Option<Fingerprint>,
+    pub needs_pin_sent: bool,
+    pub needs_passphrase_sent: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum HwiResponse {
+    Enumerate(Vec<HwiEnumeratedDevice>),
+    Error(HwiError),
+}
+
+pub fn parse_args<I, T>(args: I) -> HwiResult<HwiRequest>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let cli = HwiCli::try_parse_from(args)
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    request_from_cli(cli)
+}
+
+pub async fn process_request(request: HwiRequest) -> HwiResponse {
+    match request.command {
+        HwiCommand::Enumerate => enumerate(request.selector).await,
+        HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            format!("Unsupported HWI command: {command}"),
+        )),
+    }
+}
+
+pub async fn run_cli<I, T>(args: I) -> ExitCode
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let request = match HwiCli::try_parse_from(args) {
+        Ok(args) => match request_from_cli(args) {
+            Ok(request) => request,
+            Err(err) => return print_response(HwiResponse::Error(err)),
+        },
+        Err(err) if err.kind() == ErrorKind::DisplayHelp => {
+            print!("{err}");
+            return ExitCode::SUCCESS;
+        }
+        Err(err) if err.kind() == ErrorKind::DisplayVersion => {
+            print!("{err}");
+            return ExitCode::SUCCESS;
+        }
+        Err(err) => {
+            return print_response(HwiResponse::Error(HwiError::new(
+                HwiErrorCode::BadArgument,
+                err.to_string(),
+            )));
+        }
+    };
+    print_response(process_request(request).await)
+}
+
+async fn enumerate(selector: DeviceSelector) -> HwiResponse {
+    let manager = DeviceManager::new(selector);
+    let devices = match manager.enumerate().await {
+        Ok(devices) => devices,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+    let mut response = Vec::with_capacity(devices.len());
+    for mut device in devices {
+        let mut error = None;
+        let mut code = None;
+        let fingerprint = match device.device().unlock(manager.selector.network).await {
+            Ok(()) => match device.fingerprint().await {
+                Ok(fingerprint) => Some(fingerprint),
+                Err(err) => {
+                    error = Some(err.to_string());
+                    code = Some(HwiErrorCode::DeviceConnectionError.code());
+                    None
+                }
+            },
+            Err(err) => {
+                error = Some(err.to_string());
+                code = Some(HwiErrorCode::DeviceConnectionError.code());
+                None
+            }
+        };
+        response.push(HwiEnumeratedDevice {
+            device_type: device.device_type().to_string(),
+            model: device.model().to_owned(),
+            path: device.path().to_owned(),
+            fingerprint,
+            needs_pin_sent: false,
+            needs_passphrase_sent: false,
+            error,
+            code,
+        });
+    }
+    HwiResponse::Enumerate(response)
+}
+
+fn print_response(response: HwiResponse) -> ExitCode {
+    match response {
+        HwiResponse::Error(error) => {
+            println!(
+                "{}",
+                serde_json::to_string(&HwiResponse::Error(error)).expect("serialize HWI error")
+            );
+            ExitCode::from(1)
+        }
+        response => {
+            println!(
+                "{}",
+                serde_json::to_string(&response).expect("serialize HWI response")
+            );
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn parse_device_type(value: &str) -> HwiResult<DeviceType> {
+    match value.to_ascii_lowercase().as_str() {
+        "coldcard" => Ok(DeviceType::Coldcard),
+        "jade" => Ok(DeviceType::Jade),
+        "ledger" => Ok(DeviceType::Ledger),
+        _ => Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Unsupported device type: {value}"),
+        )),
+    }
+}
+
+fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
+    let device_type = args
+        .device_type
+        .as_deref()
+        .map(parse_device_type)
+        .transpose()?;
+    let network = parse_chain(&args.chain)?;
+    let command = match args.command {
+        HwiCliCommand::Enumerate => HwiCommand::Enumerate,
+        HwiCliCommand::External(argv) => {
+            let command = argv
+                .first()
+                .and_then(|arg| arg.to_str())
+                .unwrap_or("<unknown>")
+                .to_owned();
+            HwiCommand::Unsupported(command)
+        }
+    };
+    Ok(HwiRequest {
+        selector: DeviceSelector {
+            network,
+            fingerprint: args.fingerprint,
+            device_type,
+            device_path: args.device_path,
+            include_emulators: args.emulators,
+        },
+        command,
+    })
+}
+
+fn parse_chain(value: &str) -> HwiResult<Network> {
+    match value {
+        "main" | "mainnet" => Ok(Network::Bitcoin),
+        "test" | "testnet" => Ok(Network::Testnet),
+        _ => Network::from_str(value).map_err(|err| {
+            HwiError::new(
+                HwiErrorCode::BadArgument,
+                format!("Unsupported chain {value}: {err}"),
+            )
+        }),
+    }
+}
+
+fn option_fingerprint<S>(value: &Option<Fingerprint>, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(v) = value {
+        hex::serialize(v, ser)
+    } else {
+        ser.serialize_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_enumerate_selector() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--fingerprint",
+            "f5acc2fd",
+            "--device-type",
+            "ledger",
+            "--device-path",
+            "tcp:localhost:9999",
+            "--emulators",
+            "enumerate",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.selector.device_path.as_deref(),
+            Some("tcp:localhost:9999")
+        );
+        assert!(request.selector.include_emulators);
+        assert_eq!(request.command, HwiCommand::Enumerate);
+    }
+
+    #[test]
+    fn rejects_unknown_device_type_as_hwi_error() {
+        let error = parse_args(["hwi", "--device-type", "trezor", "enumerate"])
+            .expect_err("unsupported device type");
+
+        assert_eq!(error.code, HwiErrorCode::BadArgument.code());
+        assert!(error.error.contains("Unsupported device type"));
+    }
+
+    #[test]
+    fn captures_unsupported_commands() {
+        let request =
+            parse_args(["hwi", "getxpub", "m/84h/0h/0h"]).expect("unsupported command request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::Unsupported("getxpub".to_owned())
+        );
+    }
+}

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -84,7 +84,13 @@ pub struct HwiEnumeratedDevice {
     pub device_type: String,
     pub model: String,
     pub path: String,
-    #[serde(default, serialize_with = "option_fingerprint")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<Option<String>>,
+    #[serde(
+        default,
+        serialize_with = "option_fingerprint",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub fingerprint: Option<Fingerprint>,
     pub needs_pin_sent: bool,
     pub needs_passphrase_sent: bool,
@@ -183,6 +189,7 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
             device_type: device.device_type().to_string(),
             model: device.model().to_owned(),
             path: device.path().to_owned(),
+            label: label_for(device.device_type()),
             fingerprint,
             needs_pin_sent: false,
             needs_passphrase_sent: false,
@@ -191,6 +198,13 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
         });
     }
     HwiResponse::Enumerate(response)
+}
+
+fn label_for(device_type: DeviceType) -> Option<Option<String>> {
+    match device_type {
+        DeviceType::Coldcard | DeviceType::Ledger => Some(None),
+        DeviceType::Jade => None,
+    }
 }
 
 fn print_response(response: HwiResponse) -> ExitCode {
@@ -327,5 +341,58 @@ mod tests {
             request.command,
             HwiCommand::Unsupported("getxpub".to_owned())
         );
+    }
+
+    #[test]
+    fn ledger_and_coldcard_labels_are_serialized_as_null() {
+        assert_eq!(
+            serde_json::to_value(HwiEnumeratedDevice {
+                device_type: "ledger".to_owned(),
+                model: "ledger_nano_s".to_owned(),
+                path: "tcp:localhost:9999".to_owned(),
+                label: label_for(DeviceType::Ledger),
+                fingerprint: None,
+                needs_pin_sent: false,
+                needs_passphrase_sent: false,
+                error: None,
+                code: None,
+            })
+            .expect("json")["label"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            serde_json::to_value(HwiEnumeratedDevice {
+                device_type: "coldcard".to_owned(),
+                model: "coldcard".to_owned(),
+                path: "/tmp/ckcc-simulator.sock".to_owned(),
+                label: label_for(DeviceType::Coldcard),
+                fingerprint: None,
+                needs_pin_sent: false,
+                needs_passphrase_sent: false,
+                error: None,
+                code: None,
+            })
+            .expect("json")["label"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn jade_label_and_missing_fingerprint_are_omitted() {
+        let json = serde_json::to_value(HwiEnumeratedDevice {
+            device_type: "jade".to_owned(),
+            model: "jade".to_owned(),
+            path: "localhost:30121".to_owned(),
+            label: label_for(DeviceType::Jade),
+            fingerprint: None,
+            needs_pin_sent: false,
+            needs_passphrase_sent: false,
+            error: Some("connection failed".to_owned()),
+            code: Some(HwiErrorCode::DeviceConnectionError.code()),
+        })
+        .expect("json");
+
+        assert!(json.get("label").is_none());
+        assert!(json.get("fingerprint").is_none());
     }
 }

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -1,4 +1,9 @@
-use std::{ffi::OsString, process::ExitCode, str::FromStr};
+use std::{
+    ffi::OsString,
+    io::{self, BufRead},
+    process::ExitCode,
+    str::FromStr,
+};
 
 use bitcoin::{Network, bip32::Fingerprint};
 use clap::{Parser, Subcommand, error::ErrorKind};
@@ -13,16 +18,26 @@ type HwiResult<T> = std::result::Result<T, HwiError>;
 pub struct HwiCli {
     #[command(subcommand)]
     command: HwiCliCommand,
-    #[arg(long = "device-type")]
+    #[arg(long = "device-type", short = 't')]
     device_type: Option<String>,
-    #[arg(long = "device-path")]
+    #[arg(long = "device-path", short = 'd')]
     device_path: Option<String>,
-    #[arg(long, alias = "fingerprint")]
+    #[arg(long, short = 'f')]
     fingerprint: Option<Fingerprint>,
+    #[arg(long, short = 'p')]
+    password: Option<String>,
     #[arg(long, default_value = "main")]
     chain: String,
     #[arg(long)]
+    debug: bool,
+    #[arg(long)]
     emulators: bool,
+    #[arg(long)]
+    stdin: bool,
+    #[arg(long, short = 'i')]
+    interactive: bool,
+    #[arg(long)]
+    expert: bool,
     #[arg(long, hide = true)]
     stdinpass: bool,
 }
@@ -132,6 +147,15 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
+    let args = match args_from_stdin(args) {
+        Ok(args) => args,
+        Err(err) => {
+            return print_response(HwiResponse::Error(HwiError::new(
+                HwiErrorCode::BadArgument,
+                err.to_string(),
+            )));
+        }
+    };
     let request = match HwiCli::try_parse_from(args) {
         Ok(args) => match request_from_cli(args) {
             Ok(request) => request,
@@ -153,6 +177,27 @@ where
         }
     };
     print_response(process_request(request).await)
+}
+
+fn args_from_stdin<I, T>(args: I) -> io::Result<Vec<OsString>>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let mut args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+    if !args.iter().any(|arg| arg == "--stdin") {
+        return Ok(args);
+    }
+
+    for line in io::stdin().lock().lines() {
+        let line = line?;
+        if line.is_empty() {
+            break;
+        }
+        args.extend(line.split_whitespace().map(OsString::from));
+    }
+
+    Ok(args)
 }
 
 async fn enumerate(selector: DeviceSelector) -> HwiResponse {
@@ -239,6 +284,14 @@ fn parse_device_type(value: &str) -> HwiResult<DeviceType> {
 }
 
 fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
+    let _accepted_python_hwi_globals = (
+        args.password,
+        args.debug,
+        args.stdin,
+        args.interactive,
+        args.expert,
+        args.stdinpass,
+    );
     let device_type = args
         .device_type
         .as_deref()
@@ -302,11 +355,11 @@ mod tests {
             "hwi",
             "--chain",
             "test",
-            "--fingerprint",
+            "-f",
             "f5acc2fd",
-            "--device-type",
+            "-t",
             "ledger",
-            "--device-path",
+            "-d",
             "tcp:localhost:9999",
             "--emulators",
             "enumerate",
@@ -321,6 +374,56 @@ mod tests {
         );
         assert!(request.selector.include_emulators);
         assert_eq!(request.command, HwiCommand::Enumerate);
+    }
+
+    #[test]
+    fn parses_enumerate_python_hwi_global_flags() {
+        let request = parse_args([
+            "hwi",
+            "--password",
+            "passphrase",
+            "--debug",
+            "--stdin",
+            "--interactive",
+            "--expert",
+            "--stdinpass",
+            "enumerate",
+        ])
+        .expect("request");
+
+        assert_eq!(request.command, HwiCommand::Enumerate);
+    }
+
+    #[test]
+    fn parses_enumerate_python_hwi_short_flags() {
+        let request = parse_args([
+            "hwi",
+            "-p",
+            "passphrase",
+            "-i",
+            "-f",
+            "f5acc2fd",
+            "-t",
+            "ledger",
+            "-d",
+            "tcp:localhost:9999",
+            "enumerate",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.selector.device_path.as_deref(),
+            Some("tcp:localhost:9999")
+        );
+        assert_eq!(request.command, HwiCommand::Enumerate);
+    }
+
+    #[test]
+    fn accepts_python_hwi_version_flag() {
+        let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
+
+        assert_eq!(error.kind(), ErrorKind::DisplayVersion);
     }
 
     #[test]

--- a/bhwi-cli/src/jade.rs
+++ b/bhwi-cli/src/jade.rs
@@ -18,7 +18,7 @@ use tokio_serial::{
     SerialPort, SerialPortBuilderExt, SerialPortType, SerialStream, UsbPortInfo, available_ports,
 };
 
-use crate::{Device, DeviceEnumerator, config::Config};
+use crate::{Device, DeviceEnumerator, DeviceType, config::DeviceSelector};
 
 pub type JadeSerialDevice = Jade<SerialTransport, PinServerClient>;
 pub type JadeQemuDevice = Jade<TcpTransport<TcpClient>, PinServerClient>;
@@ -87,6 +87,9 @@ impl JadeDevice {
                     info.product.unwrap_or_else(|| "Jade".into()),
                     info.manufacturer.unwrap_or_else(|| "Blockstream".into())
                 ),
+                DeviceType::Jade,
+                port_name,
+                "jade",
                 Box::new(JadeSerialDevice::new(
                     network,
                     SerialTransport::new(port_name)?,
@@ -101,6 +104,9 @@ impl JadeDevice {
     async fn qemu_device(network: Network, stream: TcpStream) -> Result<Device> {
         Device::new(
             "Jade QEMU Emulator",
+            DeviceType::Jade,
+            DEFAULT_JADE_QEMU_ADDRESS,
+            "jade",
             Box::new(JadeQemuDevice::new(
                 network,
                 TcpTransport::new(TcpClient::new(stream)),
@@ -114,20 +120,26 @@ impl JadeDevice {
 
 #[async_trait(?Send)]
 impl DeviceEnumerator for JadeDevice {
-    async fn enumerate(config: &Config) -> Result<Vec<Device>> {
+    async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>> {
         let mut devices: Vec<Device> = iter(available_ports()?.into_iter().map(Ok))
             .try_filter_map(|info| async move {
                 match info.port_type {
-                    SerialPortType::UsbPort(usb) if Self::valid_usb(&usb) => {
-                        Self::serial_device(config.network, &info.port_name, usb).await
+                    SerialPortType::UsbPort(usb)
+                        if selector.matches(DeviceType::Jade, &info.port_name)
+                            && Self::valid_usb(&usb) =>
+                    {
+                        Self::serial_device(selector.network, &info.port_name, usb).await
                     }
                     _ => Ok(None),
                 }
             })
             .try_collect()
             .await?;
-        if let Ok(stream) = TcpStream::connect(DEFAULT_JADE_QEMU_ADDRESS).await {
-            devices.push(Self::qemu_device(config.network, stream).await?);
+        if selector.include_emulators
+            && selector.matches(DeviceType::Jade, DEFAULT_JADE_QEMU_ADDRESS)
+            && let Ok(stream) = TcpStream::connect(DEFAULT_JADE_QEMU_ADDRESS).await
+        {
+            devices.push(Self::qemu_device(selector.network, stream).await?);
         }
         Ok(devices)
     }

--- a/bhwi-cli/src/jade.rs
+++ b/bhwi-cli/src/jade.rs
@@ -106,7 +106,7 @@ impl JadeDevice {
             "Jade QEMU Emulator",
             DeviceType::Jade,
             DEFAULT_JADE_QEMU_ADDRESS,
-            "jade",
+            "jade_simulator",
             Box::new(JadeQemuDevice::new(
                 network,
                 TcpTransport::new(TcpClient::new(stream)),

--- a/bhwi-cli/src/jade.rs
+++ b/bhwi-cli/src/jade.rs
@@ -24,7 +24,11 @@ pub type JadeSerialDevice = Jade<SerialTransport, PinServerClient>;
 pub type JadeQemuDevice = Jade<TcpTransport<TcpClient>, PinServerClient>;
 
 pub const DEFAULT_JADE_BAUD_RATE: u32 = 115200;
-pub const DEFAULT_JADE_QEMU_ADDRESS: &str = "localhost:30121";
+pub const DEFAULT_JADE_QEMU_ADDRESS: &str = "tcp:127.0.0.1:30121";
+
+fn jade_tcp_addr(path: &str) -> &str {
+    path.strip_prefix("tcp:").unwrap_or(path)
+}
 
 pub struct SerialTransport {
     stream: Arc<Mutex<SerialStream>>,
@@ -136,8 +140,9 @@ impl DeviceEnumerator for JadeDevice {
             .try_collect()
             .await?;
         if selector.include_emulators
-            && selector.matches(DeviceType::Jade, DEFAULT_JADE_QEMU_ADDRESS)
-            && let Ok(stream) = TcpStream::connect(DEFAULT_JADE_QEMU_ADDRESS).await
+            && (selector.matches(DeviceType::Jade, DEFAULT_JADE_QEMU_ADDRESS)
+                || selector.matches(DeviceType::Jade, jade_tcp_addr(DEFAULT_JADE_QEMU_ADDRESS)))
+            && let Ok(stream) = TcpStream::connect(jade_tcp_addr(DEFAULT_JADE_QEMU_ADDRESS)).await
         {
             devices.push(Self::qemu_device(selector.network, stream).await?);
         }

--- a/bhwi-cli/src/ledger.rs
+++ b/bhwi-cli/src/ledger.rs
@@ -15,14 +15,14 @@ use bhwi_async::{
         },
     },
 };
-use futures::stream::{StreamExt, TryStreamExt, iter};
+use futures::stream::{StreamExt, TryStreamExt};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
     sync::Mutex,
 };
 
-use crate::{Device, DeviceEnumerator, config::Config, hid::HidChannel};
+use crate::{Device, DeviceEnumerator, DeviceType, config::DeviceSelector, hid::HidChannel};
 
 pub type LedgerHidDevice = Ledger<LedgerTransportHID<HidChannel>>;
 pub type LedgerSpeculosDevice = Ledger<LedgerTransportTcp<SpeculosTcpChannel>>;
@@ -31,9 +31,14 @@ pub struct LedgerDevice;
 
 impl LedgerDevice {
     async fn hid_device(dev: HidDevice) -> Result<Option<Device>> {
+        let path = hid_path(&dev);
+        let name = dev.name.clone();
         Ok(Some(
             Device::new(
-                &dev.name,
+                &name,
+                DeviceType::Ledger,
+                path,
+                "ledger",
                 Box::new(LedgerHidDevice::new(LedgerTransportHID::new(
                     HidChannel::new(dev.open().await?),
                 ))),
@@ -43,9 +48,12 @@ impl LedgerDevice {
         ))
     }
 
-    async fn speculos_device(stream: TcpStream) -> Result<Device> {
+    async fn speculos_device(path: &str, stream: TcpStream) -> Result<Device> {
         Device::new(
             "Ledger Speculos Emulator",
+            DeviceType::Ledger,
+            path,
+            "ledger",
             Box::new(LedgerSpeculosDevice::new(LedgerTransportTcp::new(
                 SpeculosTcpChannel {
                     stream: Arc::new(Mutex::new(stream)),
@@ -59,19 +67,21 @@ impl LedgerDevice {
 
 #[async_trait(?Send)]
 impl DeviceEnumerator for LedgerDevice {
-    async fn enumerate(_config: &Config) -> Result<Vec<Device>> {
+    async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>> {
         let DeviceId {
             vid,
             usage_page,
             emulator_path,
             ..
         } = LEDGER_DEVICE_ID;
-        let devices = HidBackend::default()
+        let mut devices: Vec<Device> = HidBackend::default()
             .enumerate()
             .await?
             .map(Ok)
             .try_filter_map(|dev| async move {
-                if dev.vendor_id == vid
+                let path = hid_path(&dev);
+                if selector.matches(DeviceType::Ledger, &path)
+                    && dev.vendor_id == vid
                     && dev.usage_page == usage_page.context("ledger usage page constant not set")?
                 {
                     Self::hid_device(dev).await
@@ -79,19 +89,22 @@ impl DeviceEnumerator for LedgerDevice {
                     Ok(None)
                 }
             })
-            .chain(
-                iter(emulator_path.map(Ok).into_iter()).try_filter_map(|path| async move {
-                    if let Ok(stream) = TcpStream::connect(path).await {
-                        Ok(Some(Self::speculos_device(stream).await?))
-                    } else {
-                        Ok(None)
-                    }
-                }),
-            )
             .try_collect()
             .await?;
+        if selector.include_emulators
+            && let Some(path) = emulator_path
+            && selector.matches(DeviceType::Ledger, path)
+            && let Ok(stream) = TcpStream::connect(path).await
+        {
+            devices.push(Self::speculos_device(path, stream).await?);
+        }
         Ok(devices)
     }
+}
+
+fn hid_path(dev: &HidDevice) -> String {
+    let suffix = dev.serial_number.as_deref().unwrap_or(&dev.name);
+    format!("hid:{:04x}:{:04x}:{suffix}", dev.vendor_id, dev.product_id)
 }
 
 pub struct SpeculosTcpChannel {

--- a/bhwi-cli/src/ledger.rs
+++ b/bhwi-cli/src/ledger.rs
@@ -65,6 +65,10 @@ impl LedgerDevice {
     }
 }
 
+fn speculos_tcp_addr(path: &str) -> &str {
+    path.strip_prefix("tcp:").unwrap_or(path)
+}
+
 #[async_trait(?Send)]
 impl DeviceEnumerator for LedgerDevice {
     async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>> {
@@ -93,8 +97,12 @@ impl DeviceEnumerator for LedgerDevice {
             .await?;
         if selector.include_emulators
             && let Some(path) = emulator_path
-            && selector.matches(DeviceType::Ledger, path)
-            && let Ok(stream) = TcpStream::connect(path).await
+            && {
+                let addr = speculos_tcp_addr(path);
+                selector.matches(DeviceType::Ledger, path)
+                    || selector.matches(DeviceType::Ledger, addr)
+            }
+            && let Ok(stream) = TcpStream::connect(speculos_tcp_addr(path)).await
         {
             devices.push(Self::speculos_device(path, stream).await?);
         }

--- a/bhwi-cli/src/ledger.rs
+++ b/bhwi-cli/src/ledger.rs
@@ -38,7 +38,7 @@ impl LedgerDevice {
                 &name,
                 DeviceType::Ledger,
                 path,
-                "ledger",
+                ledger_model(dev.product_id, false),
                 Box::new(LedgerHidDevice::new(LedgerTransportHID::new(
                     HidChannel::new(dev.open().await?),
                 ))),
@@ -53,7 +53,7 @@ impl LedgerDevice {
             "Ledger Speculos Emulator",
             DeviceType::Ledger,
             path,
-            "ledger",
+            ledger_model(0x1000, true),
             Box::new(LedgerSpeculosDevice::new(LedgerTransportTcp::new(
                 SpeculosTcpChannel {
                     stream: Arc::new(Mutex::new(stream)),
@@ -105,6 +105,18 @@ impl DeviceEnumerator for LedgerDevice {
 fn hid_path(dev: &HidDevice) -> String {
     let suffix = dev.serial_number.as_deref().unwrap_or(&dev.name);
     format!("hid:{:04x}:{:04x}:{suffix}", dev.vendor_id, dev.product_id)
+}
+
+fn ledger_model(product_id: u16, is_emulated: bool) -> &'static str {
+    match (product_id >> 8, product_id, is_emulated) {
+        (0x10, _, true) => "ledger_nano_s_simulator",
+        (0x10, _, false) | (_, 0x0001, false) => "ledger_nano_s",
+        (0x40, _, false) | (_, 0x0004, false) => "ledger_nano_x",
+        (0x50, _, false) => "ledger_nano_s_plus",
+        (0x60, _, false) => "ledger_stax",
+        (0x70, _, false) => "ledger_flex",
+        _ => "ledger",
+    }
 }
 
 pub struct SpeculosTcpChannel {

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -7,19 +7,25 @@ use futures::future::join_all;
 use serde::{Serialize, Serializer};
 use strum::{EnumIter, IntoEnumIterator};
 
-use crate::{coldcard::ColdcardDevice, config::Config, jade::JadeDevice, ledger::LedgerDevice};
+use crate::{
+    coldcard::ColdcardDevice, config::DeviceSelector, jade::JadeDevice, ledger::LedgerDevice,
+};
 
 pub mod address;
 pub mod coldcard;
 pub mod config;
 pub mod get_descriptors;
 pub mod hid;
+pub mod hwi;
 pub mod jade;
 pub mod ledger;
 
 #[derive(Serialize)]
 pub struct Device {
     name: String,
+    device_type: DeviceType,
+    path: String,
+    model: String,
     #[serde(skip)]
     device: Box<dyn HWIDevice>,
     is_emulated: bool,
@@ -58,9 +64,19 @@ impl From<bhwi_async::Info> for Info {
 }
 
 impl Device {
-    pub async fn new(name: &str, device: Box<dyn HWIDevice>, is_emulated: bool) -> Result<Self> {
+    pub async fn new(
+        name: &str,
+        device_type: DeviceType,
+        path: impl Into<String>,
+        model: impl Into<String>,
+        device: Box<dyn HWIDevice>,
+        is_emulated: bool,
+    ) -> Result<Self> {
         Ok(Self {
             name: name.into(),
+            device_type,
+            path: path.into(),
+            model: model.into(),
             device,
             is_emulated,
             fingerprint: None,
@@ -70,6 +86,18 @@ impl Device {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn device_type(&self) -> DeviceType {
+        self.device_type
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
     }
 
     pub fn device(&mut self) -> &mut Box<dyn HWIDevice> {
@@ -101,7 +129,9 @@ impl Device {
     }
 }
 
-#[derive(Debug, EnumIter, strum::Display)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumIter, ValueEnum, Serialize, strum::Display)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum DeviceType {
     Coldcard,
     Jade,
@@ -109,29 +139,29 @@ pub enum DeviceType {
 }
 
 impl DeviceType {
-    pub async fn enumerate(self, config: &Config) -> Result<Vec<Device>> {
+    pub async fn enumerate(self, selector: &DeviceSelector) -> Result<Vec<Device>> {
         Ok(match self {
-            DeviceType::Ledger => LedgerDevice::enumerate(config).await?,
-            DeviceType::Coldcard => ColdcardDevice::enumerate(config).await?,
-            DeviceType::Jade => JadeDevice::enumerate(config).await?,
+            DeviceType::Ledger => LedgerDevice::enumerate(selector).await?,
+            DeviceType::Coldcard => ColdcardDevice::enumerate(selector).await?,
+            DeviceType::Jade => JadeDevice::enumerate(selector).await?,
         })
     }
 }
 
 pub struct DeviceManager {
-    pub config: Config,
+    pub selector: DeviceSelector,
 }
 
 impl DeviceManager {
-    pub fn new(config: Config) -> Self {
-        Self { config }
+    pub fn new(selector: DeviceSelector) -> Self {
+        Self { selector }
     }
 
     pub async fn get_device_with_fingerprint(&self) -> Result<Option<Device>> {
         let mut target_dev = None;
         for mut d in self.enumerate().await? {
-            d.device.unlock(self.config.network).await?;
-            if let Some(fingerprint) = self.config.fingerprint {
+            d.device.unlock(self.selector.network).await?;
+            if let Some(fingerprint) = self.selector.fingerprint {
                 if fingerprint == d.fingerprint().await? {
                     target_dev = Some(d);
                     break;
@@ -146,7 +176,7 @@ impl DeviceManager {
         };
         let info = dev.info().await?;
         let networks = &info.networks;
-        let net = self.config.network;
+        let net = self.selector.network;
         if !networks.is_empty() && !networks.contains(&net) {
             eprintln!(
                 "Warning: device {} is on {}, expected {net}",
@@ -158,17 +188,26 @@ impl DeviceManager {
     }
 
     pub async fn enumerate(&self) -> Result<Vec<Device>> {
-        let res = join_all(DeviceType::iter().map(|t| t.enumerate(&self.config)))
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>>>()?;
+        let device_types: Vec<DeviceType> = self
+            .selector
+            .device_type
+            .map(|device_type| vec![device_type])
+            .unwrap_or_else(|| DeviceType::iter().collect());
+        let res = join_all(
+            device_types
+                .into_iter()
+                .map(|device_type| device_type.enumerate(&self.selector)),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
         Ok(res.into_iter().flatten().collect())
     }
 }
 
 #[async_trait(?Send)]
 pub trait DeviceEnumerator {
-    async fn enumerate(config: &Config) -> Result<Vec<Device>>;
+    async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>>;
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -24,7 +24,7 @@ use crate::device::DeviceId;
 
 pub const LEDGER_DEVICE_ID: DeviceId = DeviceId::new(0x2c97)
     .with_usage_page(0xffa0)
-    .with_emulator_path("localhost:9999");
+    .with_emulator_path("tcp:127.0.0.1:9999");
 
 #[derive(Debug, thiserror::Error)]
 pub enum LedgerError {

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -33,6 +33,7 @@ Apps:
 - `nix run .#coldcard`
 - `nix run .#ledger`
 - `nix run .#ledger-build-app`
+- `nix run .#hwi-upstream-suite`
 - `nix run .#jade-pinserver`
 - `nix run .#jade`
 - `nix run .#jade-init`
@@ -47,6 +48,8 @@ Packages/checks:
 
 - `nix build .#speculos`
 - `nix build .#coldcard-simulator`
+- `nix build .#hwi-reference`
+- `nix build .#hwi-upstream-suite`
 - `nix build .#ledger-app`
 - `nix build .#jade-qemu`
 - `nix build .#checks.x86_64-linux.emulator-scripts`
@@ -100,6 +103,42 @@ test -S /tmp/ckcc-simulator.sock
 nc -z localhost 9999 && nc -z localhost 5000
 nc -z localhost 8096 && nc -z localhost 30121
 ```
+
+## Upstream HWI Suite
+
+BHWI pins Bitcoin Core HWI 3.2.0 and exposes two parity helpers:
+
+- `hwi-reference`: runs Python HWI directly.
+- `hwi-upstream-suite`: runs HWI's upstream `test/` suite in `--interface=cli`
+  mode against a BHWI binary named by `HWI_BIN`.
+
+The upstream suite is the final parity gate for every HWI-supported device that
+BHWI claims to support. New device onboarding should enable that device's
+upstream HWI suite once BHWI has the matching device support.
+
+Ledger can use the existing pinned app-builder and Speculos wrapper:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+HWI_BIN="$PWD/target/debug/hwi" nix run .#hwi-upstream-suite -- ledger
+```
+
+Coldcard and Jade need HWI-compatible simulator artifacts because upstream HWI's
+tests start their own emulator processes:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+HWI_BIN="$PWD/target/debug/hwi" \
+HWI_COLDCARD_SIMULATOR=/path/to/firmware/unix/simulator.py \
+nix run .#hwi-upstream-suite -- coldcard
+
+HWI_BIN="$PWD/target/debug/hwi" \
+HWI_JADE_SIMULATOR_DIR=/path/to/hwi-style/jade/simulator \
+nix run .#hwi-upstream-suite -- jade
+```
+
+The runner also accepts `HWI_BITCOIND` to override the `bitcoind` used by the
+upstream suite, and `HWI_LEDGER_APP_ELF` to use a prebuilt Ledger app.
 
 ## Device Details
 

--- a/e2e/hwi-parity/Cargo.toml
+++ b/e2e/hwi-parity/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bhwi-e2e-hwi-parity"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+license-file.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+serde_json.workspace = true

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -1,0 +1,118 @@
+use std::{
+    env,
+    ffi::OsStr,
+    process::{Command, Output},
+};
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+#[derive(Clone, Debug)]
+pub struct HwiBinary {
+    label: &'static str,
+    path: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct HwiOutput {
+    pub status_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub json: Value,
+}
+
+impl HwiBinary {
+    pub fn from_env(label: &'static str, var: &str, default: Option<&str>) -> Result<Self> {
+        let path = match env::var(var) {
+            Ok(path) => path,
+            Err(_) => default
+                .map(str::to_owned)
+                .with_context(|| format!("{var} must point to the {label} hwi binary"))?,
+        };
+        Ok(Self { label, path })
+    }
+
+    pub fn reference() -> Result<Self> {
+        Self::from_env("reference", "REFERENCE_HWI_BIN", Some("hwi-reference"))
+    }
+
+    pub fn candidate() -> Result<Self> {
+        Self::from_env("candidate", "HWI_BIN", None)
+    }
+
+    pub fn run<I, S>(&self, args: I) -> Result<HwiOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = Command::new(&self.path)
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to spawn {} hwi at {}", self.label, self.path))?;
+        parse_output(self.label, output)
+    }
+}
+
+pub fn assert_json_parity<I, S>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S> + Clone,
+    S: AsRef<OsStr>,
+{
+    let reference = HwiBinary::reference()?.run(args.clone())?;
+    let candidate = HwiBinary::candidate()?.run(args)?;
+
+    if reference.json != candidate.json {
+        bail!(
+            "HWI JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+            serde_json::to_string_pretty(&reference.json)?,
+            serde_json::to_string_pretty(&candidate.json)?
+        );
+    }
+    Ok(())
+}
+
+fn parse_output(label: &str, output: Output) -> Result<HwiOutput> {
+    let stdout = String::from_utf8(output.stdout)
+        .with_context(|| format!("{label} hwi wrote non-utf8 stdout"))?;
+    let stderr = String::from_utf8(output.stderr)
+        .with_context(|| format!("{label} hwi wrote non-utf8 stderr"))?;
+    let json = serde_json::from_str(stdout.trim()).with_context(|| {
+        format!(
+            "{label} hwi stdout was not JSON\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+            output.status
+        )
+    })?;
+
+    Ok(HwiOutput {
+        status_code: output.status.code(),
+        stdout,
+        stderr,
+        json,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_binary_enumerate_is_json_or_reports_clear_error() -> Result<()> {
+        if env::var("REFERENCE_HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let output = HwiBinary::reference()?.run(["enumerate"])?;
+        assert!(output.json.is_array(), "unexpected enumerate shape");
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_parity_smoke_is_env_gated() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        assert_json_parity(["enumerate"])?;
+        Ok(())
+    }
+}

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -58,8 +58,20 @@ where
     I: IntoIterator<Item = S> + Clone,
     S: AsRef<OsStr>,
 {
+    assert_json_parity_value(args)?;
+    Ok(())
+}
+
+pub fn assert_json_parity_value<I, S>(args: I) -> Result<Value>
+where
+    I: IntoIterator<Item = S> + Clone,
+    S: AsRef<OsStr>,
+{
     let reference = HwiBinary::reference()?.run(args.clone())?;
     let candidate = HwiBinary::candidate()?.run(args)?;
+
+    assert_success("reference", &reference)?;
+    assert_success("candidate", &candidate)?;
 
     if reference.json != candidate.json {
         bail!(
@@ -68,7 +80,8 @@ where
             serde_json::to_string_pretty(&candidate.json)?
         );
     }
-    Ok(())
+
+    Ok(candidate.json)
 }
 
 fn parse_output(label: &str, output: Output) -> Result<HwiOutput> {
@@ -91,6 +104,18 @@ fn parse_output(label: &str, output: Output) -> Result<HwiOutput> {
     })
 }
 
+fn assert_success(label: &str, output: &HwiOutput) -> Result<()> {
+    if output.status_code != Some(0) {
+        bail!(
+            "{label} hwi exited unsuccessfully\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,17 +127,108 @@ mod tests {
         }
 
         let output = HwiBinary::reference()?.run(["enumerate"])?;
-        assert!(output.json.is_array(), "unexpected enumerate shape");
+        assert_success("reference", &output)?;
+        assert_enumerate_array("reference", &output.json)?;
         Ok(())
     }
 
     #[test]
-    fn candidate_parity_smoke_is_env_gated() -> Result<()> {
+    fn candidate_enumerate_matches_reference() -> Result<()> {
         if env::var("HWI_BIN").is_err() {
             return Ok(());
         }
 
-        assert_json_parity(["enumerate"])?;
+        let (args, expected_device_type) = enumerate_args_from_env()?;
+        assert_enumerate_parity(args, expected_device_type.as_deref())?;
         Ok(())
+    }
+
+    fn assert_enumerate_parity(
+        args: Vec<String>,
+        expected_device_type: Option<&str>,
+    ) -> Result<()> {
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_enumerate_array("reference", &reference.json)?;
+
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_enumerate_array("candidate", &candidate.json)?;
+
+        if let Some(device_type) = expected_device_type {
+            assert_enumerate_contains_device("reference", &reference.json, device_type)?;
+            assert_enumerate_contains_device("candidate", &candidate.json, device_type)?;
+        }
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_enumerate_array(label: &str, json: &Value) -> Result<()> {
+        if !json.is_array() {
+            bail!(
+                "{label} hwi enumerate output was not an array:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_enumerate_contains_device(
+        label: &str,
+        json: &Value,
+        device_type: &str,
+    ) -> Result<()> {
+        if enumerate_contains_device(json, device_type)? {
+            return Ok(());
+        }
+
+        bail!(
+            "{label} hwi enumerate output did not include expected device type {device_type:?}:\n{}",
+            serde_json::to_string_pretty(json)?
+        );
+    }
+
+    fn enumerate_contains_device(json: &Value, device_type: &str) -> Result<bool> {
+        let devices = json
+            .as_array()
+            .with_context(|| "HWI enumerate output was not an array")?;
+        Ok(devices
+            .iter()
+            .any(|device| device.get("type").and_then(Value::as_str) == Some(device_type)))
+    }
+
+    fn enumerate_args_from_env() -> Result<(Vec<String>, Option<String>)> {
+        match env::var("HWI_PARITY_DEVICE_TYPE") {
+            Ok(device_type) => {
+                let device_type = normalize_device_type(&device_type)?;
+                Ok((
+                    vec![
+                        "--emulators".to_owned(),
+                        "--device-type".to_owned(),
+                        device_type.clone(),
+                        "enumerate".to_owned(),
+                    ],
+                    Some(device_type),
+                ))
+            }
+            Err(env::VarError::NotPresent) => Ok((vec!["enumerate".to_owned()], None)),
+            Err(err) => Err(err).context("failed to read HWI_PARITY_DEVICE_TYPE"),
+        }
+    }
+
+    fn normalize_device_type(device_type: &str) -> Result<String> {
+        let device_type = device_type.to_ascii_lowercase();
+        match device_type.as_str() {
+            "coldcard" | "jade" | "ledger" => Ok(device_type),
+            _ => bail!("unsupported HWI_PARITY_DEVICE_TYPE {device_type:?}"),
+        }
     }
 }

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -1,7 +1,8 @@
 use std::{
     env,
     ffi::OsStr,
-    process::{Command, Output},
+    io::Write,
+    process::{Command, Output, Stdio},
 };
 
 use anyhow::{Context, Result, bail};
@@ -50,6 +51,32 @@ impl HwiBinary {
             .output()
             .with_context(|| format!("failed to spawn {} hwi at {}", self.label, self.path))?;
         parse_output(self.label, output)
+    }
+
+    pub fn run_with_stdin<I, S>(&self, args: I, stdin: &str) -> Result<HwiOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut child = Command::new(&self.path)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn {} hwi at {}", self.label, self.path))?;
+
+        {
+            let mut child_stdin = child
+                .stdin
+                .take()
+                .with_context(|| format!("failed to open {} hwi stdin", self.label))?;
+            child_stdin
+                .write_all(stdin.as_bytes())
+                .with_context(|| format!("failed to write {} hwi stdin", self.label))?;
+        }
+
+        parse_output(self.label, child.wait_with_output()?)
     }
 }
 
@@ -143,6 +170,34 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_enumerate_accepts_python_hwi_global_args() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        let (base_args, _) = enumerate_args_from_env()?;
+        let reference = HwiBinary::reference()?.run(base_args)?;
+        assert_success("reference", &reference)?;
+        let reference_device =
+            assert_enumerate_contains_device("reference", &reference.json, &device_type)?;
+        let device_path = assert_string_field("reference", reference_device, "path")?.to_owned();
+        let fingerprint =
+            assert_string_field("reference", reference_device, "fingerprint")?.to_owned();
+
+        for args in enumerate_python_hwi_arg_cases(&device_type, &device_path, &fingerprint) {
+            assert_enumerate_parity(args.clone(), Some(&device_type))
+                .with_context(|| format!("enumerate parity failed for args: {args:?}"))?;
+        }
+
+        assert_enumerate_stdin_parity(&device_type)?;
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -156,13 +211,44 @@ mod tests {
         assert_enumerate_array("candidate", &candidate.json)?;
 
         if let Some(device_type) = expected_device_type {
-            assert_enumerate_contains_device("reference", &reference.json, device_type)?;
-            assert_enumerate_contains_device("candidate", &candidate.json, device_type)?;
+            let reference_device =
+                assert_enumerate_contains_device("reference", &reference.json, device_type)?;
+            let candidate_device =
+                assert_enumerate_contains_device("candidate", &candidate.json, device_type)?;
+            assert_enumerate_device_shape("reference", reference_device, None)?;
+            assert_enumerate_device_shape("candidate", candidate_device, Some(reference_device))?;
         }
 
         if reference.json != candidate.json {
             bail!(
                 "HWI JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_enumerate_stdin_parity(device_type: &str) -> Result<()> {
+        let stdin = format!("--emulators --device-type {device_type} enumerate\n\n");
+        let reference = HwiBinary::reference()?.run_with_stdin(["--stdin"], &stdin)?;
+        assert_success("reference", &reference)?;
+        assert_enumerate_array("reference", &reference.json)?;
+        let reference_device =
+            assert_enumerate_contains_device("reference", &reference.json, device_type)?;
+        assert_enumerate_device_shape("reference", reference_device, None)?;
+
+        let candidate = HwiBinary::candidate()?.run_with_stdin(["--stdin"], &stdin)?;
+        assert_success("candidate", &candidate)?;
+        assert_enumerate_array("candidate", &candidate.json)?;
+        let candidate_device =
+            assert_enumerate_contains_device("candidate", &candidate.json, device_type)?;
+        assert_enumerate_device_shape("candidate", candidate_device, Some(reference_device))?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI JSON mismatch for stdin enumerate\nreference:\n{}\ncandidate:\n{}",
                 serde_json::to_string_pretty(&reference.json)?,
                 serde_json::to_string_pretty(&candidate.json)?
             );
@@ -181,13 +267,13 @@ mod tests {
         Ok(())
     }
 
-    fn assert_enumerate_contains_device(
+    fn assert_enumerate_contains_device<'a>(
         label: &str,
-        json: &Value,
+        json: &'a Value,
         device_type: &str,
-    ) -> Result<()> {
-        if enumerate_contains_device(json, device_type)? {
-            return Ok(());
+    ) -> Result<&'a Value> {
+        if let Some(device) = enumerate_device(json, device_type)? {
+            return Ok(device);
         }
 
         bail!(
@@ -196,32 +282,243 @@ mod tests {
         );
     }
 
-    fn enumerate_contains_device(json: &Value, device_type: &str) -> Result<bool> {
+    fn enumerate_device<'a>(json: &'a Value, device_type: &str) -> Result<Option<&'a Value>> {
         let devices = json
             .as_array()
             .with_context(|| "HWI enumerate output was not an array")?;
         Ok(devices
             .iter()
-            .any(|device| device.get("type").and_then(Value::as_str) == Some(device_type)))
+            .find(|device| device.get("type").and_then(Value::as_str) == Some(device_type)))
+    }
+
+    fn assert_enumerate_device_shape(
+        label: &str,
+        device: &Value,
+        reference: Option<&Value>,
+    ) -> Result<()> {
+        let Some(object) = device.as_object() else {
+            bail!(
+                "{label} hwi enumerate device entry was not an object:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        };
+
+        assert_string_field(label, device, "type")?;
+        assert_string_field(label, device, "model")?;
+        assert_string_field(label, device, "path")?;
+        assert_fingerprint_field(label, device)?;
+        assert_false_field(label, device, "needs_pin_sent")?;
+        assert_false_field(label, device, "needs_passphrase_sent")?;
+
+        if object.contains_key("error") || object.contains_key("code") {
+            bail!(
+                "{label} hwi enumerate successful device entry included error fields:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        }
+
+        if let Some(reference) = reference {
+            assert_matching_optional_field(label, device, reference, "label")?;
+            for field in [
+                "type",
+                "model",
+                "path",
+                "fingerprint",
+                "needs_pin_sent",
+                "needs_passphrase_sent",
+            ] {
+                if device.get(field) != reference.get(field) {
+                    bail!(
+                        "{label} hwi enumerate field {field:?} did not match reference\nreference:\n{}\ncandidate:\n{}",
+                        serde_json::to_string_pretty(reference)?,
+                        serde_json::to_string_pretty(device)?
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn assert_string_field<'a>(label: &str, device: &'a Value, field: &str) -> Result<&'a str> {
+        let Some(value) = device.get(field).and_then(Value::as_str) else {
+            bail!(
+                "{label} hwi enumerate field {field:?} was not a string:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        };
+
+        if value.is_empty() {
+            bail!(
+                "{label} hwi enumerate field {field:?} was empty:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        }
+
+        Ok(value)
+    }
+
+    fn assert_fingerprint_field(label: &str, device: &Value) -> Result<()> {
+        let fingerprint = assert_string_field(label, device, "fingerprint")?;
+        let valid = fingerprint.len() == 8
+            && fingerprint
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        if !valid {
+            bail!(
+                "{label} hwi enumerate fingerprint was not 8 lowercase hex chars:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_false_field(label: &str, device: &Value, field: &str) -> Result<()> {
+        if device.get(field).and_then(Value::as_bool) != Some(false) {
+            bail!(
+                "{label} hwi enumerate field {field:?} was not false:\n{}",
+                serde_json::to_string_pretty(device)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_matching_optional_field(
+        label: &str,
+        device: &Value,
+        reference: &Value,
+        field: &str,
+    ) -> Result<()> {
+        if device.get(field) != reference.get(field) {
+            bail!(
+                "{label} hwi enumerate optional field {field:?} did not match reference presence/value\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(reference)?,
+                serde_json::to_string_pretty(device)?
+            );
+        }
+        Ok(())
     }
 
     fn enumerate_args_from_env() -> Result<(Vec<String>, Option<String>)> {
+        match expected_device_type_from_env()? {
+            Some(device_type) => Ok((
+                vec![
+                    "--emulators".to_owned(),
+                    "--device-type".to_owned(),
+                    device_type.clone(),
+                    "enumerate".to_owned(),
+                ],
+                Some(device_type),
+            )),
+            None => Ok((vec!["enumerate".to_owned()], None)),
+        }
+    }
+
+    fn expected_device_type_from_env() -> Result<Option<String>> {
         match env::var("HWI_PARITY_DEVICE_TYPE") {
-            Ok(device_type) => {
-                let device_type = normalize_device_type(&device_type)?;
-                Ok((
-                    vec![
-                        "--emulators".to_owned(),
-                        "--device-type".to_owned(),
-                        device_type.clone(),
-                        "enumerate".to_owned(),
-                    ],
-                    Some(device_type),
-                ))
-            }
-            Err(env::VarError::NotPresent) => Ok((vec!["enumerate".to_owned()], None)),
+            Ok(device_type) => Ok(Some(normalize_device_type(&device_type)?)),
+            Err(env::VarError::NotPresent) => Ok(None),
             Err(err) => Err(err).context("failed to read HWI_PARITY_DEVICE_TYPE"),
         }
+    }
+
+    fn enumerate_python_hwi_arg_cases(
+        device_type: &str,
+        device_path: &str,
+        fingerprint: &str,
+    ) -> Vec<Vec<String>> {
+        vec![
+            args(["--emulators", "--device-type", device_type, "enumerate"]),
+            args(["--emulators", "-t", device_type, "enumerate"]),
+            args([
+                "--emulators",
+                "--device-type",
+                device_type,
+                "--device-path",
+                device_path,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--device-type",
+                device_type,
+                "-d",
+                device_path,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--device-type",
+                device_type,
+                "--fingerprint",
+                fingerprint,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--device-type",
+                device_type,
+                "-f",
+                fingerprint,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--debug",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--expert",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--interactive",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "-i",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--password",
+                "unused",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "-p",
+                "unused",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "enumerate",
+            ]),
+        ]
+    }
+
+    fn args<const N: usize>(items: [&str; N]) -> Vec<String> {
+        items.into_iter().map(str::to_owned).collect()
     }
 
     fn normalize_device_type(device_type: &str) -> Result<String> {

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -33,7 +33,7 @@ impl HwiBinary {
     }
 
     pub fn reference() -> Result<Self> {
-        Self::from_env("reference", "REFERENCE_HWI_BIN", Some("hwi-reference"))
+        Self::from_env("reference", "REFERENCE_HWI_BIN", Some("hwi-reference-bhwi"))
     }
 
     pub fn candidate() -> Result<Self> {

--- a/flake.lock
+++ b/flake.lock
@@ -168,6 +168,23 @@
         "type": "github"
       }
     },
+    "python-hwi": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770690416,
+        "narHash": "sha256-utNt0qaHNP6tzkhDnAMjwwNCKoMo3504oozdRpXnDEw=",
+        "owner": "bitcoin-core",
+        "repo": "HWI",
+        "rev": "a4d66f8bc18fc2658704fc5875e9d3b33cf22b2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "3.2.0",
+        "repo": "HWI",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "app-bitcoin-new": "app-bitcoin-new",
@@ -178,6 +195,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-coldcard": "nixpkgs-coldcard",
         "nixpkgs-esp-dev": "nixpkgs-esp-dev",
+        "python-hwi": "python-hwi",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
           pythonPackages.protobuf
           pythonPackages.pyaes
           pythonPackages.pyserial
+          pythonPackages.requests
           pythonPackages.semver
           pythonPackages.typing-extensions
         ]);
@@ -246,6 +247,46 @@
           type = "app";
           program = pkgs.lib.getExe program;
         };
+        commonE2eEnv = ''
+          export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+          export LD_LIBRARY_PATH=${pkgs.openssl}/lib:''${LD_LIBRARY_PATH:-}
+          export RUST_TEST_THREADS=1
+        '';
+        coldcardE2eEnv = ''
+          export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
+          export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
+            coldcardPkgs.SDL2
+            coldcardPkgs.gcc13.cc.lib
+            coldcardPkgs.glibc
+            coldcardPkgs.libffi
+            coldcardPkgs.openssl.out
+            coldcardPkgs.pcsclite
+            coldcardPkgs.systemd
+          ]}"
+          export LD_LIBRARY_PATH=${pkgs.openssl}/lib:''${LD_LIBRARY_PATH:-}
+          export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
+          export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+          export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
+          export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
+          export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
+          export RUST_TEST_THREADS=1
+        '';
+        mkHwiParityRunner = name: device: runtimeInputs: env:
+          pkgs.writeShellApplication {
+            inherit name runtimeInputs;
+            text =
+              env
+              + ''
+
+                set -euo pipefail
+                export REFERENCE_HWI_BIN="${pkgs.lib.getExe hwiReferenceBhwi}"
+                export HWI_BIN="''${HWI_BIN:-$PWD/target/debug/hwi}"
+                export HWI_PARITY_DEVICE_TYPE="${device}"
+
+                cargo build -p bhwi-cli --bins
+                exec cargo test -p bhwi-e2e-hwi-parity "$@"
+              '';
+          };
         mkRunnerWith = runnerPkgs: name: runtimeInputs: env: script:
           runnerPkgs.writeShellApplication {
             inherit name runtimeInputs;
@@ -341,11 +382,22 @@
           text = ''
             export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
             exec ${hwiPython}/bin/python - "$@" <<'PY'
-import sys
-
 from hwilib import commands
+from hwilib.devices.jadepy import jade_tcp
 
 commands.all_devs = ["ledger", "coldcard", "jade"]
+
+# XXX: HWI 3.2.0's Jade TCP backend treats read(n) as an
+# exact-fill operation. cbor2 can request a large buffer while the Jade
+# QEMU emulator has already sent a complete, shorter CBOR response, so
+# HWI blocks until timeout despite the response being available. Jade's
+# current upstream jadepy returns one recv() result here instead.
+def _bhwi_jade_tcp_read(self, n):
+    if not n:
+        return bytes()
+    return self.tcp_sock.recv(n)
+
+jade_tcp.JadeTCPImpl.read = _bhwi_jade_tcp_read
 
 from hwilib._cli import main
 
@@ -375,6 +427,9 @@ PY
             exec ${pkgs.bash}/bin/bash ${./nix/scripts/run-hwi-upstream-suite.sh} "$@"
           '';
         };
+        hwiParityColdcard = mkHwiParityRunner "bhwi-hwi-parity-coldcard" "coldcard" (coldcardInputs ++ inputs) coldcardE2eEnv;
+        hwiParityLedger = mkHwiParityRunner "bhwi-hwi-parity-ledger" "ledger" (ledgerInputs ++ inputs) commonE2eEnv;
+        hwiParityJade = mkHwiParityRunner "bhwi-hwi-parity-jade" "jade" (jadeInputs ++ inputs) commonE2eEnv;
         linuxPackages =
           pkgs.lib.optionalAttrs emulatorSystem {
             inherit speculos;
@@ -388,6 +443,9 @@ PY
             ledger = mkApp ledgerRunner;
             ledger-build-app = mkApp ledgerAppBuilder;
             hwi-upstream-suite = mkApp hwiUpstreamSuite;
+            hwi-parity-coldcard = mkApp hwiParityColdcard;
+            hwi-parity-ledger = mkApp hwiParityLedger;
+            hwi-parity-jade = mkApp hwiParityJade;
             jade = mkApp jadeRunner;
             jade-init = mkApp jadeInitRunner;
             jade-pinserver = mkApp jadePinserverRunner;
@@ -396,41 +454,15 @@ PY
           pkgs.lib.optionalAttrs emulatorSystem {
             coldcard = pkgs.mkShell {
               packages = coldcardInputs ++ inputs;
-              shellHook = ''
-                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-                export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
-                  coldcardPkgs.SDL2
-                  coldcardPkgs.gcc13.cc.lib
-                  coldcardPkgs.glibc
-                  coldcardPkgs.libffi
-                  coldcardPkgs.openssl.out
-                  coldcardPkgs.pcsclite
-                  coldcardPkgs.systemd
-                ]}"
-                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
-                export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
-                export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
-                export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
-                export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
-                export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
-                export RUST_TEST_THREADS=1
-              '';
+              shellHook = coldcardE2eEnv;
             };
             ledger = pkgs.mkShell {
               packages = inputs ++ ledgerInputs;
-              shellHook = ''
-                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
-                export RUST_TEST_THREADS=1
-              '';
+              shellHook = commonE2eEnv;
             };
             jade = pkgs.mkShell {
               packages = inputs ++ jadeInputs;
-              shellHook = ''
-                export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-                export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
-                export RUST_TEST_THREADS=1
-              '';
+              shellHook = commonE2eEnv;
             };
           };
         linuxChecks =

--- a/flake.nix
+++ b/flake.nix
@@ -70,8 +70,20 @@
         jadePython = pkgs.python3.withPackages (pythonPackages: [
           pythonPackages.zopfli
         ]);
+        hwiCbor2 = pkgs.python312Packages.cbor2.overridePythonAttrs (_old: rec {
+          version = "5.9.0";
+          src = pkgs.fetchPypi {
+            pname = "cbor2";
+            inherit version;
+            hash = "sha256-hcekYnmsjyJuEFknUiHms9DjcNK7a9BQD5eAeBYVvOo=";
+          };
+        });
         hwiPython = pkgs.python312.withPackages (pythonPackages: [
-          pythonPackages.cbor2
+          # HWI 3.2.0 times out against Jade with cbor2 5.8.0 because its
+          # larger stream reads expose HWI's exact-fill Jade TCP read loop.
+          # Upstream HWI is relaxing its cbor2 cap to permit 5.9.0:
+          # https://github.com/bitcoin-core/HWI/pull/832
+          hwiCbor2
           pythonPackages.ecdsa
           pythonPackages.hidapi
           pythonPackages.libusb1
@@ -383,21 +395,8 @@
             export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
             exec ${hwiPython}/bin/python - "$@" <<'PY'
 from hwilib import commands
-from hwilib.devices.jadepy import jade_tcp
 
 commands.all_devs = ["ledger", "coldcard", "jade"]
-
-# XXX: HWI 3.2.0's Jade TCP backend treats read(n) as an
-# exact-fill operation. cbor2 can request a large buffer while the Jade
-# QEMU emulator has already sent a complete, shorter CBOR response, so
-# HWI blocks until timeout despite the response being available. Jade's
-# current upstream jadepy returns one recv() result here instead.
-def _bhwi_jade_tcp_read(self, n):
-    if not n:
-        return bytes()
-    return self.tcp_sock.recv(n)
-
-jade_tcp.JadeTCPImpl.read = _bhwi_jade_tcp_read
 
 from hwilib._cli import main
 

--- a/flake.nix
+++ b/flake.nix
@@ -335,6 +335,24 @@
             exec ${hwiPython}/bin/python ${python-hwi}/hwi.py "$@"
           '';
         };
+        hwiReferenceBhwi = pkgs.writeShellApplication {
+          name = "hwi-reference-bhwi";
+          runtimeInputs = [hwiPython];
+          text = ''
+            export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
+            exec ${hwiPython}/bin/python - "$@" <<'PY'
+import sys
+
+from hwilib import commands
+
+commands.all_devs = ["ledger", "coldcard", "jade"]
+
+from hwilib._cli import main
+
+main()
+PY
+          '';
+        };
         hwiUpstreamSuite = pkgs.writeShellApplication {
           name = "hwi-upstream-suite";
           runtimeInputs =
@@ -430,6 +448,7 @@
       in {
         packages = {
           hwi-reference = hwiReference;
+          hwi-reference-bhwi = hwiReferenceBhwi;
           hwi-upstream-suite = hwiUpstreamSuite;
           default = pkgs.rustPlatform.buildRustPackage {
             name = "bhwi";

--- a/flake.nix
+++ b/flake.nix
@@ -388,20 +388,21 @@
             exec ${hwiPython}/bin/python ${python-hwi}/hwi.py "$@"
           '';
         };
+        hwiReferenceBhwiMain = pkgs.writeText "hwi-reference-bhwi.py" ''
+          from hwilib import commands
+
+          commands.all_devs = ["ledger", "coldcard", "jade"]
+
+          from hwilib._cli import main
+
+          main()
+        '';
         hwiReferenceBhwi = pkgs.writeShellApplication {
           name = "hwi-reference-bhwi";
           runtimeInputs = [hwiPython];
           text = ''
             export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
-            exec ${hwiPython}/bin/python - "$@" <<'PY'
-from hwilib import commands
-
-commands.all_devs = ["ledger", "coldcard", "jade"]
-
-from hwilib._cli import main
-
-main()
-PY
+            exec ${hwiPython}/bin/python ${hwiReferenceBhwiMain} "$@"
           '';
         };
         hwiUpstreamSuite = pkgs.writeShellApplication {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
       url = "github:Blockstream/blind_pin_server/0205d38e75cb47f187db2efda5846cc898a85039";
       flake = false;
     };
+    python-hwi = {
+      url = "github:bitcoin-core/HWI/3.2.0";
+      flake = false;
+    };
     nixpkgs-esp-dev.url = "github:mirrexagon/nixpkgs-esp-dev";
     nixpkgs-coldcard.url = "github:NixOS/nixpkgs/nixos-24.05";
     rust-overlay = {
@@ -34,6 +38,7 @@
     coldcard-firmware,
     jade-firmware,
     jade-pinserver,
+    python-hwi,
     nixpkgs,
     nixpkgs-coldcard,
     nixpkgs-esp-dev,
@@ -43,7 +48,12 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         overlays = [rust-overlay.overlays.default];
-        pkgs = import nixpkgs {inherit system overlays;};
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.permittedInsecurePackages = [
+            "python3.12-ecdsa-0.19.1"
+          ];
+        };
         coldcardPkgs = import nixpkgs-coldcard {inherit system;};
         emulatorSystem = system == "x86_64-linux";
         espPkgs = import nixpkgs-esp-dev.inputs.nixpkgs {
@@ -59,6 +69,19 @@
         };
         jadePython = pkgs.python3.withPackages (pythonPackages: [
           pythonPackages.zopfli
+        ]);
+        hwiPython = pkgs.python312.withPackages (pythonPackages: [
+          pythonPackages.cbor2
+          pythonPackages.ecdsa
+          pythonPackages.hidapi
+          pythonPackages.libusb1
+          pythonPackages.mnemonic
+          pythonPackages.noiseprotocol
+          pythonPackages.protobuf
+          pythonPackages.pyaes
+          pythonPackages.pyserial
+          pythonPackages.semver
+          pythonPackages.typing-extensions
         ]);
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         rustPlatformWasm = pkgs.makeRustPlatform {
@@ -304,6 +327,36 @@
           export JADE_PINSERVER_URL="https://github.com/Blockstream/blind_pin_server.git"
           export JADE_PINSERVER_PYTHON="${pkgs.python311}/bin/python3"
         '' ./nix/scripts/start-jade-pinserver.sh;
+        hwiReference = pkgs.writeShellApplication {
+          name = "hwi-reference";
+          runtimeInputs = [hwiPython];
+          text = ''
+            export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
+            exec ${hwiPython}/bin/python ${python-hwi}/hwi.py "$@"
+          '';
+        };
+        hwiUpstreamSuite = pkgs.writeShellApplication {
+          name = "hwi-upstream-suite";
+          runtimeInputs =
+            inputs
+            ++ ledgerInputs
+            ++ [
+              hwiPython
+              pkgs.bitcoin
+            ];
+          text = ''
+            export HWI_UPSTREAM_SRC="${python-hwi}"
+            export HWI_BITCOIND="''${HWI_BITCOIND:-${pkgs.bitcoin}/bin/bitcoind}"
+            export HWI_LEDGER_SPECULOS_BIN="''${HWI_LEDGER_SPECULOS_BIN:-${speculos}/bin/speculos}"
+            export LEDGER_BUILD_APP_SCRIPT="''${LEDGER_BUILD_APP_SCRIPT:-${./nix/scripts/build-ledger-app.sh}}"
+            export APP_BITCOIN_NEW_SRC="${app-bitcoin-new}"
+            export APP_BITCOIN_NEW_REV="${app-bitcoin-new.rev or "locked"}"
+            export APP_BITCOIN_NEW_URL="https://github.com/LedgerHQ/app-bitcoin-new.git"
+            export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
+
+            exec ${pkgs.bash}/bin/bash ${./nix/scripts/run-hwi-upstream-suite.sh} "$@"
+          '';
+        };
         linuxPackages =
           pkgs.lib.optionalAttrs emulatorSystem {
             inherit speculos;
@@ -316,6 +369,7 @@
             coldcard = mkApp coldcardRunner;
             ledger = mkApp ledgerRunner;
             ledger-build-app = mkApp ledgerAppBuilder;
+            hwi-upstream-suite = mkApp hwiUpstreamSuite;
             jade = mkApp jadeRunner;
             jade-init = mkApp jadeInitRunner;
             jade-pinserver = mkApp jadePinserverRunner;
@@ -375,6 +429,8 @@
           };
       in {
         packages = {
+          hwi-reference = hwiReference;
+          hwi-upstream-suite = hwiUpstreamSuite;
           default = pkgs.rustPlatform.buildRustPackage {
             name = "bhwi";
             src = ./.;

--- a/nix/scripts/run-hwi-upstream-suite.sh
+++ b/nix/scripts/run-hwi-upstream-suite.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: run-hwi-upstream-suite.sh <ledger|coldcard|jade> [extra run_tests.py args...]
+
+Required:
+  HWI_BIN                     Path to the BHWI hwi binary under test.
+
+Optional device inputs:
+  HWI_LEDGER_APP_ELF          Prebuilt Ledger Bitcoin app ELF.
+  HWI_LEDGER_SPECULOS_BIN     Speculos executable. Defaults to SPECULOS_BIN or speculos.
+  HWI_COLDCARD_SIMULATOR      Path to Coldcard simulator.py.
+  HWI_JADE_SIMULATOR_DIR      Directory containing HWI-compatible Jade simulator files.
+  HWI_BITCOIND                Path to bitcoind. Defaults to bitcoind on PATH.
+
+The runner executes Bitcoin Core HWI's upstream test suite in --interface=cli
+mode with a PATH wrapper named hwi that delegates to HWI_BIN.
+EOF
+}
+
+if [[ $# -lt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 2
+fi
+
+device="$1"
+shift
+
+if [[ -z "${HWI_BIN:-}" ]]; then
+  echo "HWI_BIN must point to the BHWI hwi binary under test" >&2
+  exit 2
+fi
+if [[ ! -x "$HWI_BIN" ]]; then
+  echo "HWI_BIN is not executable: $HWI_BIN" >&2
+  exit 2
+fi
+
+upstream_src="${HWI_UPSTREAM_SRC:?HWI_UPSTREAM_SRC must point to upstream HWI sources}"
+work="$(mktemp -d "${TMPDIR:-/tmp}/bhwi-hwi-upstream.XXXXXXXXXX")"
+cleanup() {
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+cp -R "$upstream_src"/. "$work/HWI"
+chmod -R u+w "$work/HWI"
+
+mkdir -p "$work/bin"
+cat > "$work/bin/hwi" <<EOF
+#!/usr/bin/env bash
+exec "$HWI_BIN" "\$@"
+EOF
+chmod +x "$work/bin/hwi"
+
+export PATH="$work/bin:$PATH"
+export PYTHONPATH="$work/HWI${PYTHONPATH:+:$PYTHONPATH}"
+
+bitcoind="${HWI_BITCOIND:-bitcoind}"
+common_args=(--device-only --interface=cli --bitcoind "$bitcoind")
+
+case "$device" in
+  ledger)
+    ledger_dir="$work/ledger-compat"
+    mkdir -p "$ledger_dir/apps"
+    app_elf="${HWI_LEDGER_APP_ELF:-}"
+    if [[ -z "$app_elf" ]]; then
+      app_elf="$(bash "${LEDGER_BUILD_APP_SCRIPT:?LEDGER_BUILD_APP_SCRIPT must be set or HWI_LEDGER_APP_ELF provided}")"
+    fi
+    ln -s "$app_elf" "$ledger_dir/apps/btc-test.elf"
+    cat > "$ledger_dir/speculos.py" <<'PY'
+import os
+import sys
+
+args = sys.argv[1:]
+if not args:
+    raise SystemExit("missing Speculos arguments")
+app = args[-1]
+speculos_args = args[:-1]
+speculos = os.environ.get("HWI_LEDGER_SPECULOS_BIN") or os.environ.get("SPECULOS_BIN") or "speculos"
+os.execvp(speculos, [speculos, app] + speculos_args)
+PY
+    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --ledger --ledger-path "$ledger_dir/speculos.py" "$@"
+    ;;
+  coldcard)
+    simulator="${HWI_COLDCARD_SIMULATOR:-}"
+    if [[ -z "$simulator" ]]; then
+      echo "HWI_COLDCARD_SIMULATOR must point to Coldcard simulator.py" >&2
+      exit 2
+    fi
+    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --coldcard --coldcard-path "$simulator" "$@"
+    ;;
+  jade)
+    simulator_dir="${HWI_JADE_SIMULATOR_DIR:-}"
+    if [[ -z "$simulator_dir" ]]; then
+      echo "HWI_JADE_SIMULATOR_DIR must point to an HWI-compatible Jade simulator directory" >&2
+      exit 2
+    fi
+    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --jade --jade-path "$simulator_dir" "$@"
+    ;;
+  *)
+    echo "unsupported upstream HWI suite device: $device" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/nix/scripts/start-jade-pinserver.sh
+++ b/nix/scripts/start-jade-pinserver.sh
@@ -20,7 +20,10 @@ if [[ ! -d "$work" ]]; then
   echo "Preparing Jade pinserver source in $work" >&2
   rm -rf "$package_parent"
   mkdir -p "$package_parent"
-  if [[ -n "${JADE_PINSERVER_URL:-}" && "$pinserver_rev" != "locked" ]]; then
+  if [[ -d "$pinserver_src" ]]; then
+    mkdir -p "$work"
+    cp -R "$pinserver_src"/. "$work"/
+  elif [[ -n "${JADE_PINSERVER_URL:-}" && "$pinserver_rev" != "locked" ]]; then
     git clone "$JADE_PINSERVER_URL" "$work"
     git -C "$work" checkout "$pinserver_rev"
   else


### PR DESCRIPTION
- Adds the `bhwi-e2e-hwi-parity` crate, pins the Python HWI reference environment, documents Nix usage, and adds the upstream HWI suite runner scaffold.
- Adds a separate `hwi` binary under `bhwi-cli`, keeps the native `bhwi` CLI separate, and introduces the Python-HWI-compatible command/output mapping surface.
- Implements initial `hwi enumerate` support and wires the parity harness into emulator CI smoke coverage.
- Adds `nix run .#hwi-parity-ledger`, `.#hwi-parity-jade`, and `.#hwi-parity-coldcard`, and runs those checks in the matching emulator CI jobs.
- Pins the Python HWI reference environment to `cbor2 5.9.0`, matching the upstream dependency fix direction and avoiding the Jade TCP timeout seen with HWI 3.2.0 plus `cbor2 5.8.0`.
- Expands enumerate parity with field-level assertions, Python HWI global flag coverage, stdin parity, and adds the HWI parity/FFI roadmap docs.

Relates to #51.