### PR TITLE
docs: add agent contribution guidance

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,30 @@
+# BHWI Agent Resources
+
+`AGENTS.md` is the authoritative policy layer for this repository. Use this
+directory for task-specific runbooks, checklists, review prompts, and templates
+that are too detailed for the top-level rules.
+
+## Start Here
+
+- [`context/crate-map.md`](context/crate-map.md): repo surfaces and common edit
+  points.
+- [`checklists/device-command.md`](checklists/device-command.md): add or extend
+  a command for an existing device.
+- [`checklists/new-device.md`](checklists/new-device.md): onboard a new hardware
+  wallet end to end.
+- [`runbooks/emulator-validation.md`](runbooks/emulator-validation.md): run and
+  classify emulator-backed checks.
+- [`runbooks/hwi-parity.md`](runbooks/hwi-parity.md): compare the `hwi` binary
+  with pinned Python HWI.
+- [`review/device-protocol-review.md`](review/device-protocol-review.md):
+  protocol/interpreter review prompt.
+- [`review/cli-review.md`](review/cli-review.md): CLI behavior review prompt.
+- [`templates/handoff.md`](templates/handoff.md): final handoff format.
+- [`templates/pr-description.md`](templates/pr-description.md): PR body format.
+
+## Use Pattern
+
+- Pull in only the resource that matches the task.
+- Keep workflow detail here instead of duplicating it in `AGENTS.md`.
+- Update these files when commands, crate ownership, emulator commands, or HWI
+  parity requirements change.

--- a/.agents/checklists/device-command.md
+++ b/.agents/checklists/device-command.md
@@ -1,0 +1,46 @@
+# Device Command Checklist
+
+Use this when adding a command to an existing device integration. If a surface
+is skipped, the handoff must explain why it is not applicable.
+
+## Design
+
+- Identify the exact device API command and expected request/response shape.
+- Decide whether the command is common across devices or device-specific.
+- Record required device context explicitly; do not hide it on a device wrapper.
+- Check whether Python HWI exposes equivalent behavior and whether parity tests
+  should be updated.
+
+## Core Interpreter
+
+- Add or extend `common::Command`, `common::Response`, and
+  `common::DeviceContext` only as needed.
+- Convert from `common::Command` in the device module and reject missing context
+  with a clear error.
+- Keep protocol encoding, parsing, callbacks, and state transitions in `bhwi`.
+- Keep transport, HTTP, browser, and emulator I/O outside `bhwi`.
+- Add protocol/unit tests for encoding, parsing, and state-machine behavior
+  before relying on e2e tests.
+
+## Runtime And CLI Surfaces
+
+- Add the `bhwi-async` trait method or implementation wiring when the command is
+  part of the async HWI surface.
+- Add `bhwi-cli` command support when user-facing.
+- Preserve CLI output contracts: quiet success for action-only commands,
+  Unix-friendly default output, `--pretty` tables, and `--json` for structured
+  output.
+- Use existing Bitcoin crate parsing/display helpers before adding encoding or
+  formatting dependencies.
+- Add `bhwi-wasm` support when the existing browser surface requires parity.
+
+## Tests And Docs
+
+- Add emulator-backed package e2e coverage for every emulator-supported command.
+- Add matching `bhwi-e2e-cli` coverage for user-facing emulator-supported CLI
+  commands.
+- Update HWI parity tests and `docs/HWI_PARITY.md` when the command affects the
+  Python-HWI-compatible `hwi` binary.
+- Update device docs when setup, support status, upstream references, or user
+  behavior changes.
+- Run the validation required by `AGENTS.md` for the changed surfaces.

