### PR TITLE
feat(jade): display addresses by path

### DIFF
--- a/bhwi/src/jade/api.rs
+++ b/bhwi/src/jade/api.rs
@@ -200,6 +200,13 @@ pub struct DescriptorAddressParams<'a> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct PathAddressParams<'a> {
+    pub network: &'a str,
+    pub path: Vec<u32>,
+    pub variant: &'a str,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SignPsbtParams<'a> {
     pub network: &'a str,
     #[serde(with = "serde_bytes")]

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use base64ct::{Base64, Encoding};
 use bitcoin::Network;
+use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
@@ -44,17 +45,25 @@ pub enum JadeCommand {
     GetMasterFingerprint,
     GetInfo,
     GetXpub(DerivationPath),
-    GetReceiveAddress {
-        index: u32,
-        change: bool,
-        descriptor_name: String,
-    },
+    GetReceiveAddress(ReceiveAddress),
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
     },
     SignPsbt {
         psbt: Psbt,
+    },
+}
+
+pub enum ReceiveAddress {
+    Descriptor {
+        index: u32,
+        change: bool,
+        descriptor_name: String,
+    },
+    Path {
+        path: DerivationPath,
+        variant: &'static str,
     },
 }
 
@@ -213,19 +222,29 @@ where
                     psbt: psbt.serialize(),
                 }),
             ),
-            JadeCommand::GetReceiveAddress {
-                index,
-                change,
-                descriptor_name,
-            } => request(
-                "get_receive_address",
-                Some(api::DescriptorAddressParams {
-                    network: self.network,
-                    branch: u32::from(*change),
-                    pointer: *index,
+            JadeCommand::GetReceiveAddress(address) => match address {
+                ReceiveAddress::Descriptor {
+                    index,
+                    change,
                     descriptor_name,
-                }),
-            ),
+                } => request(
+                    "get_receive_address",
+                    Some(api::DescriptorAddressParams {
+                        network: self.network,
+                        branch: u32::from(*change),
+                        pointer: *index,
+                        descriptor_name,
+                    }),
+                ),
+                ReceiveAddress::Path { path, variant } => request(
+                    "get_receive_address",
+                    Some(api::PathAddressParams {
+                        network: self.network,
+                        path: path.to_u32_vec(),
+                        variant,
+                    }),
+                ),
+            },
             JadeCommand::GetInfo => request("get_version_info", None::<api::EmptyRequest>),
         };
 
@@ -380,7 +399,7 @@ where
                 }
             }
             State::GettingExtendedData { .. } => unreachable!("handled before immutable match"),
-            State::Running(JadeCommand::GetReceiveAddress { .. }) => {
+            State::Running(JadeCommand::GetReceiveAddress(_)) => {
                 let address: String = from_response(&data)?.into_result()?;
                 response = Some(JadeResponse::Address(address));
                 None
@@ -423,16 +442,22 @@ impl TryFrom<Command> for JadeCommand {
                     ..
                 },
                 _ctx,
-            ) => Ok(Self::GetReceiveAddress {
+            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Descriptor {
                 index,
                 change,
                 descriptor_name,
-            }),
-            Command::DisplayAddress(DisplayAddress::ByPath { .. }, _) => {
-                Err(Error::UnsupportedDisplayAddress(
-                    "Jade does not support path-based address display".into(),
-                ))
-            }
+            })),
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    address_format,
+                    ..
+                },
+                _,
+            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Path {
+                path,
+                variant: jade_path_variant(address_format)?,
+            })),
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetInfo),
             Command::RegisterWallet { .. } => Err(Error::MissingCommandInfo(
@@ -440,6 +465,20 @@ impl TryFrom<Command> for JadeCommand {
             )),
             Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
         }
+    }
+}
+
+fn jade_path_variant(address_format: Option<AddressType>) -> Result<&'static str, Error> {
+    match address_format.unwrap_or(AddressType::P2wpkh) {
+        AddressType::P2pkh => Ok("pkh(k)"),
+        AddressType::P2sh => Ok("sh(wpkh(k))"),
+        AddressType::P2wpkh => Ok("wpkh(k)"),
+        AddressType::P2wsh | AddressType::P2tr => Err(Error::UnsupportedDisplayAddress(
+            "Jade does not support this path address format".into(),
+        )),
+        _ => Err(Error::UnsupportedDisplayAddress(
+            "Jade does not support this path address format".into(),
+        )),
     }
 }
 
