### PR TITLE
feat: add Jade and Coldcard descriptor registration

### DIFF
--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -12,6 +12,7 @@ pub use bhwi::common::DeviceBackup;
 pub use bhwi::common::DeviceContext;
 pub use bhwi::common::DisplayAddress;
 pub use bhwi::common::Info;
+pub use bhwi::common::WalletRegistration;
 use bhwi::miniscript::descriptor::WalletPolicy;
 use bhwi::{
     Interpreter,
@@ -60,7 +61,11 @@ pub trait HWI {
         address: common::DisplayAddress,
         context: Option<common::DeviceContext>,
     ) -> Result<String, Self::Error>;
-    async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<[u8; 32], Self::Error>;
+    async fn register_wallet(
+        &mut self,
+        name: &str,
+        policy: &str,
+    ) -> Result<WalletRegistration, Self::Error>;
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
@@ -96,7 +101,7 @@ pub trait HWIDevice {
         &mut self,
         name: &str,
         policy: &str,
-    ) -> Result<[u8; 32], HWIDeviceError>;
+    ) -> Result<WalletRegistration, HWIDeviceError>;
     async fn sign_tx(
         &mut self,
         psbt: Psbt,
@@ -224,10 +229,14 @@ where
         }
     }
 
-    async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<[u8; 32], Self::Error> {
+    async fn register_wallet(
+        &mut self,
+        name: &str,
+        policy: &str,
+    ) -> Result<WalletRegistration, Self::Error> {
         let wallet_policy = WalletPolicy::from_str(policy)
             .map_err(|e| common::Error::Serialization(e.to_string()))?;
-        if let common::Response::WalletHmac(hmac) = run_command(
+        if let common::Response::WalletRegistration(registration) = run_command(
             self,
             common::Command::RegisterWallet {
                 name: name.to_string(),
@@ -236,7 +245,7 @@ where
         )
         .await?
         {
-            Ok(hmac)
+            Ok(registration)
         } else {
             Err(common::Error::NoErrorOrResult.into())
         }
@@ -317,7 +326,7 @@ where
         &mut self,
         name: &str,
         policy: &str,
-    ) -> Result<[u8; 32], HWIDeviceError> {
+    ) -> Result<WalletRegistration, HWIDeviceError> {
         HWI::register_wallet(self, name, policy)
             .await
             .map_err(HWIDeviceError::new)

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
-use bhwi_async::{DeviceBackup, DeviceContext};
+use bhwi_async::{DeviceBackup, DeviceContext, WalletRegistration};
 use bhwi_cli::{
     DeviceManager, OutputFormat, address::AddressTarget, config::DeviceSelector,
     get_descriptors::GetKeypoolOptions,
@@ -332,8 +332,29 @@ async fn main() -> Result<()> {
         }
         Commands::RegisterWallet { name, descriptor } => {
             if let Some(mut d) = dev_man.get_device_with_fingerprint().await? {
-                let hmac = d.device().register_wallet(&name, &descriptor).await?;
-                println!("{}", hex::encode(hmac));
+                let registration = d.device().register_wallet(&name, &descriptor).await?;
+                match format {
+                    Some(OutputFormat::Json) => {
+                        let (status, hmac) = match registration {
+                            WalletRegistration::Complete { hmac } => {
+                                ("complete", hmac.map(hex::encode))
+                            }
+                            WalletRegistration::PendingUserConfirmation => {
+                                ("pending_user_confirmation", None)
+                            }
+                        };
+                        println!("{}", serde_json::json!({ "status": status, "hmac": hmac }));
+                    }
+                    _ => match registration {
+                        WalletRegistration::Complete { hmac: Some(hmac) } => {
+                            println!("{}", hex::encode(hmac));
+                        }
+                        WalletRegistration::Complete { hmac: None } => {}
+                        WalletRegistration::PendingUserConfirmation => {
+                            eprintln!("Wallet registration is pending confirmation on the device.");
+                        }
+                    },
+                }
             }
         }
         Commands::SignPsbt {

--- a/bhwi-wasm/src/lib.rs
+++ b/bhwi-wasm/src/lib.rs
@@ -11,8 +11,8 @@ use bhwi::ledger::{LedgerWalletPolicy, Version};
 use bhwi::miniscript::descriptor::WalletPolicy;
 use bhwi::{coldcard::COLDCARD_DEVICE_ID, ledger::LEDGER_DEVICE_ID};
 use bhwi_async::{
-    DeviceContext, DisplayAddress, HWI as AsyncHWI, Jade, Ledger, bitbox::BitBox,
-    coldcard::Coldcard, transport::bitbox::hid::BitBoxTransportHID,
+    DeviceContext, DisplayAddress, HWI as AsyncHWI, Jade, Ledger, WalletRegistration,
+    bitbox::BitBox, coldcard::Coldcard, transport::bitbox::hid::BitBoxTransportHID,
     transport::coldcard::hid::ColdcardTransportHID, transport::ledger::hid::LedgerTransportHID,
 };
 use bitcoin::{Network, address::AddressType, bip32::DerivationPath};
@@ -31,6 +31,21 @@ pub fn initialize_logging(level: &str) {
     console_log::init_with_level(log_level).expect("error initializing log");
 }
 
+fn wallet_registration_js(registration: WalletRegistration) -> Result<JsValue, JsValue> {
+    let result = js_sys::Object::new();
+    let (status, hmac) = match registration {
+        WalletRegistration::Complete { hmac } => (
+            "complete",
+            hmac.map(|value| JsValue::from_str(&hex::encode(value)))
+                .unwrap_or(JsValue::NULL),
+        ),
+        WalletRegistration::PendingUserConfirmation => ("pending_user_confirmation", JsValue::NULL),
+    };
+    js_sys::Reflect::set(&result, &"status".into(), &JsValue::from_str(status))?;
+    js_sys::Reflect::set(&result, &"hmac".into(), &hmac)?;
+    Ok(result.into())
+}
+
 #[async_trait(?Send)]
 pub trait HWI {
     async fn unlock(&mut self, network: &str) -> Result<(), JsValue>;
@@ -41,7 +56,11 @@ pub trait HWI {
         address: DisplayAddress,
         context: Option<DeviceContext>,
     ) -> Result<String, JsValue>;
-    async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<Vec<u8>, JsValue>;
+    async fn register_wallet(
+        &mut self,
+        name: &str,
+        policy: &str,
+    ) -> Result<WalletRegistration, JsValue>;
     async fn get_info(&mut self) -> Result<JsValue, JsValue>;
 }
 
@@ -80,10 +99,13 @@ impl<T: AsyncHWI> HWI for T {
             .map_err(|e| JsValue::from_str(&format!("Failed to display address: {:?}", e)))
     }
 
-    async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<Vec<u8>, JsValue> {
+    async fn register_wallet(
+        &mut self,
+        name: &str,
+        policy: &str,
+    ) -> Result<WalletRegistration, JsValue> {
         AsyncHWI::register_wallet(self, name, policy)
             .await
-            .map(|hmac| hmac.to_vec())
             .map_err(|e| JsValue::from_str(&format!("Failed to register wallet: {:?}", e)))
     }
 
@@ -260,26 +282,12 @@ impl Client {
     }
 
     #[wasm_bindgen]
-    pub async fn register_wallet(
-        &mut self,
-        name: &str,
-        policy: &str,
-    ) -> Result<Option<String>, JsValue> {
-        match &mut self.device {
-            Some(Device::Ledger(l)) => {
-                let hmac = AsyncHWI::register_wallet(l, name, policy)
-                    .await
-                    .map_err(|e| {
-                        JsValue::from_str(&format!("Failed to register wallet: {:?}", e))
-                    })?;
-                Ok(Some(hex::encode(hmac)))
-            }
-            Some(d) => {
-                d.as_mut().register_wallet(name, policy).await?;
-                Ok(None)
-            }
+    pub async fn register_wallet(&mut self, name: &str, policy: &str) -> Result<JsValue, JsValue> {
+        let registration = match &mut self.device {
+            Some(d) => d.as_mut().register_wallet(name, policy).await,
             None => Err(JsValue::from_str("Device not connected")),
-        }
+        }?;
+        wallet_registration_js(registration)
     }
 
     #[wasm_bindgen]

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -1100,7 +1100,11 @@ impl From<BitBoxResponse> for Response {
             BitBoxResponse::Xpub(xpub) => Response::Xpub(xpub),
             BitBoxResponse::Address(addr) => Response::Address(addr),
             BitBoxResponse::IsRegistered(_) => Response::TaskDone,
-            BitBoxResponse::Registered => Response::WalletHmac([0u8; 32]),
+            BitBoxResponse::Registered => {
+                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
+                    hmac: None,
+                })
+            }
             BitBoxResponse::SignedPsbt(psbt) => Response::SignedPsbt(*psbt),
             BitBoxResponse::Signature(header, sig) => Response::Signature(header, sig),
             BitBoxResponse::Backup => Response::Backup(DeviceBackup::Complete),

--- a/bhwi/src/coldcard/api.rs
+++ b/bhwi/src/coldcard/api.rs
@@ -105,6 +105,13 @@ pub mod request {
         rv
     }
 
+    pub fn multisig_enroll(length: u32, file_sha: &[u8; 32]) -> Vec<u8> {
+        let mut data = b"enrl".to_vec();
+        data.extend(length.to_le_bytes());
+        data.extend(file_sha);
+        data
+    }
+
     pub fn get_signed_transaction() -> Vec<u8> {
         b"stok".to_vec()
     }
@@ -155,6 +162,15 @@ mod tests {
         assert_eq!(u32::from_le_bytes(req[4..8].try_into().unwrap()), 99);
         assert_eq!(u32::from_le_bytes(req[8..12].try_into().unwrap()), 0);
         assert_eq!(&req[12..], &hash);
+    }
+
+    #[test]
+    fn multisig_enroll_request_encodes_length_and_hash() {
+        let hash = [4u8; 32];
+        let req = super::request::multisig_enroll(321, &hash);
+        assert_eq!(&req[..4], b"enrl");
+        assert_eq!(u32::from_le_bytes(req[4..8].try_into().unwrap()), 321);
+        assert_eq!(&req[8..], &hash);
     }
 
     #[test]
@@ -386,6 +402,10 @@ pub mod response {
                 &[ResponseMessage::Okay, ResponseMessage::Busy],
             )),
         }
+    }
+
+    pub fn okay(res: &[u8]) -> Result<(), ColdcardError> {
+        ResponseHandler::expect_response(res, ResponseMessage::Okay).map(|_| ())
     }
 
     pub fn signed_transaction(res: &[u8]) -> Result<SignedTransactionStatus, ColdcardError> {

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -7,6 +7,10 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
+use miniscript::{
+    Descriptor, Miniscript, ScriptContext, Terminal,
+    descriptor::{DescriptorPublicKey, ShInner, WalletPolicy, Wildcard},
+};
 
 use crate::Interpreter;
 use crate::coldcard::api::response::ResponseMessage;
@@ -35,6 +39,9 @@ pub enum ColdcardError {
     /// Serialization error
     #[error("serialization error: {0}")]
     Serialization(String),
+
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 
     /// Unexpected response message from device
     #[error("unexpected response message: got {got:?}, expected {expected:?}")]
@@ -78,6 +85,9 @@ pub enum ColdcardCommand {
     SignPsbt {
         psbt: Psbt,
     },
+    RegisterWallet {
+        payload: Vec<u8>,
+    },
 }
 
 pub enum ColdcardResponse {
@@ -98,6 +108,7 @@ pub enum ColdcardResponse {
     Address(String),
     Backup(Vec<u8>),
     SignedPsbt(Psbt),
+    WalletRegistrationPending,
 }
 
 pub struct ColdcardTransmit {
@@ -108,15 +119,18 @@ pub struct ColdcardTransmit {
 enum State {
     New,
     Running(ColdcardCommand),
-    UploadingPsbt {
+    UploadingFile {
         bytes: Vec<u8>,
         offset: usize,
+        action: UploadAction,
     },
-    VerifyingPsbtUpload {
+    VerifyingFileUpload {
         length: usize,
         expected_sha: [u8; 32],
+        action: UploadAction,
     },
     SigningPsbt,
+    EnrollingWallet,
     PollingSignedPsbt,
     PollingBackupFile,
     DownloadingFile {
@@ -128,6 +142,12 @@ enum State {
         total_len: usize,
     },
     Finished(ColdcardResponse),
+}
+
+#[derive(Clone, Copy)]
+enum UploadAction {
+    SignPsbt,
+    RegisterWallet,
 }
 
 enum FileDownloadResponse {
@@ -161,12 +181,12 @@ fn request(
     })
 }
 
-fn psbt_upload_request(bytes: &[u8], offset: usize) -> Result<Vec<u8>, ColdcardError> {
+fn file_upload_request(bytes: &[u8], offset: usize) -> Result<Vec<u8>, ColdcardError> {
     let end = (offset + api::request::MAX_UPLOAD_CHUNK_LEN).min(bytes.len());
     let offset = u32::try_from(offset)
         .map_err(|_| ColdcardError::Serialization("upload offset too large".to_string()))?;
     let total = u32::try_from(bytes.len())
-        .map_err(|_| ColdcardError::Serialization("psbt too large".to_string()))?;
+        .map_err(|_| ColdcardError::Serialization("upload too large".to_string()))?;
     Ok(api::request::upload(
         offset,
         total,
@@ -231,8 +251,22 @@ where
             )?,
             ColdcardCommand::SignPsbt { psbt } => {
                 let bytes = psbt.serialize();
-                let req = request(psbt_upload_request(&bytes, 0)?, self.encryption)?;
-                self.state = State::UploadingPsbt { bytes, offset: 0 };
+                let req = request(file_upload_request(&bytes, 0)?, self.encryption)?;
+                self.state = State::UploadingFile {
+                    bytes,
+                    offset: 0,
+                    action: UploadAction::SignPsbt,
+                };
+                return Ok(req.into());
+            }
+            ColdcardCommand::RegisterWallet { payload } => {
+                let bytes = payload.clone();
+                let req = request(file_upload_request(&bytes, 0)?, self.encryption)?;
+                self.state = State::UploadingFile {
+                    bytes,
+                    offset: 0,
+                    action: UploadAction::RegisterWallet,
+                };
                 return Ok(req.into());
             }
         };
@@ -296,7 +330,14 @@ where
                 Ok(None)
             }
             State::Running(ColdcardCommand::SignPsbt { .. }) => unreachable!("handled in start"),
-            State::UploadingPsbt { bytes, offset } => {
+            State::Running(ColdcardCommand::RegisterWallet { .. }) => {
+                unreachable!("handled in start")
+            }
+            State::UploadingFile {
+                bytes,
+                offset,
+                action,
+            } => {
                 let data = self.encryption.decrypt(data)?;
                 let acknowledged = api::response::upload(&data)? as usize;
                 if acknowledged != *offset {
@@ -308,24 +349,26 @@ where
 
                 let next_offset = (*offset + api::request::MAX_UPLOAD_CHUNK_LEN).min(bytes.len());
                 if next_offset < bytes.len() {
-                    let req = request(psbt_upload_request(bytes, next_offset)?, self.encryption)?;
+                    let req = request(file_upload_request(bytes, next_offset)?, self.encryption)?;
                     *offset = next_offset;
                     return Ok(Some(req.into()));
                 }
 
                 let length = bytes.len();
                 let expected_sha = sha256::Hash::hash(bytes).to_byte_array();
-                self.state = State::VerifyingPsbtUpload {
+                self.state = State::VerifyingFileUpload {
                     length,
                     expected_sha,
+                    action: *action,
                 };
                 Ok(Some(
                     request(api::request::sha256(), self.encryption)?.into(),
                 ))
             }
-            State::VerifyingPsbtUpload {
+            State::VerifyingFileUpload {
                 length,
                 expected_sha,
+                action,
             } => {
                 let data = self.encryption.decrypt(data)?;
                 let length = *length;
@@ -339,15 +382,18 @@ where
                 }
 
                 let length = u32::try_from(length)
-                    .map_err(|_| ColdcardError::Serialization("psbt too large".to_string()))?;
-                self.state = State::SigningPsbt;
-                Ok(Some(
-                    request(
-                        api::request::sign_transaction(length, &expected_sha),
-                        self.encryption,
-                    )?
-                    .into(),
-                ))
+                    .map_err(|_| ColdcardError::Serialization("upload too large".to_string()))?;
+                let request_payload = match action {
+                    UploadAction::SignPsbt => {
+                        self.state = State::SigningPsbt;
+                        api::request::sign_transaction(length, &expected_sha)
+                    }
+                    UploadAction::RegisterWallet => {
+                        self.state = State::EnrollingWallet;
+                        api::request::multisig_enroll(length, &expected_sha)
+                    }
+                };
+                Ok(Some(request(request_payload, self.encryption)?.into()))
             }
             State::SigningPsbt => {
                 let data = self.encryption.decrypt(data)?;
@@ -358,6 +404,12 @@ where
                         request(api::request::get_signed_transaction(), self.encryption)?.into(),
                     ));
                 }
+                Ok(None)
+            }
+            State::EnrollingWallet => {
+                let data = self.encryption.decrypt(data)?;
+                api::response::okay(&data)?;
+                self.state = State::Finished(ColdcardResponse::WalletRegistrationPending);
                 Ok(None)
             }
             State::PollingSignedPsbt => {
@@ -516,9 +568,9 @@ impl TryFrom<Command> for ColdcardCommand {
                 change,
                 index,
             }),
-            Command::RegisterWallet { .. } => Err(ColdcardError::MissingCommandInfo(
-                "RegisterWallet not supported by Coldcard",
-            )),
+            Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
+                payload: coldcard_registration_payload(&name, &policy)?,
+            }),
             Command::SignTx(psbt, context) => {
                 if context.is_some() {
                     return Err(ColdcardError::MissingCommandInfo(
@@ -528,6 +580,114 @@ impl TryFrom<Command> for ColdcardCommand {
                 Ok(Self::SignPsbt { psbt })
             }
         }
+    }
+}
+
+fn coldcard_registration_payload(
+    name: &str,
+    policy: &WalletPolicy,
+) -> Result<Vec<u8>, ColdcardError> {
+    if !(2..=20).contains(&name.len())
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
+    {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard wallet names must be 2 to 20 printable ASCII characters".to_string(),
+        ));
+    }
+
+    let descriptor = policy
+        .clone()
+        .into_descriptor()
+        .map_err(|error| ColdcardError::InvalidInput(error.to_string()))?;
+    let (threshold, signer_count) = coldcard_sortedmulti_size(&descriptor).ok_or_else(|| {
+        ColdcardError::InvalidInput(
+            "Coldcard registration supports only sh(sortedmulti), wsh(sortedmulti), and sh(wsh(sortedmulti)) descriptors"
+                .to_string(),
+        )
+    })?;
+    if threshold == 0 || threshold > signer_count || signer_count > 15 {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard multisig policies require 1 to 15 signers and a valid threshold".to_string(),
+        ));
+    }
+    for key in descriptor.iter_pk() {
+        validate_coldcard_registration_key(&key)?;
+    }
+
+    let descriptor = format!("{descriptor:#}");
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "name": name,
+        "desc": descriptor,
+    }))
+    .map_err(|error| ColdcardError::Serialization(error.to_string()))?;
+    if !(101..=4000).contains(&payload.len()) {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard multisig registration payload must be 101 to 4000 bytes".to_string(),
+        ));
+    }
+    Ok(payload)
+}
+
+fn coldcard_sortedmulti_size(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+) -> Option<(usize, usize)> {
+    match descriptor {
+        Descriptor::Sh(sh) => match sh.as_inner() {
+            ShInner::Ms(miniscript) => sortedmulti_size(miniscript),
+            ShInner::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
+            ShInner::Wpkh(_) => None,
+        },
+        Descriptor::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
+        _ => None,
+    }
+}
+
+fn sortedmulti_size<Ctx: ScriptContext>(
+    miniscript: &Miniscript<DescriptorPublicKey, Ctx>,
+) -> Option<(usize, usize)> {
+    match &miniscript.node {
+        Terminal::SortedMulti(threshold) => Some((threshold.k(), threshold.n())),
+        _ => None,
+    }
+}
+
+fn validate_coldcard_registration_key(key: &DescriptorPublicKey) -> Result<(), ColdcardError> {
+    let normal = |index| bitcoin::bip32::ChildNumber::from_normal_idx(index).expect("small index");
+    let valid_single_path = |path: &DerivationPath| path.as_ref() == [normal(0)];
+    let valid_multi_paths = |paths: &[DerivationPath]| {
+        if paths.len() != 2 || paths.iter().any(|path| path.as_ref().len() != 1) {
+            return false;
+        }
+        let mut branches = paths
+            .iter()
+            .map(|path| path.as_ref()[0])
+            .collect::<Vec<_>>();
+        branches.sort_unstable();
+        branches == [normal(0), normal(1)]
+    };
+
+    let valid = match key {
+        DescriptorPublicKey::XPub(key) => {
+            key.origin.is_some()
+                && key.wildcard == Wildcard::Unhardened
+                && valid_single_path(&key.derivation_path)
+        }
+        DescriptorPublicKey::MultiXPub(key) => {
+            key.origin.is_some()
+                && key.wildcard == Wildcard::Unhardened
+                && valid_multi_paths(key.derivation_paths.paths())
+        }
+        DescriptorPublicKey::Single(_) => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(ColdcardError::InvalidInput(
+            "Coldcard multisig keys require origins, extended public keys, and /0/* or /<0;1>/* derivation"
+                .to_string(),
+        ))
     }
 }
 
@@ -555,6 +715,9 @@ impl From<ColdcardResponse> for Response {
             ColdcardResponse::Address(address) => Response::Address(address),
             ColdcardResponse::Backup(bytes) => Response::Backup(DeviceBackup::File(bytes)),
             ColdcardResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
+            ColdcardResponse::WalletRegistrationPending => Response::WalletRegistration(
+                crate::common::WalletRegistration::PendingUserConfirmation,
+            ),
         }
     }
 }