--- a/.agents/checklists/new-device.md
+++ b/.agents/checklists/new-device.md
@@ -1,0 +1,100 @@
+# New Device Checklist
+
+Use this when onboarding a new hardware wallet. Do not claim device support
+until core behavior, user surfaces, emulator-backed e2e coverage, and HWI parity
+status are all accounted for.
+
+## Research And Scope
+
+- Identify upstream protocol documentation, client libraries, emulator or
+  simulator support, and Python HWI support status.
+- Pin upstream emulator or firmware inputs when CI or local e2e depends on
+  them.
+- Record the device transport model: HID, TCP, serial, WebHID, WebSerial, HTTP,
+  or device-requested callback service.
+- Map authentication, unlock, PIN/passphrase, network selection, and refusal
+  semantics before writing code.
+- Decide the initial supported BHWI commands and explicitly record unsupported
+  commands or intentional parity gaps.
+- Identify sensitive fields that must never appear in logs: seeds, private keys,
+  xprvs, PINs, passphrases, wallet secrets, real HMACs, and raw real-device
+  payloads.
+
+## Core `bhwi`
+
+- Add `bhwi/src/<device>/` with the sans-I/O interpreter and protocol helpers.
+- Export the module from `bhwi/src/lib.rs`.
+- Preserve the `Interpreter` flow: `start`, repeated `exchange`, then `end`.
+- Keep device protocol state machines, request encoding, response parsing, and
+  device-requested callbacks in the interpreter.
+- Keep HID, TCP, serial, browser, HTTP, and emulator I/O out of core.
+- Add device conversion from `common::Command`; reject unsupported command
+  shapes and missing `DeviceContext` with clear errors.
+- Extend `common::DeviceContext` only for device-specific command data.
+- Add protocol/unit tests for request encoding, response parsing, error mapping,
+  state-machine transitions, authentication callbacks, and refusal paths.
+- Update `common_interpreter_is_satisfied` or equivalent compile-time coverage
+  so the new common interpreter participates in the shared surface.
+
+## Async, CLI, And WASM
+
+- Add `bhwi-async/src/<device>.rs` and any required transport/client wiring
+  outside the core interpreter.
+- Export the async device type from `bhwi-async/src/lib.rs` when it is part of
+  the public surface.
+- Add `bhwi-cli/src/<device>.rs` with discovery/enumeration and execution
+  wiring.
+- Add the device to `DeviceType`, `DeviceType::enumerate`, selector matching,
+  HWI parsing, and HWI label handling.
+- Ensure native `bhwi` CLI output follows quiet success, `--pretty`, and
+  `--json` rules.
+- Ensure Python-HWI-compatible `hwi` output uses Python HWI command names, JSON
+  shapes, and error codes where parity is claimed.
+- Add `bhwi-wasm` support only when the existing browser surface should support
+  the device; otherwise explain why it is skipped.
+
+## E2E Crates And Emulator Infrastructure
+
+- Add `e2e/<device>/Cargo.toml` and `e2e/<device>/src/lib.rs` for
+  emulator-backed device tests.
+- Cover discovery, unlock/info, master fingerprint, xpub, address display,
+  signing, refusal, and error paths according to the initial support claim.
+- Add `e2e/cli/src/<device>.rs` and wire it from `e2e/cli/src/lib.rs` for every
+  user-facing emulator-supported CLI command.
+- Add Nix inputs for pinned firmware/emulator sources in `flake.nix`.
+- Add `nix/scripts/start-<device>.sh` and readiness helpers when needed.
+- Add a flake app `nix run .#<device>` and shell
+  `nix develop .#<device>` for local e2e.
+- Add the new script to `checks.x86_64-linux.emulator-scripts`; remember that
+  new scripts must be staged before flake source checks can see them.
+- Add a device job to `.github/workflows/emulators.yml` with emulator startup,
+  CLI e2e, package e2e, redacted failure logs, and serial test execution.
+- Use `-- --test-threads=1` for emulator tests.
+- Report emulator startup separately from Rust test execution.
+
+## HWI Parity
+
+- Confirm whether Python HWI supports the device and which command surface is
+  expected to match.
+- Add the device to the pinned Python-HWI reference restriction in `flake.nix`
+  (`commands.all_devs`).
+- Add a `hwi-parity-<device>` flake app using `HWI_PARITY_DEVICE_TYPE=<device>`.
+- Add the device to `e2e/hwi-parity` normalization and any command fixtures.
+- Run parity with only the intended emulator family active; do not run multiple
+  emulator families at once.
+- Add the device parity app to Emulator CI.
+- Update `docs/HWI_PARITY.md` with support status, command matrix, known
+  deviations, and validation evidence.
+- If a command is intentionally unsupported, parse it and return a
+  Python-HWI-shaped unsupported error instead of letting clap reject it.
+
+## Documentation And Handoff
+
+- Update `docs/DEVICE_ONBOARDING.md` with upstream references and local code
+  entry points.
+- Add or update `docs/<DEVICE>.md` with emulator setup and local e2e commands.
+- Update `docs/NIX.md` for new flake apps, shells, readiness checks, and
+  emulator details.
+- Call out public API, CLI, dependency, security/logging, and HWI parity impact
+  in the handoff.
+- List every skipped surface with the reason it is not applicable.