@@ -496,5 +535,65 @@ impl From<JadeError> for Error {
                 Error::UnsupportedDisplayAddress("unsupported display address on Jade".into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Interpreter;
+    use crate::common::{Command, DisplayAddress, JadeInterpreter};
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct OwnedRequest {
+        method: String,
+        params: Option<OwnedPathAddressParams>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct OwnedPathAddressParams {
+        network: String,
+        path: Vec<u32>,
+        variant: String,
+    }
+
+    #[test]
+    fn path_display_request_encodes_jade_path_params() {
+        let mut interpreter = JadeInterpreter::default().with_network(Network::Testnet);
+        let transmit = interpreter
+            .start(Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path: "m/49'/1'/0'/0/0".parse().unwrap(),
+                    display: true,
+                    address_format: Some(AddressType::P2sh),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let request: OwnedRequest = serde_cbor::from_slice(&transmit.payload).unwrap();
+        let params = request.params.unwrap();
+        assert_eq!(request.method, "get_receive_address");
+        assert_eq!(params.network, JADE_NETWORK_TESTNET);
+        assert_eq!(params.variant, "sh(wpkh(k))");
+        assert_eq!(
+            params.path,
+            vec![0x8000_0031, 0x8000_0001, 0x8000_0000, 0, 0]
+        );
+    }
+
+    #[test]
+    fn path_display_rejects_unsupported_jade_address_format() {
+        let result = JadeCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByPath {
+                path: "m/86'/1'/0'/0/0".parse().unwrap(),
+                display: true,
+                address_format: Some(AddressType::P2tr),
+            },
+            None,
+        ));
+
+        assert!(matches!(result, Err(Error::UnsupportedDisplayAddress(_))));
     }
 }

--- a/e2e/cli/src/jade.rs
+++ b/e2e/cli/src/jade.rs
@@ -3,6 +3,8 @@ use anyhow::Result;
 use crate::support::{Cli, CommandCase, ExpectedOutput, assert_command};
 
 const JADE_FINGERPRINT: &str = "e3ebcc79";
+const JADE_ADDRESS_84_0: &str = "tb1q9t9pgtdsyf6r8ks7gnxvj99sea4d3nmjl0tnzu";
+const JADE_ADDRESS_49_0: &str = "2MsFo9x4kZMVumePtLZvjh9Hn9A98bS3MF6";
 const JADE_XPUB_44: &str = "tpubDCKD5cdxMEFd2i4cNa3PJUbUHMsGDxsnfqjxVpMoG1ymWYUQUaZzTcHQo3JwYgaKe2FyKGA2FzGPSVczBoAiHGyERuA1mZ2UkGKufEnUxKk";
 
 #[test]
@@ -22,6 +24,33 @@ fn jade_xpub_get() -> Result<()> {
         cli: Cli::for_device(JADE_FINGERPRINT),
         args: &["xpub", "get", "m/44'/1'/0'"],
         expected: ExpectedOutput::Exact(JADE_XPUB_44),
+    })
+}
+
+#[test]
+fn jade_address_get_by_path() -> Result<()> {
+    assert_command(CommandCase {
+        name: "address get m/84'/1'/0'/0/0",
+        cli: Cli::for_device(JADE_FINGERPRINT),
+        args: &["address", "get", "--from-path", "m/84'/1'/0'/0/0"],
+        expected: ExpectedOutput::Exact(JADE_ADDRESS_84_0),
+    })
+}
+
+#[test]
+fn jade_nested_segwit_address_get_by_path() -> Result<()> {
+    assert_command(CommandCase {
+        name: "address get m/49'/1'/0'/0/0",
+        cli: Cli::for_device(JADE_FINGERPRINT),
+        args: &[
+            "address",
+            "get",
+            "--from-path",
+            "m/49'/1'/0'/0/0",
+            "--address-format",
+            "p2sh",
+        ],
+        expected: ExpectedOutput::Exact(JADE_ADDRESS_49_0),
     })
 }
 

--- a/e2e/jade/src/lib.rs
+++ b/e2e/jade/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
         Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
         Witness,
         absolute::LockTime,
-        address::Address,
+        address::{Address, AddressType},
         bip32::{ChildNumber, DerivationPath},
         psbt::{Input, Psbt},
         secp256k1::Secp256k1,
@@ -83,9 +83,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn can_display_address_miniscript() {
+    async fn can_display_address_by_path() {
         let mut dev = device().await;
-        let res = dev
+        let address = dev
             .display_address(
                 DisplayAddress::ByPath {
                     path: "m/84'/1'/0'/0/0".parse().unwrap(),
@@ -94,9 +94,43 @@ mod tests {
                 },
                 None,
             )
-            .await;
-        // Jade does not support Path-based address display
-        assert!(res.is_err());
+            .await
+            .unwrap();
+        assert_eq!(address, "tb1q9t9pgtdsyf6r8ks7gnxvj99sea4d3nmjl0tnzu");
+    }
+
+    #[tokio::test]
+    async fn can_display_nested_segwit_address_by_path() {
+        let mut dev = device().await;
+        let address = dev
+            .display_address(
+                DisplayAddress::ByPath {
+                    path: "m/49'/1'/0'/0/0".parse().unwrap(),
+                    display: true,
+                    address_format: Some(AddressType::P2sh),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(address, "2MsFo9x4kZMVumePtLZvjh9Hn9A98bS3MF6");
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_path_address_format() {
+        let mut dev = device().await;
+        let err = dev
+            .display_address(
+                DisplayAddress::ByPath {
+                    path: "m/86'/1'/0'/0/0".parse().unwrap(),
+                    display: true,
+                    address_format: Some(AddressType::P2tr),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unsupported display address"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Ran into this when implementing HWI parity. It will allow us to have
full test coverage on `displayaddress`.