@@ -576,6 +739,7 @@ impl From<ColdcardError> for Error {
             ColdcardError::MissingCommandInfo(e) => Error::MissingCommandInfo(e),
             ColdcardError::NoErrorOrResult => Error::NoErrorOrResult,
             ColdcardError::Serialization(s) => Error::Serialization(s),
+            ColdcardError::InvalidInput(s) => Error::InvalidInput(s),
             ColdcardError::UnexpectedResponseMessage { got, expected } => Error::unexpected_result(
                 format!("{got:?}").into_bytes(),
                 format!("coldcard unexpected response: expected {expected:?}, got {got:?}"),
@@ -592,9 +756,13 @@ impl From<FromUtf8Error> for ColdcardError {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use bitcoin::hashes::{Hash, sha256};
 
     use super::*;
+
+    const REGISTRATION_POLICY: &str = "wsh(sortedmulti(2,[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))";
 
     fn paired_engines() -> (encrypt::Engine, encrypt::Engine) {
         let mut host = encrypt::Engine::New(k256::SecretKey::from_slice(&[1u8; 32]).unwrap());
@@ -667,5 +835,95 @@ mod tests {
             Response::Backup(DeviceBackup::File(bytes)) => assert_eq!(bytes, backup),
             _ => panic!("expected backup response"),
         }
+    }
+
+    #[test]
+    fn registration_payload_contains_name_and_full_descriptor() {
+        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
+        let payload = coldcard_registration_payload("cold-wallet", &policy).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(payload["name"], "cold-wallet");
+        assert_eq!(payload["desc"], REGISTRATION_POLICY);
+    }
+
+    #[test]
+    fn registration_rejects_unsupported_policy_and_name() {
+        let singlesig = WalletPolicy::from_str(
+            "wpkh([f5acc2fd/84'/1'/0']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*)",
+        )
+        .unwrap();
+        let error = coldcard_registration_payload("cold-wallet", &singlesig).unwrap_err();
+        assert!(error.to_string().contains("supports only"));
+
+        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
+        let error = coldcard_registration_payload("x", &policy).unwrap_err();
+        assert!(error.to_string().contains("2 to 20"));
+    }
+
+    #[test]
+    fn registration_rejects_keys_without_origins() {
+        let policy = WalletPolicy::from_str(
+            "wsh(sortedmulti(2,tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))",
+        )
+        .unwrap();
+        let error = coldcard_registration_payload("cold-wallet", &policy).unwrap_err();
+        assert!(error.to_string().contains("require origins"));
+    }
+
+    #[test]
+    fn register_wallet_uploads_verifies_and_starts_enrollment() {
+        let (mut host, mut device) = paired_engines();
+        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
+        let mut interpreter: ColdcardInterpreter<'_, Command, Transmit, Response, Error> =
+            ColdcardInterpreter::new(&mut host);
+
+        let request = interpreter
+            .start(Command::RegisterWallet {
+                name: "cold-wallet".to_string(),
+                policy,
+            })
+            .unwrap();
+        let upload = decrypt_request(&mut device, request);
+        assert_eq!(&upload[..4], b"upld");
+        assert_eq!(u32::from_le_bytes(upload[4..8].try_into().unwrap()), 0);
+        let total_len = u32::from_le_bytes(upload[8..12].try_into().unwrap()) as usize;
+        let uploaded = &upload[12..];
+        assert_eq!(uploaded.len(), total_len);
+
+        let mut acknowledged = b"int1".to_vec();
+        acknowledged.extend(0u32.to_le_bytes());
+        let request = interpreter
+            .exchange(encrypt_response(&mut device, &acknowledged))
+            .unwrap()
+            .expect("sha request");
+        assert_eq!(decrypt_request(&mut device, request), b"sha2");
+
+        let upload_sha = sha256::Hash::hash(uploaded).to_byte_array();
+        let mut sha_response = b"biny".to_vec();
+        sha_response.extend(upload_sha);
+        let request = interpreter
+            .exchange(encrypt_response(&mut device, &sha_response))
+            .unwrap()
+            .expect("enrollment request");
+        let enroll = decrypt_request(&mut device, request);
+        assert_eq!(&enroll[..4], b"enrl");
+        assert_eq!(
+            u32::from_le_bytes(enroll[4..8].try_into().unwrap()),
+            total_len as u32
+        );
+        assert_eq!(&enroll[8..], &upload_sha);
+
+        assert!(
+            interpreter
+                .exchange(encrypt_response(&mut device, b"okay"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(matches!(
+            interpreter.end().unwrap(),
+            Response::WalletRegistration(
+                crate::common::WalletRegistration::PendingUserConfirmation
+            )
+        ));
     }
 }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -141,6 +141,9 @@ pub enum Error {
     #[error("serialization error: {0}")]
     Serialization(String),
 
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
     #[error("request error: {0}")]
     Request(&'static str),
 

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -78,7 +78,22 @@ pub enum Response {
     Signature(u8, Signature),
     SignedPsbt(Psbt),
     Address(String),
-    WalletHmac([u8; 32]),
+    WalletRegistration(WalletRegistration),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WalletRegistration {
+    Complete { hmac: Option<[u8; 32]> },
+    PendingUserConfirmation,
+}
+
+impl WalletRegistration {
+    pub fn hmac(self) -> Option<[u8; 32]> {
+        match self {
+            Self::Complete { hmac } => hmac,
+            Self::PendingUserConfirmation => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -46,6 +47,11 @@ pub enum JadeCommand {
     GetInfo,
     GetXpub(DerivationPath),
     GetReceiveAddress(ReceiveAddress),
+    RegisterDescriptor {
+        descriptor_name: String,
+        descriptor: String,
+        datavalues: BTreeMap<String, String>,
+    },
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
@@ -74,6 +80,7 @@ pub enum JadeResponse {
     TaskDone,
     Xpub(Xpub),
     Address(String),
+    RegisteredDescriptor,
     SignedPsbt(Psbt),
 }
 
@@ -245,6 +252,19 @@ where
                     }),
                 ),
             },
+            JadeCommand::RegisterDescriptor {
+                descriptor_name,
+                descriptor,
+                datavalues,
+            } => request(
+                "register_descriptor",
+                Some(api::RegisterDescriptorParams {
+                    network: self.network,
+                    descriptor_name,
+                    descriptor: descriptor.clone(),
+                    datavalues: datavalues.clone(),
+                }),
+            ),
             JadeCommand::GetInfo => request("get_version_info", None::<api::EmptyRequest>),
         };
 
@@ -404,6 +424,17 @@ where
                 response = Some(JadeResponse::Address(address));
                 None
             }
+            State::Running(JadeCommand::RegisterDescriptor { .. }) => {
+                let registered: bool = from_response(&data)?.into_result()?;
+                if !registered {
+                    return Err(JadeError::UnexpectedResult(
+                        "register_descriptor returned false".to_string(),
+                    )
+                    .into());
+                }
+                response = Some(JadeResponse::RegisteredDescriptor);
+                None
+            }
             State::Running(JadeCommand::GetInfo) => {
                 let info: GetInfoResponse = from_response(&data)?.into_result()?;
                 response = Some(JadeResponse::GetInfo(info));
@@ -461,9 +492,23 @@ impl TryFrom<Command> for JadeCommand {
             })),
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetInfo),
-            Command::RegisterWallet { .. } => Err(Error::MissingCommandInfo(
-                "RegisterWallet not supported by Jade",
-            )),
+            Command::RegisterWallet { name, policy } => {
+                let (descriptor, keys) = crate::policy::extract_parts(&policy)
+                    .map_err(|err| Error::Serialization(err.to_string()))?;
+                // Jade's descriptor parser uses the explicit multipath spelling,
+                // while BIP-388 WalletPolicy display canonicalizes it to `/**`.
+                let descriptor = descriptor.replace("/**", "/<0;1>/*");
+                let datavalues = keys
+                    .iter()
+                    .enumerate()
+                    .map(|(index, key)| (format!("@{index}"), crate::policy::format_key_info(key)))
+                    .collect();
+                Ok(Self::RegisterDescriptor {
+                    descriptor_name: name,
+                    descriptor,
+                    datavalues,
+                })
+            }
             Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
         }
     }
@@ -496,6 +541,11 @@ impl From<JadeResponse> for Response {
                 firmware: None,
             }),
             JadeResponse::Address(address) => Response::Address(address),
+            JadeResponse::RegisteredDescriptor => {
+                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
+                    hmac: None,
+                })
+            }
             JadeResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
         }
     }