--- a/.agents/context/crate-map.md
+++ b/.agents/context/crate-map.md
@@ -1,0 +1,44 @@
+# BHWI Crate Map
+
+Use this map to find the right surface before editing.
+
+## Core
+
+- `bhwi`: sans-I/O protocol interpreters, shared common command surface, device
+  protocol encoding/parsing, and protocol tests.
+- `bhwi/src/common.rs`: common commands, responses, recipients, transmits, and
+  device-specific context.
+- `bhwi/src/device.rs`: device/client inventory types that do not belong in the
+  common interpreter surface.
+- `bhwi/src/<device>/`: device protocol modules.
+
+## Runtime And User Surfaces
+
+- `bhwi-async`: async execution, transports, HTTP clients, and the HWI trait/API.
+- `bhwi-cli`: native `bhwi` CLI, Python-HWI-compatible `hwi` binary, discovery,
+  selectors, output formatting, and device enumeration.
+- `bhwi-wasm`: browser-facing transports and device support where the existing
+  browser surface requires parity.
+- `website`: website and demo build surface.
+
+## E2E And Tooling
+
+- `e2e/<device>`: emulator-backed device package tests.
+- `e2e/cli`: emulator-backed user-facing CLI tests.
+- `e2e/hwi-parity`: JSON parity harness comparing BHWI `hwi` with pinned
+  Python HWI.
+- `nix/scripts`: emulator startup, readiness, HWI upstream-suite helpers, and
+  CI log helpers.
+- `flake.nix`: pinned emulator inputs, flake apps, dev shells, packages, checks,
+  and HWI parity runners.
+- `.github/workflows/main.yml`: non-emulator Rust CI.
+- `.github/workflows/emulators.yml`: emulator, CLI e2e, and HWI parity CI.
+- `.github/workflows/website.yml`: website build/deploy.
+
+## Docs
+
+- `README.md` and `docs/VISION.md`: architecture rationale.
+- `docs/DEVICE_ONBOARDING.md`: upstream references and device onboarding notes.
+- `docs/NIX.md`: emulator and Nix workflow.
+- `docs/HWI_PARITY.md`: Python HWI parity status and known deviations.
+- `docs/<DEVICE>.md`: per-device emulator/setup notes.

--- a/.agents/review/cli-review.md
+++ b/.agents/review/cli-review.md
@@ -1,0 +1,27 @@
+# CLI Review Prompt
+
+Use this prompt when reviewing native `bhwi` or Python-HWI-compatible `hwi`
+changes.
+
+Review the CLI change for behavior regressions and contract drift. Prioritize
+findings with file/line references.
+
+Check:
+
+- Default output is Unix-friendly: no headers, easy separators, and chainable
+  output.
+- `--pretty` is used for tables and `--json` is used for structured output.
+- Action-only success paths print nothing unless the existing contract says
+  otherwise.
+- Command names match user expectation: `device`, `descriptor`, and `address`
+  remain scoped to their intended domains.
+- Existing output shapes are preserved unless the task explicitly changes them.
+- Parsing/display uses existing Bitcoin crate APIs where reasonable.
+- Python-HWI-compatible `hwi` behavior matches Python HWI command names,
+  argument names, JSON fields, error codes, and unsupported-command behavior.
+- Device selection by type, path, fingerprint, chain, and emulator flag is
+  covered where applicable.
+- User-facing emulator-supported behavior has matching `bhwi-e2e-cli` coverage.
+- Error messages distinguish bad arguments, no device, transport failure,
+  network mismatch, unsupported command shape, protocol refusal, and parser
+  failure.