@@ -544,6 +594,7 @@ mod tests {
     use super::*;
     use crate::Interpreter;
     use crate::common::{Command, DisplayAddress, JadeInterpreter};
+    use crate::miniscript::descriptor::WalletPolicy;
     use serde::Deserialize;
 
     #[derive(Debug, Deserialize)]
@@ -558,6 +609,22 @@ mod tests {
         path: Vec<u32>,
         variant: String,
     }
+
+    #[derive(Debug, Deserialize)]
+    struct OwnedRegistrationRequest {
+        method: String,
+        params: Option<OwnedRegistrationParams>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct OwnedRegistrationParams {
+        network: String,
+        descriptor_name: String,
+        descriptor: String,
+        datavalues: BTreeMap<String, String>,
+    }
+
+    const REGISTRATION_POLICY: &str = "wsh(or_d(pk([f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*),and_v(v:pkh([00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*),older(100))))";
 
     #[test]
     fn path_display_request_encodes_jade_path_params() {
@@ -596,5 +663,91 @@ mod tests {
         ));
 
         assert!(matches!(result, Err(Error::UnsupportedDisplayAddress(_))));
+    }
+
+    #[test]
+    fn register_wallet_encodes_jade_descriptor_params() {
+        let mut interpreter = JadeInterpreter::default().with_network(Network::Testnet);
+        let transmit = interpreter
+            .start(Command::RegisterWallet {
+                name: "inheritance".to_string(),
+                policy: WalletPolicy::from_str(REGISTRATION_POLICY).unwrap(),
+            })
+            .unwrap();
+
+        let request: OwnedRegistrationRequest = serde_cbor::from_slice(&transmit.payload).unwrap();
+        let params = request.params.unwrap();
+        assert_eq!(request.method, "register_descriptor");
+        assert_eq!(params.network, JADE_NETWORK_TESTNET);
+        assert_eq!(params.descriptor_name, "inheritance");
+        assert_eq!(
+            params.descriptor,
+            "wsh(or_d(pk(@0/<0;1>/*),and_v(v:pkh(@1/<0;1>/*),older(100))))"
+        );
+        assert_eq!(params.datavalues.len(), 2);
+        assert_eq!(
+            params.datavalues.get("@0").unwrap(),
+            "[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP"
+        );
+        assert_eq!(
+            params.datavalues.get("@1").unwrap(),
+            "[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S"
+        );
+    }
+
+    #[test]
+    fn register_wallet_maps_true_to_completed_registration() {
+        let mut interpreter = JadeInterpreter::default();
+        interpreter
+            .start(Command::RegisterWallet {
+                name: "inheritance".to_string(),
+                policy: WalletPolicy::from_str(REGISTRATION_POLICY).unwrap(),
+            })
+            .unwrap();
+        let response = serde_cbor::to_vec(&api::Response {
+            id: "1".to_string(),
+            seqlen: None,
+            seqnum: None,
+            result: Some(true),
+            error: None,
+        })
+        .unwrap();
+
+        assert!(interpreter.exchange(response).unwrap().is_none());
+        assert!(matches!(
+            interpreter.end().unwrap(),
+            Response::WalletRegistration(crate::common::WalletRegistration::Complete {
+                hmac: None
+            })
+        ));
+    }
+
+    #[test]
+    fn register_wallet_rejects_false_result() {
+        let mut interpreter = JadeInterpreter::default();
+        interpreter
+            .start(Command::RegisterWallet {
+                name: "inheritance".to_string(),
+                policy: WalletPolicy::from_str(REGISTRATION_POLICY).unwrap(),
+            })
+            .unwrap();
+        let response = serde_cbor::to_vec(&api::Response {
+            id: "1".to_string(),
+            seqlen: None,
+            seqnum: None,
+            result: Some(false),
+            error: None,
+        })
+        .unwrap();
+
+        let error = match interpreter.exchange(response) {
+            Err(error) => error,
+            Ok(_) => panic!("false registration result must fail"),
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("register_descriptor returned false")
+        );
     }
 }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -814,7 +814,11 @@ impl From<LedgerResponse> for Response {
             LedgerResponse::Xpub(xpub) => Response::Xpub(xpub),
             LedgerResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
             LedgerResponse::Address(address) => Response::Address(address),
-            LedgerResponse::WalletHmac(hmac) => Response::WalletHmac(hmac),
+            LedgerResponse::WalletHmac(hmac) => {
+                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
+                    hmac: Some(hmac),
+                })
+            }
             LedgerResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
         }
     }

--- a/e2e/cli/src/coldcard.rs
+++ b/e2e/cli/src/coldcard.rs
@@ -1,10 +1,19 @@
 use anyhow::{Context, Result, bail};
-use bhwi_async::{Transport, transport::coldcard::DEFAULT_CKCC_SOCKET};
+use bhwi_async::{
+    Transport,
+    transport::coldcard::{DEFAULT_CKCC_SOCKET, hid::ColdcardTransportHID},
+};
 use bhwi_cli::coldcard::emulator::EmulatorClient;
+use bitcoin::{
+    Network,
+    bip32::{DerivationPath, Xpriv, Xpub},
+    secp256k1::Secp256k1,
+};
 use std::{
     env, fs,
     path::PathBuf,
     process::{Command, Output, Stdio},
+    str::FromStr,
     time::Duration,
 };
 
@@ -71,6 +80,29 @@ fn coldcard_keypool_get() -> Result<()> {
             internal: false,
         },
     })
+}
+
+#[test]
+fn coldcard_register_wallet_reports_pending_and_persists() -> Result<()> {
+    let cli = Cli::for_device(COLDCARD_FINGERPRINT);
+    let account_path: DerivationPath = "48'/1'/0'/2'".parse()?;
+    let device_xpub = Xpub::from_str(cli.run_ok(["xpub", "get", "48'/1'/0'/2'"])?.trim())?;
+    let secp = Secp256k1::new();
+    let cosigner_master = Xpriv::new_master(Network::Testnet, &[10u8; 32])?;
+    let cosigner_fingerprint = cosigner_master.fingerprint(&secp);
+    let cosigner_xpriv = cosigner_master.derive_priv(&secp, &account_path)?;
+    let cosigner_xpub = Xpub::from_priv(&secp, &cosigner_xpriv);
+    let descriptor = format!(
+        "wsh(sortedmulti(2,[{COLDCARD_FINGERPRINT}/{account_path}]{device_xpub}/<0;1>/*,[{cosigner_fingerprint}/{account_path}]{cosigner_xpub}/<0;1>/*))"
+    );
+
+    let output = run_register_command(&descriptor)?;
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stderr)?,
+        "Wallet registration is pending confirmation on the device.\n"
+    );
+    Ok(())
 }
 
 #[test]