--- a/.agents/review/device-protocol-review.md
+++ b/.agents/review/device-protocol-review.md
@@ -1,0 +1,27 @@
+# Device Protocol Review Prompt
+
+Use this prompt when reviewing protocol, interpreter, or device-command changes.
+
+Review the change for protocol correctness, security, interpreter boundaries,
+and test coverage. Prioritize findings with file/line references.
+
+Check:
+
+- Core `bhwi` remains sans-I/O; no HID, TCP, serial, browser, HTTP, emulator, or
+  runtime code leaks into interpreters.
+- The interpreter preserves `start`, repeated `exchange`, then `end`.
+- Device command conversion rejects missing context and unsupported command
+  shapes with clear errors.
+- Protocol encoding, response parsing, callbacks, authentication, and refusal
+  paths have focused unit tests.
+- E2E tests do not replace protocol/unit tests for new parser, encoder, or
+  state-machine behavior.
+- Errors include command/context details and distinguish network mismatch,
+  missing context, unsupported shape, transport failure, parser/encoding
+  failure, protocol refusal, and device busy states.
+- Secrets and real device payloads are not logged; logs use structured,
+  truncated metadata.
+- New dependencies are justified and not replacing reasonable existing crate
+  APIs or caller-side handling.
+- HWI parity, CLI e2e, docs, and emulator infrastructure are updated when the
+  behavior is user-facing or parity-relevant.

--- a/.agents/runbooks/emulator-validation.md
+++ b/.agents/runbooks/emulator-validation.md
@@ -1,0 +1,132 @@
+# Emulator Validation Runbook
+
+Use this when a change touches device protocol behavior, emulator-supported CLI
+behavior, HWI parity, Nix emulator infrastructure, or CI logs.
+
+## General Rules
+
+- Run only the intended emulator family for the test being performed.
+- Use `-- --test-threads=1` for emulator tests.
+- Treat emulator startup and Rust test execution as separate validation steps.
+- Redact sensitive logs. Do not include seeds, private keys, xprvs, PINs,
+  passphrases, wallet secrets, real HMACs, raw APDU dumps, or full real-device
+  payloads in handoffs or CI comments.
+- If validation fails, determine whether the failure is caused by the current
+  change, pre-existing behavior, or local environment.
+
+## Coldcard
+
+Start:
+
+```sh
+nix run .#coldcard
+```
+
+Readiness:
+
+```sh
+test -S /tmp/ckcc-simulator.sock
+```
+
+Package e2e:
+
+```sh
+nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1
+```
+
+CLI e2e:
+
+```sh
+cargo build -p bhwi-cli
+BHWI_BIN="$PWD/target/debug/bhwi" \
+  nix develop .#coldcard -c cargo test -p bhwi-e2e-cli coldcard -- --test-threads=1
+```
+
+HWI parity:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+nix run .#hwi-parity-coldcard
+```
+
+## Ledger
+
+Start:
+
+```sh
+nix run .#ledger
+```
+
+Readiness:
+
+```sh
+nc -z localhost 9999 && nc -z localhost 5000
+```
+
+Package e2e:
+
+```sh
+nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1
+```
+
+CLI e2e:
+
+```sh
+cargo build -p bhwi-cli
+BHWI_BIN="$PWD/target/debug/bhwi" \
+  nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --test-threads=1
+```
+
+HWI parity:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+nix run .#hwi-parity-ledger
+```
+
+## Jade
+
+Start:
+
+```sh
+nix run .#jade-pinserver
+nix run .#jade
+nix run .#jade-init
+```
+
+Readiness:
+
+```sh
+nc -z localhost 8096 && nc -z localhost 30121
+```
+
+Package e2e:
+
+```sh
+nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1
+```
+
+CLI e2e:
+
+```sh
+cargo build -p bhwi-cli
+BHWI_BIN="$PWD/target/debug/bhwi" \
+  nix develop .#jade -c cargo test -p bhwi-e2e-cli jade -- --test-threads=1
+```
+
+HWI parity:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+nix run .#hwi-parity-jade
+```
+
+## Nix Script Checks
+
+Run after adding or changing emulator scripts:
+
+```sh
+nix build .#checks.x86_64-linux.emulator-scripts
+```
+
+New scripts must be staged before this flake check can see them.

--- a/.agents/runbooks/hwi-parity.md
+++ b/.agents/runbooks/hwi-parity.md
@@ -1,0 +1,65 @@
+# HWI Parity Runbook
+
+Use this when changing the Python-HWI-compatible `hwi` binary, device
+enumeration, command parsing, command output, or HWI status docs.
+
+## Contract
+
+- Compare BHWI `hwi` output against pinned Python HWI.
+- Match command names, argument names, short flags, JSON key names, JSON value
+  shapes, error codes, and base64 formats where parity is claimed.
+- Parse unsupported Python HWI commands and return Python-HWI-shaped unsupported
+  errors instead of clap parse errors.
+- Record every intentional divergence in `docs/HWI_PARITY.md`.
+
+## Local Foundation
+
+Build the candidate binary:
+
+```sh
+cargo build -p bhwi-cli --bin hwi
+```
+
+Run the harness directly when custom binaries are needed:
+
+```sh
+REFERENCE_HWI_BIN="$(nix build --no-link --print-out-paths .#hwi-reference-bhwi)/bin/hwi-reference-bhwi" \
+HWI_BIN="$PWD/target/debug/hwi" \
+nix develop -c cargo test -p bhwi-e2e-hwi-parity
+```
+
+## Device-Scoped Apps
+
+Run only one emulator family at a time. Multiple active emulator families can
+contaminate reference/candidate enumeration and cause misleading parity
+failures.
+
+```sh
+nix run .#hwi-parity-coldcard
+nix run .#hwi-parity-ledger
+nix run .#hwi-parity-jade
+```
+
+## Adding A Parity Device
+
+- Add the device to the pinned reference HWI restriction in `flake.nix`
+  (`commands.all_devs`).
+- Add a `mkHwiParityRunner` instance with
+  `HWI_PARITY_DEVICE_TYPE=<device>`.
+- Export a `hwi-parity-<device>` flake app.
+- Add the device to `e2e/hwi-parity` normalization.
+- Add command fixtures or device-specific assertions needed for the new device.
+- Wire the parity app into `.github/workflows/emulators.yml`.
+- Update `docs/HWI_PARITY.md` with status, known deviations, and validation
+  evidence.
+
+## Failure Triage
+
+- If JSON differs, compare field names, optional field presence, value formats,
+  and device ordering before changing protocol code.
+- If reference discovery sees the wrong device, stop extra emulator families and
+  rerun with only the intended device active.
+- If Python HWI times out or fails before BHWI runs, inspect pinned dependency
+  behavior in `flake.nix` before patching BHWI.
+- If the candidate fails only after selecting a device, classify the failure as
+  parser, CLI selection, async device, transport, protocol, or emulator setup.

--- a/.agents/templates/handoff.md
+++ b/.agents/templates/handoff.md
@@ -1,0 +1,37 @@
+# Handoff Template
+
+Use this shape for final handoffs after code or docs changes.
+
+## Summary
+
+- Changed:
+- Public API impact:
+- CLI impact:
+- Dependency impact:
+- Security/logging impact:
+
+## Validation
+
+| Command | Result | Notes |
+|---|---|---|
+| `cargo fmt --all --check` | passed/failed/skipped | |
+| `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings` | passed/failed/skipped | |
+| `cargo test --verbose --no-default-features` | passed/failed/skipped | |
+| `cargo test --verbose --color always -- --nocapture` | passed/failed/skipped | |
+| `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture` | passed/failed/skipped | |
+| emulator startup | passed/failed/skipped | device and command |
+| emulator e2e | passed/failed/skipped | device and command |
+| CLI e2e | passed/failed/skipped | device and command |
+| HWI parity | passed/failed/skipped | device and command |
+
+For docs-only changes, report:
+
+```text
+Skipped code validation because only docs changed.
+```
+
+## Notes
+
+- Skipped surfaces and why:
+- Pre-existing or environmental failures:
+- Unrelated local changes left untouched:

--- a/.agents/templates/pr-description.md
+++ b/.agents/templates/pr-description.md
@@ -1,0 +1,29 @@
+# PR Description Template
+
+## Summary
+
+- 
+
+## Behavior
+
+- Public API:
+- CLI:
+- Device protocol:
+- HWI parity:
+- Security/logging:
+
+## Tests
+
+- [ ] `cargo fmt --all --check`
+- [ ] `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
+- [ ] `cargo test --verbose --no-default-features`
+- [ ] `cargo test --verbose --color always -- --nocapture`
+- [ ] `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
+- [ ] Device e2e:
+- [ ] CLI e2e:
+- [ ] HWI parity:
+
+## Docs
+
+- Updated:
+- Not needed because:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,169 @@
+# BHWI Agent Rules
+
+## Purpose And Precedence
+
+- Use this file as the working agreement for agents and developers contributing to BHWI.
+- Direct user instructions override this file.
+- For technical facts, prefer current code and repository docs. For workflow rules and architecture boundaries, follow this file unless a more specific tracked project doc says otherwise.
+- If instructions conflict in a way that materially affects public APIs, CLI output shape, validation scope, branch history, or security-sensitive behavior, pause and ask before changing those areas.
+- Preserve unrelated local changes. Do not revert, format, stage, or commit files outside the requested scope unless explicitly asked.
+- Prefer root-cause fixes over cosmetic workarounds, and keep changes as small as the task allows.
+
+## Team Workflow
+
+- Start by checking the current branch and worktree status.
+- For non-trivial or review-bound work, create or switch to a feature branch named `github_user/short_topic_name` before edits. If already on a suitable feature branch, stay there.
+- Read-only investigation does not require a new branch.
+- Do not commit unless asked. When asked to commit, use signed commits and keep them atomic by crate or concern.
+- For broad or ambiguous work, clarify the intended behavior before implementation. For narrow bugs, inspect first and implement the smallest defensible fix.
+- Handoffs must state what changed, whether public APIs or CLI behavior changed, and which validation commands passed, failed, or were skipped.
+
+## Task Workflow Matrix
+
+- Docs-only: update docs or instructions only; no Rust validation required.
+- Core Rust/API/common interpreter: preserve sans-I/O boundaries and run all non-emulator CI checks.
+- CLI behavior or output: preserve Unix-friendly output and run non-emulator CI plus focused CLI or CLI e2e tests when supported.
+- Device protocol command: add protocol/unit tests, then run the matching device emulator e2e package.
+- User-facing emulator-supported command: run the matching device e2e package and the matching `bhwi-e2e-cli` device test.
+- WASM or website: run the existing build or test command for the touched surface when one exists.
+- Nix, CI, or emulator infrastructure: pin upstream inputs when local or CI flows depend on them, and update docs when setup or references change.
+
+## Non-Negotiable Architecture Invariants
+
+- BHWI is a sans-I/O Bitcoin hardware wallet interface.
+- Keep device protocol state machines in `bhwi`.
+- Keep async runtimes, HID/TCP/Web transport, HTTP clients, browser APIs, and emulator I/O outside the core interpreters.
+- Preserve the `Interpreter` model: `start`, repeated `exchange`, then `end`.
+- Treat `common` as the common interpreter surface: shared commands, responses, recipients, transmits, and device-specific context.
+- Keep device discovery and concrete device inventory types out of `bhwi/src/common.rs`; use device/client modules such as `device.rs` or CLI/async layers.
+- Keep library APIs flexible for sync, async, FFI, WASM, and custom execution models.
+
+## Device Commands
+
+- For every new device command, wire the full path where relevant:
+  - common command, response, and context in `bhwi`
+  - device interpreter conversion and protocol encoding/parsing
+  - protocol unit tests for encoding, parsing, and state-machine behavior
+  - `bhwi-async` HWI trait/API
+  - `bhwi-cli` command when user-facing
+  - WASM support when the existing surface requires parity
+  - emulator-backed e2e coverage when the command is emulator-supported
+  - docs update when setup, support status, or user-visible behavior changes
+- If a surface in the command path is skipped, explain in the handoff why it is not applicable.
+- Do not rely only on e2e tests when protocol encoding, parsing, or state-machine behavior changed.
+- If a command needs device-specific data, pass it through `Option<common::DeviceContext>` rather than storing hidden state on the device wrapper.
+- Keep `DeviceContext` fields organized by device. Let `TryFrom<common::Command>` for each device reject missing required fields with a clear error.
+- Do not require Ledger wallet policy data for devices that do not need it. For Ledger, keep policy name, policy, and HMAC optional at the common layer, and validate at Ledger conversion time.
+- Use precise names for context fields. Prefer `policy_name` over vague `name` in transaction signing contexts.
+- Device-specific commands and responses should mirror the device API as closely as possible. Let the common layer map names and shapes into a unified interface.
+
+## Error Handling
+
+- Unexpected device responses must include command/context details; avoid bare `unexpected result: []` errors.
+- When adding an error path, include enough context to distinguish network mismatch, missing context, unsupported command shape, transport failure, protocol refusal, and parser/encoding failure.
+- Do not panic in recoverable or user-facing paths for absent emulators, missing sockets, disconnected devices, empty discovery results, malformed user input, or unsupported device actions.
+- Prefer typed errors that preserve useful context over string-only errors, within existing public API compatibility constraints.
+
+## CLI UX
+
+- CLI commands should be scoped by user expectation:
+  - `device` is for listing devices, firmware/app info, and device management.
+  - `descriptor` is for descriptor-related operations.
+  - `address` is for address display/check/get flows.
+- Prefer command names that describe actual behavior. Do not reserve broad names like `descriptor list` for narrower "common pubkey descriptor" behavior; use names like `descriptor pubkeys` when appropriate.
+- Default CLI output should be Unix-friendly: no headers, easy separators, and chainable output.
+- Use `--pretty` for table output.
+- Use `--json` for structured output suitable for `jq`.
+- Commands that only perform an action successfully should usually print nothing.
+- Preserve existing output contracts unless the task explicitly changes them.
+- Use existing Bitcoin crate parsing/display APIs before adding encoding dependencies. Examples: `Psbt::from_str`, `Psbt` display, and `MessageSignature` base64 helpers.
+- Build `target/debug/bhwi` before running CLI e2e tests that set `BHWI_BIN="$PWD/target/debug/bhwi"`.
+
+## Security And Logging
+
+- Treat hardware-wallet protocol data as sensitive by default.
+- Never log seeds, private keys, xprvs, PINs, passphrases, wallet secrets, or real HMACs.
+- Prefer structured, truncated protocol metadata over raw APDU dumps or full PSBTs.
+- Use synthetic or regtest fixtures for tests. Require explicit user approval before exposing real device payloads in logs, handoffs, CI output, or issue comments.
+- Redact emulator and device logs in handoffs, CI summaries, and issue comments.
+- Keep client-provided Ledger data authenticated by the device protocol.
+- Avoid adding dependencies for parsing, formatting, transport, logging, or encoding unless existing crate APIs or caller-side handling are insufficient.
+
+## Architecture Preferences From Review
+
+- Keep trait bounds as loose as the implementation allows. Do not add `StdError + Send + Sync + Debug + 'static` unless the code truly needs them.
+- Avoid new dependencies when the consumer can reasonably do the work or an existing dependency already provides the needed parsing/formatting.
+- Pin emulator/upstream inputs when CI or local emulator flows depend on upstream behavior. Do not leave emulator builds exposed to unreviewed upstream breakage.
+- Update docs under `docs/` when emulator setup, upstream references, support status, or device onboarding steps change.
+
+## Device Notes
+
+- Ledger uses APDUs, wallet policies, Merkle proofs, and device-requested client callbacks. Keep client-provided data authenticated by the device protocol.
+- Ledger PSBT signing may need wallet policy context for non-standard policies; standard policies may not.
+- Jade uses CBOR-RPC and may require PIN server routing via `Recipient::PinServer`.
+- Coldcard commands are encrypted after the initial public-key exchange.
+- Keep transport-specific code in `bhwi-async`, `bhwi-wasm`, `bhwi-cli`, or `e2e`, not in the core interpreter.
+
+## Review Preflight
+
+- Review changed code for public API compatibility, trait-surface impact, and downstream callers before validation.
+- Check interpreter boundaries: keep transport, runtime, HTTP, browser, and emulator I/O code outside `bhwi`.
+- Check error paths include enough context to distinguish missing context, unsupported command shape, network mismatch, protocol refusal, parser/encoding failure, and transport failure.
+- Check CLI output shape, quiet success behavior, `--pretty`, and `--json` behavior match existing UX rules.
+- Check test coverage matches the changed behavior. Do not rely on e2e tests alone when protocol encoding, parsing, or state-machine behavior changed.
+- Justify every new dependency. Prefer existing crate APIs and caller-side parsing/formatting when reasonable.
+- Confirm documentation is updated when behavior, setup, support status, or upstream references change.
+
+## Verification
+
+- Docs-only changes do not require code validation. Report: `Skipped code validation because only docs changed.`
+- Code changes must pass the local non-emulator CI checks before handoff:
+  - `cargo fmt --all --check`
+  - `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
+  - `cargo test --verbose --no-default-features`
+  - `cargo test --verbose --color always -- --nocapture`
+  - `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
+- For device protocol or user-facing CLI behavior changes, run the matching emulator-backed tests:
+  - Coldcard: `nix run .#coldcard`, then `nix develop .#coldcard -c cargo test -p bhwi-e2e-coldcard -- --test-threads=1`
+  - Ledger: `nix run .#ledger`, then `nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1`
+  - Jade: `nix run .#jade-pinserver`, `nix run .#jade`, `nix run .#jade-init`, then `nix develop .#jade -c cargo test -p bhwi-e2e-jade -- --test-threads=1`
+- For user-facing emulator-supported CLI commands, build the CLI binary and run the matching CLI e2e test with `BHWI_BIN` set:
+  - Build: `cargo build -p bhwi-cli`
+  - Coldcard: `BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#coldcard -c cargo test -p bhwi-e2e-cli coldcard -- --test-threads=1`
+  - Ledger: `BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --test-threads=1`
+  - Jade: `BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#jade -c cargo test -p bhwi-e2e-cli jade -- --test-threads=1`
+- Report emulator startup separately from Rust test execution when emulator-backed validation is required.
+- If a broad validation command fails, inspect whether the failure was caused by the current change. Fix current-change regressions before handoff; report pre-existing or environmental failures with evidence and the exact rerun command.
+- If a required check cannot run because of the local environment or emulator availability, report the exact command, the concrete blocker, and the command the user should run.
+- Every code-change handoff must include a validation summary listing each required command as passed, failed, or skipped with reason.
+
+## Commit Style
+
+- When committing, use signed commits only.
+- Use Conventional Commit style where it fits the repo history:
+  - `feat(bhwi): add ...`
+  - `feat(bhwi-async): add ...`
+  - `feat(bhwi-cli): add ...`
+  - `feat(e2e/ledger): add ...`
+  - `test(e2e): add ...`
+  - `fix(nix): ...`
+  - `docs: ...`
+  - `style: format ...`
+- Keep commits atomic by crate or concern.
+- Split cross-cutting command work into reviewable commits, commonly:
+  - core/common interpreter support
+  - one device implementation
+  - async API surface
+  - CLI support
+  - e2e tests and automations
+  - docs or Nix/CI updates
+- Do not mix formatting-only churn into feature commits. Use a separate `style:` commit if needed.
+- Keep commit messages brief and direct. Avoid ticket references unless asked.
+
+## Definition Of Done
+
+- The requested behavior or documentation change is complete and scoped to the task.
+- Public API, CLI, dependency, and security-sensitive impacts are explicitly called out.
+- Required tests or checks are run for the change type, or skipped with a concrete reason.
+- Emulator-backed checks include whether emulator startup succeeded.
+- The final handoff names unrelated local changes that were intentionally left untouched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
- add tracked AGENTS.md contribution rules for BHWI agents and small-team workflows
- add .agents/ runbooks, checklists, review prompts, templates, and crate map
- add CLAUDE.md shim pointing Claude users at AGENTS.md