@@ -141,6 +173,87 @@ fn run_backup_command(output: &str) -> Result<Output> {
         bail!(
             "bhwi device backup failed with status {}\nstdout:\n{}\nstderr:\n{}",
             output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output)
+}
+
+fn run_register_command(descriptor: &str) -> Result<Output> {
+    let bin = env::var("BHWI_BIN").context("BHWI_BIN must point to the built bhwi binary")?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()?;
+    runtime.block_on(async {
+        let mut control =
+            ColdcardTransportHID::new(EmulatorClient::new(DEFAULT_CKCC_SOCKET).await?);
+        control
+            .exchange(b"EXECsettings.set('multisig', []); settings.save()", false)
+            .await?;
+        Ok::<_, anyhow::Error>(())
+    })?;
+
+    let mut child = Command::new(bin)
+        .args([
+            "--network",
+            "testnet",
+            "--fingerprint",
+            COLDCARD_FINGERPRINT,
+            "register-wallet",
+            "--name",
+            "cold-cli",
+            "--descriptor",
+            descriptor,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn bhwi register-wallet command")?;
+
+    let persisted = runtime.block_on(async {
+        let mut control =
+            ColdcardTransportHID::new(EmulatorClient::new(DEFAULT_CKCC_SOCKET).await?);
+        for _ in 0..240 {
+            if child.try_wait()?.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        if child.try_wait()?.is_none() {
+            let _ = child.kill();
+            bail!("timed out waiting for bhwi register-wallet acknowledgement");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        control.exchange(b"XKEYy", false).await?;
+        for _ in 0..40 {
+            let response = control
+                .exchange(b"EVALsettings.get('multisig', [])", false)
+                .await?;
+            if response
+                .strip_prefix(b"biny")
+                .is_some_and(|value| String::from_utf8_lossy(value).contains("cold-cli"))
+            {
+                return Ok(true);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        Ok::<_, anyhow::Error>(false)
+    })?;
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        bail!(
+            "bhwi register-wallet failed with status {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    if !persisted {
+        bail!(
+            "Coldcard multisig registration was not persisted\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );

--- a/e2e/cli/src/jade.rs
+++ b/e2e/cli/src/jade.rs
@@ -1,4 +1,11 @@
 use anyhow::Result;
+use bitcoin::{
+    Address, Network, PublicKey,
+    bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
+    blockdata::{opcodes, script::Builder},
+    secp256k1::Secp256k1,
+};
+use std::str::FromStr;
 
 use crate::support::{Cli, CommandCase, ExpectedOutput, assert_command};
 
@@ -92,6 +99,61 @@ fn jade_keypool_get() -> Result<()> {
             internal: false,
         },
     })
+}
+
+#[test]
+fn jade_register_wallet_and_descriptor_address() -> Result<()> {
+    let cli = Cli::for_device(JADE_FINGERPRINT);
+    let account_path: DerivationPath = "m/48'/1'/0'/2'".parse()?;
+    let device_xpub = Xpub::from_str(cli.run_ok(["xpub", "get", "m/48'/1'/0'/2'"])?.trim())?;
+    let secp = Secp256k1::new();
+    let cosigner_master = Xpriv::new_master(Network::Testnet, &[7u8; 32])?;
+    let cosigner_fingerprint = cosigner_master.fingerprint(&secp);
+    let cosigner_xpriv = cosigner_master.derive_priv(&secp, &account_path)?;
+    let cosigner_xpub = Xpub::from_priv(&secp, &cosigner_xpriv);
+    let descriptor = format!(
+        "wsh(sortedmulti(2,[{JADE_FINGERPRINT}/{account_path}]{device_xpub}/<0;1>/*,[{cosigner_fingerprint}/{account_path}]{cosigner_xpub}/<0;1>/*))"
+    );
+
+    let output = cli.run_ok([
+        "register-wallet",
+        "--name",
+        "jade-cli",
+        "--descriptor",
+        &descriptor,
+    ])?;
+    assert!(output.is_empty());
+
+    let address = cli.run_ok(["address", "get", "--from-descriptor", "jade-cli"])?;
+    assert_eq!(
+        address.trim(),
+        multisig_address(&secp, device_xpub, cosigner_xpub)
+    );
+    Ok(())
+}
+
+fn multisig_address(
+    secp: &Secp256k1<bitcoin::secp256k1::All>,
+    first: Xpub,
+    second: Xpub,
+) -> String {
+    let path = DerivationPath::from(vec![
+        ChildNumber::from_normal_idx(0).unwrap(),
+        ChildNumber::from_normal_idx(0).unwrap(),
+    ]);
+    let mut keys = [
+        first.derive_pub(secp, &path).unwrap().public_key,
+        second.derive_pub(secp, &path).unwrap().public_key,
+    ];
+    keys.sort_by_key(|key| key.serialize());
+    let script = Builder::new()
+        .push_int(2)
+        .push_key(&PublicKey::new(keys[0]))
+        .push_key(&PublicKey::new(keys[1]))
+        .push_int(2)
+        .push_opcode(opcodes::all::OP_CHECKMULTISIG)
+        .into_script();
+    Address::p2wsh(&script, Network::Testnet).to_string()
 }
 
 #[test]

--- a/e2e/coldcard/src/lib.rs
+++ b/e2e/coldcard/src/lib.rs
@@ -39,18 +39,39 @@ impl DeviceControl {
         }
         Ok(())
     }
+
+    pub async fn reset_multisig(&mut self) -> Result<()> {
+        self.client
+            .exchange(b"EXECsettings.set('multisig', []); settings.save()", false)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn multisig_settings(&mut self) -> Result<String> {
+        let response = self
+            .client
+            .exchange(b"EVALsettings.get('multisig', [])", false)
+            .await?;
+        let value = response
+            .strip_prefix(b"biny")
+            .ok_or_else(|| anyhow::anyhow!("unexpected Coldcard EVAL response"))?;
+        Ok(String::from_utf8(value.to_vec())?)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use base64ct::{Base64, Encoding};
-    use bhwi_async::{DeviceBackup, DisplayAddress, HWI, transport::coldcard::DEFAULT_CKCC_SOCKET};
+    use bhwi_async::{
+        DeviceBackup, DisplayAddress, HWI, WalletRegistration,
+        transport::coldcard::DEFAULT_CKCC_SOCKET,
+    };
     use bitcoin::{
         Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
         Witness,
         absolute::LockTime,
         address::Address,
-        bip32::{ChildNumber, DerivationPath},
+        bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
         psbt::{Input, Output, Psbt},
         secp256k1::Secp256k1,
         transaction::Version as TxVersion,
@@ -158,6 +179,49 @@ mod tests {
         // The simulator returns err_Unknown cmd for msas, so we expect an error.
         // On real hardware with a registered descriptor, this would succeed.
         assert!(display_res.is_err());
+    }
+
+    #[tokio::test]
+    async fn can_enroll_multisig_descriptor() {
+        let (mut dev, mut control) = device().await;
+        control.reset_multisig().await.unwrap();
+        let secp = Secp256k1::new();
+        let account_path: DerivationPath = "48'/1'/0'/2'".parse().unwrap();
+        let device_fingerprint = dev.get_master_fingerprint().await.unwrap();
+        let device_xpub = dev
+            .get_extended_pubkey(account_path.clone(), false)
+            .await
+            .unwrap();
+        let cosigner_master = Xpriv::new_master(Network::Testnet, &[9u8; 32]).unwrap();
+        let cosigner_fingerprint = cosigner_master.fingerprint(&secp);
+        let cosigner_xpriv = cosigner_master.derive_priv(&secp, &account_path).unwrap();
+        let cosigner_xpub = Xpub::from_priv(&secp, &cosigner_xpriv);
+        let policy = format!(
+            "wsh(sortedmulti(2,[{device_fingerprint}/{account_path}]{device_xpub}/<0;1>/*,[{cosigner_fingerprint}/{account_path}]{cosigner_xpub}/<0;1>/*))"
+        );
+
+        let registration = dev
+            .register_wallet("cold-e2e", &policy)
+            .await
+            .expect("start Coldcard enrollment");
+        assert_eq!(registration, WalletRegistration::PendingUserConfirmation);
+
+        control
+            .approve_after(std::time::Duration::from_millis(250))
+            .await
+            .unwrap();
+        for _ in 0..40 {
+            if control
+                .multisig_settings()
+                .await
+                .unwrap()
+                .contains("cold-e2e")
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        panic!("Coldcard multisig registration was not persisted");
     }
 
     #[tokio::test]

--- a/e2e/jade/src/lib.rs
+++ b/e2e/jade/src/lib.rs
@@ -2,14 +2,15 @@
 mod tests {
     use base64ct::{Base64, Encoding};
     use bhwi_async::transport::jade::tcp::TcpTransport;
-    use bhwi_async::{DisplayAddress, HWI};
+    use bhwi_async::{DisplayAddress, HWI, WalletRegistration};
     use bhwi_cli::jade::{JadeQemuDevice, PinServerClient, TcpClient};
     use bitcoin::{
         Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
         Witness,
         absolute::LockTime,
         address::{Address, AddressType},
-        bip32::{ChildNumber, DerivationPath},
+        bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
+        blockdata::{opcodes, script::Builder},
         psbt::{Input, Psbt},
         secp256k1::Secp256k1,
         transaction::Version as TxVersion,
@@ -114,6 +115,74 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(address, "2MsFo9x4kZMVumePtLZvjh9Hn9A98bS3MF6");
+    }
+
+    #[tokio::test]
+    async fn can_register_and_display_descriptor_address() {
+        let mut dev = device().await;
+        let secp = Secp256k1::new();
+        let account_path: DerivationPath = "m/48'/1'/0'/2'".parse().unwrap();
+        let device_fingerprint = dev.get_master_fingerprint().await.unwrap();
+        let device_xpub = dev
+            .get_extended_pubkey(account_path.clone(), false)
+            .await
+            .unwrap();
+        let cosigner_master = Xpriv::new_master(Network::Testnet, &[7u8; 32]).unwrap();
+        let cosigner_fingerprint = cosigner_master.fingerprint(&secp);
+        let cosigner_xpriv = cosigner_master.derive_priv(&secp, &account_path).unwrap();
+        let cosigner_xpub = Xpub::from_priv(&secp, &cosigner_xpriv);
+        let policy = format!(
+            "wsh(sortedmulti(2,[{device_fingerprint}/{account_path}]{device_xpub}/<0;1>/*,[{cosigner_fingerprint}/{account_path}]{cosigner_xpub}/<0;1>/*))"
+        );
+
+        let registration = dev
+            .register_wallet("jade-e2e", &policy)
+            .await
+            .expect("register Jade descriptor");
+        assert_eq!(registration, WalletRegistration::Complete { hmac: None });
+
+        let address = dev
+            .display_address(
+                DisplayAddress::ByDescriptor {
+                    index: 0,
+                    change: false,
+                    display: true,
+                    descriptor_name: "jade-e2e".to_string(),
+                },
+                None,
+            )
+            .await
+            .expect("display registered Jade descriptor address");
+        assert_eq!(
+            address,
+            multisig_address(&secp, device_xpub, cosigner_xpub, 0, 0)
+        );
+    }
+
+    fn multisig_address(
+        secp: &Secp256k1<bitcoin::secp256k1::All>,
+        first: Xpub,
+        second: Xpub,
+        branch: u32,
+        index: u32,
+    ) -> String {
+        let path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(branch).unwrap(),
+            ChildNumber::from_normal_idx(index).unwrap(),
+        ]);
+        let mut keys = [
+            first.derive_pub(secp, &path).unwrap().public_key,
+            second.derive_pub(secp, &path).unwrap().public_key,
+        ];
+        keys.sort_by_key(|key| key.serialize());
+        let script = Builder::new()
+            .push_int(2)
+            .push_key(&PublicKey::new(keys[0]))
+            .push_key(&PublicKey::new(keys[1]))
+            .push_int(2)
+            .push_opcode(opcodes::all::OP_CHECKMULTISIG)
+            .into_script();
+        Address::p2wsh(&script, Network::Testnet).to_string()
     }
 
     #[tokio::test]

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -186,7 +186,9 @@ mod tests {
         let hmac = dev
             .register_wallet(name, &policy_str)
             .await
-            .expect("failed to register wallet");
+            .expect("failed to register wallet")
+            .hmac()
+            .expect("ledger registration must return an HMAC");
         let wallet_policy = WalletPolicy::from_str(&policy_str).unwrap();
         let ledger_policy = LedgerWalletPolicy::new(name.to_string(), Version::V2, wallet_policy);
         let ctx = DeviceContext::Ledger {
@@ -306,7 +308,9 @@ mod tests {
         let hmac = dev
             .register_wallet(name, &policy)
             .await
-            .expect("failed to register psbt wallet");
+            .expect("failed to register psbt wallet")
+            .hmac()
+            .expect("ledger registration must return an HMAC");
 
         client
             .set_automation(

--- a/e2e/ledger/src/multisig.rs
+++ b/e2e/ledger/src/multisig.rs
@@ -138,7 +138,12 @@ async fn register(
         include_str!("../automations/register_wallet_accept.json"),
     )
     .await;
-    let hmac = dev.register_wallet(name, policy).await.unwrap();
+    let hmac = dev
+        .register_wallet(name, policy)
+        .await
+        .unwrap()
+        .hmac()
+        .expect("ledger registration must return an HMAC");
     assert_eq!(hmac.len(), 32);
     DeviceContext::Ledger {
         wallet_policy: LedgerWalletPolicy::new(

--- a/flake.nix
+++ b/flake.nix
@@ -151,7 +151,7 @@
             name = "bhwi-website";
             src = ./website;
             nodejs = nodejs_20;
-            npmDepsHash = "sha256-N2Uxh6567ry8CSZyBWWIg8yDJEqQXFtToKi4hVBr8Hk=";
+            npmDepsHash = "sha256-B+hl2uXdXBV9N99+RDSRzwO4xvpr8l+l2RU7MO2OyWA=";
             postPatch = ''
               cp -rL --no-preserve=mode,ownership ${bhwi-wasm-pkg} pkg
             '';

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -40,6 +40,12 @@ const ADDRESS_FORMAT_PURPOSE: Record<AddressFormat, number> = {
 interface RegisterWalletResult {
     name: string;
     policy: string;
+    status: 'complete' | 'pending_user_confirmation';
+    hmac: string | null;
+}
+
+interface WalletRegistration {
+    status: 'complete' | 'pending_user_confirmation';
     hmac: string | null;
 }
 
@@ -247,8 +253,13 @@ const App = () => {
         setRegisteringWallet(true);
         setProcessing(true);
         try {
-            const hmac = await device.client.register_wallet(walletName, walletPolicy);
-            setRegisterWalletResults(prev => [{ name: walletName, policy: walletPolicy, hmac: hmac ?? null }, ...prev]);
+            const registration = await device.client.register_wallet(walletName, walletPolicy) as WalletRegistration;
+            setRegisterWalletResults(prev => [{
+                name: walletName,
+                policy: walletPolicy,
+                status: registration.status,
+                hmac: registration.hmac,
+            }, ...prev]);
         } catch (err) {
             const message = err instanceof Error ? err.message : typeof err === 'string' ? err : "Failed to register wallet";
             showError(message);
@@ -602,6 +613,9 @@ const App = () => {
                                             <div key={index} className="bg-gray-700/50 rounded-lg p-4">
                                                 <div className="text-sm text-gray-400 mb-1">{result.name}</div>
                                                 <div className="font-mono text-sm break-all mb-1">{result.policy}</div>
+                                                {result.status === 'pending_user_confirmation' && (
+                                                    <div className="text-sm text-amber-300">Pending device confirmation</div>
+                                                )}
                                                 {result.hmac && (
                                                     <div className="text-sm">
                                                         <span className="text-gray-400">HMAC: </span>


### PR DESCRIPTION
- Model wallet registration outcomes explicitly, including completed
  registrations without HMACs and registrations awaiting device
  confirmation.
- Add native Jade descriptor registration with descriptor-template
  conversion and emulator-backed address verification.
- Add restricted Coldcard multisig enrollment with descriptor,
  wallet-name, network, and payload validation.
- Added appropriate e2e tests for Jade and Coldcard
- Update CLI, WASM, website, Ledger, and BitBox consumers for the new
  registration result model.

Closes #57