### PR TITLE
feat: complete HWI parity 

### DIFF
--- a/.agents/runbooks/hwi-parity.md
+++ b/.agents/runbooks/hwi-parity.md
@@ -11,6 +11,11 @@ enumeration, command parsing, command output, or HWI status docs.
 - Parse unsupported Python HWI commands and return Python-HWI-shaped unsupported
   errors instead of clap parse errors.
 - Record every intentional divergence in `docs/HWI_PARITY.md`.
+- Treat the unmodified upstream HWI device suite as the final acceptance gate.
+  Do not patch upstream tests or add BHWI-owned skips.
+- Emulator compatibility changes authored by upstream HWI, such as
+  `test/data/coldcard-multisig.patch`, may be applied to an isolated emulator
+  build. Keep the normal emulator build unchanged.
 
 ## Local Foundation
 
@@ -38,6 +43,17 @@ failures.
 nix run .#hwi-parity-coldcard
 nix run .#hwi-parity-ledger
 nix run .#hwi-parity-jade
+nix run .#hwi-parity-bitbox
+```
+
+After focused and differential parity checks pass, stop any long-lived
+simulator and run the matching final gate:
+
+```sh
+nix run .#hwi-upstream-coldcard
+nix run .#hwi-upstream-ledger
+nix run .#hwi-upstream-jade
+nix run .#hwi-upstream-bitbox
 ```
 
 ## Adding A Parity Device
@@ -50,6 +66,8 @@ nix run .#hwi-parity-jade
 - Add the device to `e2e/hwi-parity` normalization.
 - Add command fixtures or device-specific assertions needed for the new device.
 - Wire the parity app into `.github/workflows/emulators.yml`.
+- Wire the tailored `hwi-upstream-<device>` app into the same CI job as its
+  final test step, after stopping the long-lived emulator.
 - Update `docs/HWI_PARITY.md` with status, known deviations, and validation
   evidence.
 
@@ -63,3 +81,6 @@ nix run .#hwi-parity-jade
   behavior in `flake.nix` before patching BHWI.
 - If the candidate fails only after selecting a device, classify the failure as
   parser, CLI selection, async device, transport, protocol, or emulator setup.
+- If the differential suite passes but the upstream gate fails, treat the
+  upstream case as a missing compatibility contract. Do not normalize it away
+  or add a local skip.

--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -72,6 +72,14 @@ jobs:
             cat bitbox-cli-e2e.log || true
             exit 1
           }
+      - name: Run HWI parity tests
+        run: |
+          set -o pipefail
+          nix run .#hwi-parity-bitbox -- -- --test-threads=1 2>&1 | tee bitbox-hwi-parity.log || {
+            bash nix/scripts/emit-gh-error-log.sh "BitBox HWI parity log" bitbox-hwi-parity.log
+            cat bitbox-hwi-parity.log || true
+            exit 1
+          }
       - name: BitBox logs
         if: always()
         run: |

--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -80,11 +80,13 @@ jobs:
             cat bitbox-hwi-parity.log || true
             exit 1
           }
-      - name: BitBox logs
+      - name: Stop BitBox simulator before upstream gate
+        run: bash nix/scripts/stop-emulator.sh bitbox.pid tcp localhost 15423 60
+      - name: Run upstream HWI BitBox02 suite
+        run: timeout 45m nix run .#hwi-upstream-bitbox
+      - name: Stop BitBox simulator
         if: always()
-        run: |
-          cat bitbox.log || true
-          if [ -f bitbox.pid ]; then kill "$(cat bitbox.pid)" || true; fi
+        run: bash nix/scripts/stop-emulator.sh bitbox.pid tcp localhost 15423 60
 
   coldcard-e2e:
     needs: nix-flake
@@ -114,7 +116,7 @@ jobs:
       - name: Run HWI parity tests
         run: |
           set -o pipefail
-          nix run .#hwi-parity-coldcard 2>&1 | tee coldcard-hwi-parity.log || {
+          nix run .#hwi-parity-coldcard -- -- --test-threads=1 2>&1 | tee coldcard-hwi-parity.log || {
             bash nix/scripts/emit-gh-error-log.sh "Coldcard HWI parity log" coldcard-hwi-parity.log
             cat coldcard-hwi-parity.log || true
             exit 1
@@ -135,11 +137,13 @@ jobs:
             cat coldcard-e2e.log || true
             exit 1
           }
-      - name: Coldcard logs
+      - name: Stop Coldcard simulator before upstream gate
+        run: bash nix/scripts/stop-emulator.sh coldcard.pid socket /tmp/ckcc-simulator.sock 60
+      - name: Run upstream HWI Coldcard suite
+        run: timeout 90m nix run .#hwi-upstream-coldcard
+      - name: Stop Coldcard simulator
         if: always()
-        run: |
-          cat coldcard.log || true
-          if [ -f coldcard.pid ]; then kill "$(cat coldcard.pid)" || true; fi
+        run: bash nix/scripts/stop-emulator.sh coldcard.pid socket /tmp/ckcc-simulator.sock 60
 
   ledger-e2e:
     needs: nix-flake
@@ -156,8 +160,13 @@ jobs:
             ledger-${{ runner.os }}-
       - name: Start Ledger Speculos
         run: |
-          nix run .#ledger > ledger.log 2>&1 &
-          echo $! > ledger.pid
+          rm -f ledger.pid
+          setsid bash -c 'echo "$$" > ledger.pid; exec nix run .#ledger' > ledger.log 2>&1 &
+          for _ in {1..100}; do
+            [[ -s ledger.pid ]] && break
+            sleep 0.1
+          done
+          test -s ledger.pid
           tail -n +1 -F ledger.log &
           echo $! > ledger-tail.pid
           bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
@@ -174,32 +183,142 @@ jobs:
       - name: Run HWI parity tests
         run: |
           set -o pipefail
-          nix run .#hwi-parity-ledger 2>&1 | tee ledger-hwi-parity.log || {
+          nix run .#hwi-parity-ledger -- -- --test-threads=1 2>&1 | tee ledger-hwi-parity.log || {
             bash nix/scripts/emit-gh-error-log.sh "Ledger HWI parity log" ledger-hwi-parity.log
             cat ledger-hwi-parity.log || true
             exit 1
           }
-      - name: Run Ledger CLI e2e
+      - name: Restart Ledger Speculos after HWI parity tests
+        run: |
+          bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
+          rm -f ledger.pid
+          setsid bash -c 'echo "$$" > ledger.pid; exec nix run .#ledger' > ledger.log 2>&1 &
+          for _ in {1..100}; do
+            [[ -s ledger.pid ]] && break
+            sleep 0.1
+          done
+          test -s ledger.pid
+          tail -n +1 -F ledger.log &
+          echo $! > ledger-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          bash nix/scripts/wait-for-port.sh localhost 5000 300 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger CLI e2e except PSBT signing
         run: |
           set -o pipefail
-          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --test-threads=1 2>&1 | tee ledger-cli-e2e.log || {
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger -- --skip ledger_sign_psbt --test-threads=1 2>&1 | tee ledger-cli-e2e.log || {
             bash nix/scripts/emit-gh-error-log.sh "Ledger CLI e2e log" ledger-cli-e2e.log
             cat ledger-cli-e2e.log || true
             exit 1
           }
-      - name: Run Ledger e2e
+      - name: Restart Ledger Speculos before PSBT CLI e2e
+        run: |
+          bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
+          rm -f ledger.pid
+          setsid bash -c 'echo "$$" > ledger.pid; exec nix run .#ledger' > ledger.log 2>&1 &
+          for _ in {1..100}; do
+            [[ -s ledger.pid ]] && break
+            sleep 0.1
+          done
+          test -s ledger.pid
+          tail -n +1 -F ledger.log &
+          echo $! > ledger-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          bash nix/scripts/wait-for-port.sh localhost 5000 300 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger PSBT CLI e2e
         run: |
           set -o pipefail
-          nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --test-threads=1 2>&1 | tee ledger-e2e.log || {
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#ledger -c cargo test -p bhwi-e2e-cli ledger_sign_psbt -- --test-threads=1 2>&1 | tee ledger-cli-psbt-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger PSBT CLI e2e log" ledger-cli-psbt-e2e.log
+            cat ledger-cli-psbt-e2e.log || true
+            exit 1
+          }
+      - name: Restart Ledger Speculos before Ledger e2e
+        run: |
+          bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
+          rm -f ledger.pid
+          setsid bash -c 'echo "$$" > ledger.pid; exec nix run .#ledger' > ledger.log 2>&1 &
+          for _ in {1..100}; do
+            [[ -s ledger.pid ]] && break
+            sleep 0.1
+          done
+          test -s ledger.pid
+          tail -n +1 -F ledger.log &
+          echo $! > ledger-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          bash nix/scripts/wait-for-port.sh localhost 5000 300 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger e2e except PSBT signing
+        run: |
+          set -o pipefail
+          nix develop .#ledger -c cargo test -p bhwi-e2e-ledger -- --skip can_sign_psbt --test-threads=1 2>&1 | tee ledger-e2e.log || {
             bash nix/scripts/emit-gh-error-log.sh "Ledger e2e log" ledger-e2e.log
             cat ledger-e2e.log || true
             exit 1
           }
-      - name: Ledger logs
-        if: always()
+      - name: Restart Ledger Speculos before PSBT e2e
         run: |
-          cat ledger.log || true
-          if [ -f ledger.pid ]; then kill "$(cat ledger.pid)" || true; fi
+          bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
+          rm -f ledger.pid
+          setsid bash -c 'echo "$$" > ledger.pid; exec nix run .#ledger' > ledger.log 2>&1 &
+          for _ in {1..100}; do
+            [[ -s ledger.pid ]] && break
+            sleep 0.1
+          done
+          test -s ledger.pid
+          tail -n +1 -F ledger.log &
+          echo $! > ledger-tail.pid
+          bash nix/scripts/wait-for-port.sh localhost 9999 1800 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          bash nix/scripts/wait-for-port.sh localhost 5000 300 "$(cat ledger.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger restart log" ledger.log
+            cat ledger.log || true
+            exit 1
+          }
+          kill "$(cat ledger-tail.pid)" || true
+      - name: Run Ledger PSBT e2e
+        run: |
+          set -o pipefail
+          nix develop .#ledger -c cargo test -p bhwi-e2e-ledger can_sign_psbt -- --test-threads=1 2>&1 | tee ledger-psbt-e2e.log || {
+            bash nix/scripts/emit-gh-error-log.sh "Ledger PSBT e2e log" ledger-psbt-e2e.log
+            cat ledger-psbt-e2e.log || true
+            exit 1
+          }
+      - name: Stop Ledger Speculos before upstream gate
+        run: bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
+      - name: Run upstream HWI Ledger suite
+        run: timeout 90m nix run .#hwi-upstream-ledger
+      - name: Stop Ledger Speculos
+        if: always()
+        run: bash nix/scripts/stop-emulator.sh ledger.pid tcp localhost 9999 60
 
   jade-e2e:
     needs: nix-flake
@@ -248,7 +367,7 @@ jobs:
       - name: Run HWI parity tests
         run: |
           set -o pipefail
-          nix run .#hwi-parity-jade 2>&1 | tee jade-hwi-parity.log || {
+          nix run .#hwi-parity-jade -- -- --test-threads=1 2>&1 | tee jade-hwi-parity.log || {
             bash nix/scripts/emit-gh-error-log.sh "Jade HWI parity log" jade-hwi-parity.log
             cat jade-hwi-parity.log || true
             exit 1
@@ -269,10 +388,14 @@ jobs:
             cat jade-e2e.log || true
             exit 1
           }
-      - name: Jade logs
+      - name: Stop Jade services before upstream gate
+        run: |
+          bash nix/scripts/stop-emulator.sh jade.pid tcp localhost 30121 60
+          bash nix/scripts/stop-emulator.sh jade-pinserver.pid tcp localhost 8096 60
+      - name: Run upstream HWI Jade suite
+        run: timeout 120m nix run .#hwi-upstream-jade
+      - name: Stop Jade services
         if: always()
         run: |
-          cat jade-pinserver.log || true
-          cat jade.log || true
-          if [ -f jade.pid ]; then kill "$(cat jade.pid)" || true; fi
-          if [ -f jade-pinserver.pid ]; then kill "$(cat jade-pinserver.pid)" || true; fi
+          bash nix/scripts/stop-emulator.sh jade.pid tcp localhost 30121 60
+          bash nix/scripts/stop-emulator.sh jade-pinserver.pid tcp localhost 8096 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ name = "bhwi-e2e-hwi-parity"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitcoin",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "libc",
  "miniscript",
  "rand_core 0.6.4",
  "reqwest",

--- a/bhwi-cli/Cargo.toml
+++ b/bhwi-cli/Cargo.toml
@@ -24,6 +24,7 @@ bhwi-async = { workspace = true, features = ["bitbox", "emulators"] }
 bhwi.workspace = true
 futures.workspace = true
 hex = { workspace = true, features = ["serde"] }
+libc = "0.2"
 miniscript = { workspace = true, features = ["serde"] }
 rand_core.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -2,8 +2,11 @@ use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
 use bhwi_async::{DeviceBackup, DeviceContext, WalletRegistration};
 use bhwi_cli::{
-    DeviceManager, OutputFormat, address::AddressTarget, config::DeviceSelector,
+    DeviceManager, OutputFormat,
+    address::AddressTarget,
+    config::DeviceSelector,
     get_descriptors::GetKeypoolOptions,
+    udev::{UdevRuleSelection, install_udev_rules},
 };
 
 use std::path::PathBuf;
@@ -146,6 +149,18 @@ enum DeviceCommands {
         /// Output file for devices that export encrypted backup bytes
         #[arg(long, short)]
         output: Option<PathBuf>,
+    },
+    /// Install udev rules for hardware wallet device access
+    InstallUdevRules {
+        /// Device rule targets to install
+        #[arg(value_enum)]
+        targets: Vec<bhwi_cli::DeviceType>,
+        /// Install rules for all BHWI-supported devices
+        #[arg(long)]
+        all: bool,
+        /// Directory where udev rule files are copied
+        #[arg(long, default_value = "/etc/udev/rules.d/")]
+        location: PathBuf,
     },
 }
 
@@ -325,6 +340,32 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Device(DeviceCommands::InstallUdevRules {
+            targets,
+            all,
+            location,
+        }) => {
+            if all && !targets.is_empty() {
+                anyhow::bail!("--all cannot be combined with explicit device targets");
+            }
+            if !all && targets.is_empty() {
+                anyhow::bail!("specify at least one device target or --all");
+            }
+
+            let selection = if all {
+                UdevRuleSelection::Devices(vec![
+                    bhwi_cli::DeviceType::Coldcard,
+                    bhwi_cli::DeviceType::Jade,
+                    bhwi_cli::DeviceType::Ledger,
+                ])
+            } else {
+                UdevRuleSelection::Devices(targets)
+            };
+            install_udev_rules(&location, selection)?;
+            if let Some(OutputFormat::Json) = format {
+                println!("{}", serde_json::json!({ "success": true }));
+            }
+        }
         Commands::Xpub(XpubCommands::Get { path }) => {
             if let Some(mut d) = dev_man.get_device_with_fingerprint().await? {
                 println!("{}", d.device().get_extended_pubkey(path, false).await?);
@@ -477,6 +518,55 @@ mod tests {
         .expect_err("path and descriptor are mutually exclusive");
 
         assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn parses_device_install_udev_rules_targets() {
+        let args = Args::try_parse_from([
+            "bhwi",
+            "device",
+            "install-udev-rules",
+            "--location",
+            "/tmp/rules.d",
+            "ledger",
+            "jade",
+        ])
+        .expect("parse install udev rules");
+
+        match args.command {
+            Commands::Device(DeviceCommands::InstallUdevRules {
+                targets,
+                all,
+                location,
+            }) => {
+                assert_eq!(
+                    targets,
+                    vec![bhwi_cli::DeviceType::Ledger, bhwi_cli::DeviceType::Jade]
+                );
+                assert!(!all);
+                assert_eq!(location, PathBuf::from("/tmp/rules.d"));
+            }
+            command => panic!("unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_device_install_udev_rules_all() {
+        let args = Args::try_parse_from(["bhwi", "device", "install-udev-rules", "--all"])
+            .expect("parse install all udev rules");
+
+        match args.command {
+            Commands::Device(DeviceCommands::InstallUdevRules {
+                targets,
+                all,
+                location,
+            }) => {
+                assert!(targets.is_empty());
+                assert!(all);
+                assert_eq!(location, PathBuf::from("/etc/udev/rules.d/"));
+            }
+            command => panic!("unexpected command: {command:?}"),
+        }
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -20,7 +20,7 @@ use bitcoin::{
     },
     psbt::Input,
 };
-use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use miniscript::{
     Descriptor, DescriptorPublicKey,
     descriptor::{DescriptorType, WalletPolicy, checksum},
@@ -88,6 +88,24 @@ pub enum HwiCliCommand {
         #[arg(long, default_value_t = 0)]
         account: u32,
     },
+    Getkeypool {
+        start: u32,
+        end: u32,
+        #[arg(long, action = ArgAction::SetTrue, conflicts_with = "nokeypool")]
+        keypool: bool,
+        #[arg(long, action = ArgAction::SetTrue)]
+        nokeypool: bool,
+        #[arg(long, action = ArgAction::SetTrue)]
+        internal: bool,
+        #[arg(long = "addr-type", value_enum, conflicts_with = "all")]
+        addr_type: Option<HwiAddressType>,
+        #[arg(long, action = ArgAction::SetTrue)]
+        all: bool,
+        #[arg(long, default_value_t = 0)]
+        account: u32,
+        #[arg(long)]
+        path: Option<String>,
+    },
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -118,6 +136,16 @@ pub enum HwiCommand {
     },
     GetDescriptors {
         account: u32,
+    },
+    GetKeypool {
+        start: u32,
+        end: u32,
+        internal: bool,
+        keypool: bool,
+        account: u32,
+        addr_type: HwiAddressType,
+        all: bool,
+        path: Option<String>,
     },
     Unsupported(String),
 }
@@ -196,6 +224,7 @@ pub enum HwiResponse {
     Enumerate(Vec<HwiEnumeratedDevice>),
     GetXpub(HwiGetXpubResponse),
     GetDescriptors(HwiGetDescriptorsResponse),
+    GetKeypool(Vec<HwiGetKeypoolEntry>),
     SignTx(HwiSignTxResponse),
     SignMessage(HwiSignMessageResponse),
     Error(HwiError),
@@ -241,6 +270,17 @@ pub struct HwiGetDescriptorsResponse {
     pub internal: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct HwiGetKeypoolEntry {
+    pub desc: String,
+    pub range: [u32; 2],
+    pub timestamp: &'static str,
+    pub internal: bool,
+    pub keypool: bool,
+    pub active: bool,
+    pub watchonly: bool,
+}
+
 pub fn parse_args<I, T>(args: I) -> HwiResult<HwiRequest>
 where
     I: IntoIterator<Item = T>,
@@ -263,6 +303,31 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
         }
         HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
         HwiCommand::GetDescriptors { account } => get_descriptors(request.selector, account).await,
+        HwiCommand::GetKeypool {
+            start,
+            end,
+            internal,
+            keypool,
+            account,
+            addr_type,
+            all,
+            path,
+        } => {
+            get_keypool(
+                request.selector,
+                HwiGetKeypoolRequest {
+                    start,
+                    end,
+                    internal,
+                    keypool,
+                    account,
+                    addr_type,
+                    all,
+                    path,
+                },
+            )
+            .await
+        }
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
             format!("Unsupported HWI command: {command}"),
@@ -631,6 +696,134 @@ async fn get_descriptors(selector: DeviceSelector, account: u32) -> HwiResponse 
     HwiResponse::GetDescriptors(response)
 }
 
+struct HwiGetKeypoolRequest {
+    start: u32,
+    end: u32,
+    internal: bool,
+    keypool: bool,
+    account: u32,
+    addr_type: HwiAddressType,
+    all: bool,
+    path: Option<String>,
+}
+
+async fn get_keypool(selector: DeviceSelector, request: HwiGetKeypoolRequest) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+    if request.start > request.end {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "keypool start index must be less than or equal to end index",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let fingerprint = match device.fingerprint().await {
+        Ok(fingerprint) => fingerprint,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+    let device_type = device.device_type();
+    let model = device.model().to_owned();
+    let network = manager.selector.network;
+    let addr_types = if request.all {
+        hwi_descriptor_addr_types(device_type, &model)
+    } else if request.addr_type == HwiAddressType::Tap && !hwi_can_sign_taproot(device_type, &model)
+    {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "Device does not support Taproot",
+        ));
+    } else {
+        vec![request.addr_type]
+    };
+
+    let branches = if request.path.is_none() && !request.internal {
+        vec![false, true]
+    } else {
+        vec![request.internal]
+    };
+
+    let mut entries = Vec::new();
+    for addr_type in addr_types {
+        for internal in branches.iter().copied() {
+            let descriptor_type = descriptor_type_for(addr_type);
+            let options = match request.path.as_deref() {
+                Some(path) => match keypool_path_descriptor_options(
+                    fingerprint,
+                    path,
+                    internal,
+                    descriptor_type,
+                    network,
+                ) {
+                    Ok(options) => options,
+                    Err(error) => return HwiResponse::Error(error),
+                },
+                None => GetDescriptorOptions::with_account(
+                    fingerprint,
+                    request.account,
+                    internal,
+                    descriptor_type,
+                    network,
+                ),
+            };
+            let descriptor = match manager.get_descriptor(device.device(), options).await {
+                Ok(descriptor) => descriptor,
+                Err(err) => {
+                    return HwiResponse::Error(HwiError::new(
+                        HwiErrorCode::DeviceConnectionError,
+                        err.to_string(),
+                    ));
+                }
+            };
+            let desc = match hwi_descriptor_string(&descriptor) {
+                Ok(descriptor) => descriptor,
+                Err(err) => {
+                    return HwiResponse::Error(HwiError::new(
+                        HwiErrorCode::BadArgument,
+                        err.to_string(),
+                    ));
+                }
+            };
+            entries.push(HwiGetKeypoolEntry {
+                desc,
+                range: [request.start, request.end],
+                timestamp: "now",
+                internal,
+                keypool: request.keypool,
+                active: request.keypool,
+                watchonly: true,
+            });
+        }
+    }
+
+    HwiResponse::GetKeypool(entries)
+}
+
 async fn ledger_signing_context(
     device: &mut Device,
     psbt: &Psbt,
@@ -993,6 +1186,36 @@ fn hwi_descriptor_string(
     Ok(format!("{descriptor}#{}", checksum.checksum()))
 }
 
+fn keypool_path_descriptor_options(
+    master_fingerprint: Fingerprint,
+    path: &str,
+    internal: bool,
+    descriptor_type: DescriptorType,
+    network: Network,
+) -> Result<GetDescriptorOptions, HwiError> {
+    if !path.starts_with("m/") {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Path must start with m/",
+        ));
+    }
+    let Some(path) = path.strip_suffix("/*") else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Path must end with /*",
+        ));
+    };
+    let path = DerivationPath::from_str(path)
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    Ok(GetDescriptorOptions::with_path(
+        master_fingerprint,
+        path,
+        internal,
+        descriptor_type,
+        network,
+    ))
+}
+
 fn get_xpub_response(xpub: Xpub, expert: bool) -> HwiGetXpubResponse {
     if !expert {
         return HwiGetXpubResponse {
@@ -1082,6 +1305,26 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Signmessage { message, path } => HwiCommand::SignMessage { message, path },
         HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
         HwiCliCommand::Getdescriptors { account } => HwiCommand::GetDescriptors { account },
+        HwiCliCommand::Getkeypool {
+            start,
+            end,
+            keypool: _keypool,
+            nokeypool,
+            internal,
+            addr_type,
+            all,
+            account,
+            path,
+        } => HwiCommand::GetKeypool {
+            start,
+            end,
+            internal,
+            keypool: !nokeypool,
+            account,
+            addr_type: addr_type.unwrap_or(HwiAddressType::Wit),
+            all,
+            path,
+        },
         HwiCliCommand::External(argv) => {
             let command = argv
                 .first()
@@ -1349,6 +1592,107 @@ mod tests {
     }
 
     #[test]
+    fn parses_getkeypool_defaults() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "--emulators",
+            "getkeypool",
+            "0",
+            "10",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert!(request.selector.include_emulators);
+        assert_eq!(
+            request.command,
+            HwiCommand::GetKeypool {
+                start: 0,
+                end: 10,
+                internal: false,
+                keypool: true,
+                account: 0,
+                addr_type: HwiAddressType::Wit,
+                all: false,
+                path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_getkeypool_all_options() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "getkeypool",
+            "--nokeypool",
+            "--internal",
+            "--all",
+            "--account",
+            "2",
+            "--path",
+            "m/84h/1h/0h/1/*",
+            "5",
+            "8",
+        ])
+        .expect("request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::GetKeypool {
+                start: 5,
+                end: 8,
+                internal: true,
+                keypool: false,
+                account: 2,
+                addr_type: HwiAddressType::Wit,
+                all: true,
+                path: Some("m/84h/1h/0h/1/*".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_getkeypool_addr_type() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "getkeypool",
+            "--addr-type",
+            "sh_wit",
+            "--keypool",
+            "5",
+            "8",
+        ])
+        .expect("request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::GetKeypool {
+                start: 5,
+                end: 8,
+                internal: false,
+                keypool: true,
+                account: 0,
+                addr_type: HwiAddressType::ShWit,
+                all: false,
+                path: None,
+            }
+        );
+    }
+
+    #[test]
     fn accepts_python_hwi_version_flag() {
         let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
 
@@ -1470,6 +1814,35 @@ mod tests {
     }
 
     #[test]
+    fn getkeypool_serializes_importdescriptors_shape() {
+        let json = serde_json::to_value(HwiResponse::GetKeypool(vec![HwiGetKeypoolEntry {
+            desc: "wpkh(...)#keypool".to_owned(),
+            range: [0, 10],
+            timestamp: "now",
+            internal: false,
+            keypool: true,
+            active: true,
+            watchonly: true,
+        }]))
+        .expect("json");
+
+        assert_eq!(
+            json,
+            serde_json::json!([
+                {
+                    "desc": "wpkh(...)#keypool",
+                    "range": [0, 10],
+                    "timestamp": "now",
+                    "internal": false,
+                    "keypool": true,
+                    "active": true,
+                    "watchonly": true,
+                }
+            ])
+        );
+    }
+
+    #[test]
     fn signmessage_normalizes_coldcard_header_for_python_hwi() {
         assert_eq!(python_hwi_message_header(DeviceType::Coldcard, 40), 32);
         assert_eq!(python_hwi_message_header(DeviceType::Ledger, 32), 32);
@@ -1488,6 +1861,56 @@ mod tests {
         assert!(descriptor.contains("/84h/1h/0h]"));
         assert!(!descriptor.contains('\''));
         checksum::verify_checksum(&descriptor).expect("valid checksum");
+    }
+
+    #[test]
+    fn getkeypool_path_accepts_hwi_ranged_path() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+
+        let options = keypool_path_descriptor_options(
+            fingerprint,
+            "m/84h/1h/0h/0/*",
+            false,
+            DescriptorType::Wpkh,
+            Network::Testnet,
+        )
+        .expect("keypool path options");
+
+        assert_eq!(options.master_fingerprint, fingerprint);
+    }
+
+    #[test]
+    fn getkeypool_path_rejects_missing_master_prefix() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+
+        let err = keypool_path_descriptor_options(
+            fingerprint,
+            "84h/1h/0h/0/*",
+            false,
+            DescriptorType::Wpkh,
+            Network::Testnet,
+        )
+        .expect_err("missing master prefix");
+
+        assert_eq!(err.code, HwiErrorCode::BadArgument.code());
+        assert_eq!(err.error, "Path must start with m/");
+    }
+
+    #[test]
+    fn getkeypool_path_rejects_missing_wildcard() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+
+        let err = keypool_path_descriptor_options(
+            fingerprint,
+            "m/84h/1h/0h/0",
+            false,
+            DescriptorType::Wpkh,
+            Network::Testnet,
+        )
+        .expect_err("missing wildcard");
+
+        assert_eq!(err.code, HwiErrorCode::BadArgument.code());
+        assert_eq!(err.error, "Path must end with /*");
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -10,7 +10,7 @@ use std::{
 
 use bhwi::{
     bitcoin::psbt::Psbt,
-    common::{MultisigAddressType, MultisigDisplayAddress, MultisigDisplayKey},
+    common::{MultisigAddressType, MultisigDisplayAddress},
     ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
 };
 use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress};
@@ -263,6 +263,7 @@ pub struct HwiError {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum HwiErrorCode {
     NoDeviceType,
+    UnknownDevice,
     BadArgument,
     UnsupportedCommand,
     DeviceFailure,
@@ -274,6 +275,7 @@ impl HwiErrorCode {
     fn code(self) -> i32 {
         match self {
             HwiErrorCode::NoDeviceType => -1,
+            HwiErrorCode::UnknownDevice => -4,
             HwiErrorCode::BadArgument => -7,
             HwiErrorCode::UnsupportedCommand => -9,
             HwiErrorCode::DeviceFailure => -13,
@@ -662,7 +664,13 @@ async fn backup_device(
         }
     }
 
-    match device.device().backup_device().await {
+    let approval =
+        coldcard_emulator_approval(coldcard_emulator_path(&device), ColdcardApproval::Backup);
+    let (backup, approval) = tokio::join!(device.device().backup_device(), approval);
+    if let Err(err) = approval {
+        return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceConnectionError, err));
+    }
+    match backup {
         Ok(DeviceBackup::Complete) => HwiResponse::Success(HwiSuccessResponse { success: true }),
         Ok(DeviceBackup::File(bytes)) => match write_hwi_backup_file(&bytes) {
             Ok(()) => HwiResponse::Success(HwiSuccessResponse { success: true }),
@@ -831,7 +839,16 @@ async fn sign_message(
     };
 
     let device_type = device.device_type();
-    match device.device().sign_message(message.as_bytes(), path).await {
+    let approval =
+        coldcard_emulator_approval(coldcard_emulator_path(&device), ColdcardApproval::Once);
+    let (signature, approval) = tokio::join!(
+        device.device().sign_message(message.as_bytes(), path),
+        approval
+    );
+    if let Err(err) = approval {
+        return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceConnectionError, err));
+    }
+    match signature {
         Ok((header, signature)) => HwiResponse::SignMessage(HwiSignMessageResponse {
             signature: message_signature_base64(
                 python_hwi_message_header(device_type, header),
@@ -894,7 +911,10 @@ async fn display_address(
             match singlesig_display_address_from_descriptor(&mut device, &descriptor).await {
                 Ok(address) => Ok(address),
                 Err(single_sig_error) => {
-                    if device.device_type() == DeviceType::Coldcard {
+                    if matches!(
+                        device.device_type(),
+                        DeviceType::Coldcard | DeviceType::Jade
+                    ) {
                         match multisig_display_address_from_descriptor(&descriptor) {
                             Ok(address) => Ok(DisplayAddress::ByMultisig(address)),
                             Err(_) => return HwiResponse::Error(single_sig_error),
@@ -912,10 +932,92 @@ async fn display_address(
         Err(error) => return HwiResponse::Error(error),
     };
 
-    match device.device().display_address(display, None).await {
+    let approval =
+        coldcard_emulator_approval(coldcard_emulator_path(&device), ColdcardApproval::Once);
+    let (address, approval) =
+        tokio::join!(device.device().display_address(display, None), approval);
+    if let Err(err) = approval {
+        return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceConnectionError, err));
+    }
+    match address {
         Ok(address) => HwiResponse::DisplayAddress(HwiDisplayAddressResponse { address }),
         Err(err) => display_address_error(err.to_string()),
     }
+}
+
+#[derive(Clone, Copy)]
+enum ColdcardApproval {
+    Once,
+    Backup,
+}
+
+fn coldcard_emulator_path(device: &Device) -> Option<String> {
+    (device.device_type() == DeviceType::Coldcard && device.is_emulated())
+        .then(|| device.path().to_string())
+}
+
+async fn coldcard_emulator_approval(
+    socket_path: Option<String>,
+    approval: ColdcardApproval,
+) -> Result<(), String> {
+    match socket_path {
+        Some(socket_path) => coldcard_emulator_keypresses(&socket_path, approval).await,
+        None => Ok(()),
+    }
+}
+
+#[cfg(unix)]
+async fn coldcard_emulator_keypresses(
+    socket_path: &str,
+    approval: ColdcardApproval,
+) -> Result<(), String> {
+    use tokio::net::UnixDatagram;
+
+    let client_path = format!(
+        "/tmp/bhwi-hwi-approval-{}-{}.sock",
+        std::process::id(),
+        generate_hwi_socket_id()
+    );
+    let _ = fs::remove_file(&client_path);
+    let socket = UnixDatagram::bind(&client_path).map_err(|err| err.to_string())?;
+    socket.connect(socket_path).map_err(|err| err.to_string())?;
+    send_coldcard_simulator_keypress(&socket, b'y').await?;
+    if matches!(approval, ColdcardApproval::Backup) {
+        for _ in 0..20 {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            send_coldcard_simulator_keypress(&socket, b'1').await?;
+        }
+    }
+    drop(socket);
+    let _ = fs::remove_file(client_path);
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn send_coldcard_simulator_keypress(
+    socket: &tokio::net::UnixDatagram,
+    key: u8,
+) -> Result<(), String> {
+    let mut packet = [0u8; 64];
+    packet[0] = 0x80 | 5;
+    packet[1..5].copy_from_slice(b"XKEY");
+    packet[5] = key;
+    socket.send(&packet).await.map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn coldcard_emulator_keypresses(
+    _socket_path: &str,
+    _approval: ColdcardApproval,
+) -> Result<(), String> {
+    Ok(())
+}
+
+fn generate_hwi_socket_id() -> usize {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SOCKET_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    SOCKET_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 fn python_hwi_message_header(device_type: DeviceType, header: u8) -> u8 {
@@ -1225,11 +1327,14 @@ async fn ledger_multisig_context(
         return Ok(None);
     };
     let name = ledger_multisig_wallet_name(&policy);
-    let hmac = device
+    let registration = device
         .device()
         .register_wallet(&name, &policy)
         .await
         .map_err(|err| err.to_string())?;
+    let hmac = registration
+        .hmac()
+        .ok_or_else(|| "Ledger wallet registration returned no HMAC".to_string())?;
     let wallet_policy = WalletPolicy::from_str(&policy).map_err(|err| err.to_string())?;
     Ok(Some(DeviceContext::Ledger {
         wallet_policy: LedgerWalletPolicy::new(name, Version::V2, wallet_policy),
@@ -1649,32 +1754,13 @@ fn multisig_display_address_from_descriptor(
     descriptor: &str,
 ) -> Result<MultisigDisplayAddress, HwiError> {
     let descriptor = strip_descriptor_checksum(descriptor);
-    let (address_type, inner) = if let Some(inner) = descriptor
-        .strip_prefix("sh(wsh(sortedmulti(")
-        .and_then(|value| value.strip_suffix(")))"))
-    {
-        (MultisigAddressType::ShWit, inner)
-    } else if let Some(inner) = descriptor
-        .strip_prefix("wsh(sortedmulti(")
-        .and_then(|value| value.strip_suffix("))"))
-    {
-        (MultisigAddressType::Wit, inner)
-    } else if let Some(inner) = descriptor
-        .strip_prefix("sh(sortedmulti(")
-        .and_then(|value| value.strip_suffix("))"))
-    {
-        (MultisigAddressType::Legacy, inner)
-    } else if descriptor.contains("multi(") {
-        return Err(HwiError::new(
-            HwiErrorCode::BadArgument,
-            "Coldcards only allow sortedmulti descriptors",
-        ));
-    } else {
-        return Err(HwiError::new(
-            HwiErrorCode::BadArgument,
-            format!("Unsupported displayaddress descriptor: {descriptor}"),
-        ));
-    };
+    let (address_type, sorted, inner) =
+        parse_multisig_descriptor_envelope(descriptor).ok_or_else(|| {
+            HwiError::new(
+                HwiErrorCode::BadArgument,
+                format!("Unsupported displayaddress descriptor: {descriptor}"),
+            )
+        })?;
 
     let mut parts = inner.split(',');
     let threshold = parts
@@ -1687,8 +1773,11 @@ fn multisig_display_address_from_descriptor(
         })?
         .parse::<u8>()
         .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
-    let mut keys = parts
-        .map(parse_multisig_display_key)
+    let keys = parts
+        .map(|key| {
+            DescriptorPublicKey::from_str(key)
+                .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     if keys.is_empty() || threshold == 0 || usize::from(threshold) > keys.len() {
         return Err(HwiError::new(
@@ -1696,37 +1785,43 @@ fn multisig_display_address_from_descriptor(
             "Either the redeem script provided is invalid or the keypaths provided are insufficient",
         ));
     }
-    keys.sort_by_key(|key| key.public_key.serialize());
-
     Ok(MultisigDisplayAddress {
         threshold,
         address_type,
+        sorted,
         keys,
     })
 }
 
-fn parse_multisig_display_key(key_expr: &str) -> Result<MultisigDisplayKey, HwiError> {
-    let Some(rest) = key_expr.strip_prefix('[') else {
-        return Err(HwiError::new(
-            HwiErrorCode::BadArgument,
-            "Coldcard multisig display requires key origin information",
-        ));
-    };
-    let Some((origin, key_and_suffix)) = rest.split_once(']') else {
-        return Err(HwiError::new(
-            HwiErrorCode::BadArgument,
-            "Coldcard multisig display requires key origin information",
-        ));
-    };
-    let (fingerprint, origin_path) = parse_key_origin(origin)?;
-    let (key, suffix_path) = split_key_suffix(key_and_suffix)?;
-    let public_key = SecpPublicKey::from_str(key)
-        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
-    Ok(MultisigDisplayKey {
-        fingerprint,
-        path: join_derivation_path(&origin_path, &suffix_path),
-        public_key,
-    })
+fn parse_multisig_descriptor_envelope(
+    descriptor: &str,
+) -> Option<(MultisigAddressType, bool, &str)> {
+    let wrappers = [
+        ("sh(wsh(", "))", MultisigAddressType::ShWit),
+        ("wsh(", ")", MultisigAddressType::Wit),
+        ("sh(", ")", MultisigAddressType::Legacy),
+    ];
+    for (prefix, suffix, address_type) in wrappers {
+        let Some(inner) = descriptor
+            .strip_prefix(prefix)
+            .and_then(|value| value.strip_suffix(suffix))
+        else {
+            continue;
+        };
+        if let Some(inner) = inner
+            .strip_prefix("sortedmulti(")
+            .and_then(|value| value.strip_suffix(')'))
+        {
+            return Some((address_type, true, inner));
+        }
+        if let Some(inner) = inner
+            .strip_prefix("multi(")
+            .and_then(|value| value.strip_suffix(')'))
+        {
+            return Some((address_type, false, inner));
+        }
+    }
+    None
 }
 
 fn strip_descriptor_checksum(descriptor: &str) -> &str {
@@ -1781,9 +1876,10 @@ fn display_address_error(error: String) -> HwiResponse {
     let code = if error.contains("unsupported display address")
         || error.contains("does not support displaying")
         || error.contains("does not support this path address format")
+        || error.contains("does not support this address format")
     {
         HwiErrorCode::UnsupportedCommand
-    } else if error.contains("Coldcard Error:") {
+    } else if error.contains("Coldcard Error:") || error.starts_with("invalid input:") {
         HwiErrorCode::BadArgument
     } else {
         HwiErrorCode::DeviceConnectionError
@@ -2017,10 +2113,28 @@ fn parse_device_type(value: &str) -> HwiResult<DeviceType> {
         "jade" => Ok(DeviceType::Jade),
         "ledger" => Ok(DeviceType::Ledger),
         _ => Err(HwiError::new(
-            HwiErrorCode::BadArgument,
-            format!("Unsupported device type: {value}"),
+            HwiErrorCode::UnknownDevice,
+            "Unknown device type specified",
         )),
     }
+}
+
+fn is_known_emulator_path(device_type: Option<DeviceType>, path: Option<&str>) -> bool {
+    matches!(
+        (device_type, path),
+        (
+            Some(DeviceType::BitBox02),
+            Some("127.0.0.1:15423" | "tcp:127.0.0.1:15423")
+        ) | (Some(DeviceType::Coldcard), Some("/tmp/ckcc-simulator.sock"))
+            | (
+                Some(DeviceType::Jade),
+                Some("127.0.0.1:30121" | "tcp:127.0.0.1:30121")
+            )
+            | (
+                Some(DeviceType::Ledger),
+                Some("127.0.0.1:9999" | "tcp:127.0.0.1:9999")
+            )
+    )
 }
 
 fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
@@ -2037,6 +2151,8 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         .as_deref()
         .map(parse_device_type)
         .transpose()?;
+    let include_emulators =
+        args.emulators || is_known_emulator_path(device_type, args.device_path.as_deref());
     let network = parse_chain(&args.chain)?;
     let command = match args.command {
         HwiCliCommand::Enumerate => HwiCommand::Enumerate,
@@ -2135,7 +2251,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
             fingerprint: args.fingerprint,
             device_type,
             device_path: args.device_path,
-            include_emulators: args.emulators,
+            include_emulators,
         },
         command,
     })
@@ -2549,8 +2665,8 @@ mod tests {
         let error = parse_args(["hwi", "--device-type", "trezor", "enumerate"])
             .expect_err("unsupported device type");
 
-        assert_eq!(error.code, HwiErrorCode::BadArgument.code());
-        assert!(error.error.contains("Unsupported device type"));
+        assert_eq!(error.code, HwiErrorCode::UnknownDevice.code());
+        assert_eq!(error.error, "Unknown device type specified");
     }
 
     #[test]
@@ -2830,6 +2946,17 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_bitbox_address_format_uses_hwi_unsupported_code() {
+        let response = display_address_error(
+            "invalid input: BitBox does not support this address format".into(),
+        );
+        let HwiResponse::Error(error) = response else {
+            panic!("expected HWI error");
+        };
+        assert_eq!(error.code, HwiErrorCode::UnsupportedCommand.code());
+    }
+
+    #[test]
     fn getdescriptors_serializes_receive_and_internal() {
         let json = serde_json::to_value(HwiResponse::GetDescriptors(HwiGetDescriptorsResponse {
             receive: vec!["wpkh(...)#receive".to_owned()],
@@ -2999,14 +3126,22 @@ mod tests {
 
         assert_eq!(parsed.threshold, 2);
         assert!(matches!(parsed.address_type, MultisigAddressType::ShWit));
+        assert!(parsed.sorted);
         assert_eq!(parsed.keys.len(), 2);
+        let origins = parsed
+            .keys
+            .iter()
+            .map(|key| match key {
+                DescriptorPublicKey::Single(key) => key.origin.clone().unwrap().1,
+                _ => panic!("expected concrete public key"),
+            })
+            .collect::<Vec<_>>();
         assert_eq!(
-            parsed.keys[0].path,
-            DerivationPath::from_str("m/48h/1h/0h/0h/0").unwrap()
-        );
-        assert_eq!(
-            parsed.keys[1].path,
-            DerivationPath::from_str("m/48h/1h/1h/0h/0").unwrap()
+            origins,
+            vec![
+                DerivationPath::from_str("m/48h/1h/0h/0h/0").unwrap(),
+                DerivationPath::from_str("m/48h/1h/1h/0h/0").unwrap(),
+            ]
         );
     }
 

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -893,7 +893,7 @@ async fn get_descriptors(selector: DeviceSelector, account: u32) -> HwiResponse 
     };
 
     for internal in [false, true] {
-        for addr_type in hwi_getdescriptors_addr_types(device_type, &model) {
+        for addr_type in hwi_descriptor_addr_types(device_type, &model) {
             let descriptor_type = descriptor_type_for(addr_type);
             let options = GetDescriptorOptions::with_account(
                 fingerprint,
@@ -1681,13 +1681,6 @@ fn hwi_descriptor_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAdd
     types
 }
 
-fn hwi_getdescriptors_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAddressType> {
-    match device_type {
-        DeviceType::BitBox02 => vec![HwiAddressType::Wit, HwiAddressType::ShWit],
-        _ => hwi_descriptor_addr_types(device_type, model),
-    }
-}
-
 fn hwi_can_sign_taproot(device_type: DeviceType, model: &str) -> bool {
     match device_type {
         DeviceType::BitBox02 => false,
@@ -1771,7 +1764,7 @@ fn label_for(device_type: DeviceType) -> Option<Option<String>> {
 
 fn hwi_enumerate_model(device_type: DeviceType, model: &str, is_emulated: bool) -> String {
     match (device_type, is_emulated) {
-        (DeviceType::BitBox02, true) => "bitbox02_multi".to_owned(),
+        (DeviceType::BitBox02, true) => "bitbox02_nova_multi".to_owned(),
         _ => model.to_owned(),
     }
 }
@@ -2679,7 +2672,7 @@ mod tests {
         })
         .expect("json");
 
-        assert_eq!(json["model"], "bitbox02_multi");
+        assert_eq!(json["model"], "bitbox02_nova_multi");
         assert_eq!(json["path"], "127.0.0.1:15423");
         assert!(json.get("label").is_none());
     }
@@ -2921,10 +2914,6 @@ mod tests {
                 HwiAddressType::Wit,
                 HwiAddressType::ShWit,
             ]
-        );
-        assert_eq!(
-            hwi_getdescriptors_addr_types(DeviceType::BitBox02, "bitbox02_multi"),
-            vec![HwiAddressType::Wit, HwiAddressType::ShWit]
         );
         assert!(hwi_can_sign_taproot(
             DeviceType::Coldcard,

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -5,14 +5,26 @@ use std::{
     str::FromStr,
 };
 
+use bhwi::{
+    bitcoin::psbt::Psbt,
+    ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
+};
+use bhwi_async::DeviceContext;
 use bitcoin::{
-    Network, NetworkKind,
-    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
+    Network, NetworkKind, PublicKey, ScriptBuf,
+    base64::prelude::{BASE64_STANDARD, Engine as _},
+    bip32::{ChildNumber, DerivationPath, Fingerprint, KeySource, Xpub},
+    blockdata::{
+        opcodes::all::{OP_CHECKMULTISIG, OP_PUSHNUM_1, OP_PUSHNUM_16},
+        script::{Instruction, PushBytes},
+    },
+    psbt::Input,
 };
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
+use miniscript::descriptor::WalletPolicy;
 use serde::{Serialize, Serializer};
 
-use crate::{DeviceManager, DeviceType, config::DeviceSelector};
+use crate::{Device, DeviceManager, DeviceType, config::DeviceSelector};
 
 type HwiResult<T> = std::result::Result<T, HwiError>;
 
@@ -54,6 +66,14 @@ pub enum HwiCliCommand {
         #[arg(long, default_value_t = 0)]
         account: u32,
     },
+    Signtx {
+        psbt: String,
+    },
+    Signmessage {
+        message: String,
+        #[arg(value_parser = clap::value_parser!(DerivationPath))]
+        path: DerivationPath,
+    },
     Getxpub {
         #[arg(value_parser = clap::value_parser!(DerivationPath))]
         path: DerivationPath,
@@ -74,6 +94,13 @@ pub enum HwiCommand {
     GetMasterXpub {
         addr_type: HwiAddressType,
         account: u32,
+    },
+    SignTx {
+        psbt: String,
+    },
+    SignMessage {
+        message: String,
+        path: DerivationPath,
     },
     GetXpub {
         path: DerivationPath,
@@ -155,7 +182,20 @@ pub struct HwiEnumeratedDevice {
 pub enum HwiResponse {
     Enumerate(Vec<HwiEnumeratedDevice>),
     GetXpub(HwiGetXpubResponse),
+    SignTx(HwiSignTxResponse),
+    SignMessage(HwiSignMessageResponse),
     Error(HwiError),
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiSignTxResponse {
+    pub psbt: String,
+    pub signed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiSignMessageResponse {
+    pub signature: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -196,6 +236,10 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
         HwiCommand::Enumerate => enumerate(request.selector).await,
         HwiCommand::GetMasterXpub { addr_type, account } => {
             get_master_xpub(request.selector, addr_type, account).await
+        }
+        HwiCommand::SignTx { psbt } => sign_tx(request.selector, psbt).await,
+        HwiCommand::SignMessage { message, path } => {
+            sign_message(request.selector, message, path).await
         }
         HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
@@ -322,6 +366,135 @@ async fn get_master_xpub(
     get_xpub(selector, path, false).await
 }
 
+async fn sign_tx(selector: DeviceSelector, psbt: String) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let parsed = match Psbt::from_str(psbt.trim()) {
+        Ok(psbt) => psbt,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(HwiErrorCode::BadArgument, err.to_string()));
+        }
+    };
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let original = parsed.to_string();
+    let context = if device.device_type() == DeviceType::Ledger {
+        match ledger_signing_context(&mut device, &parsed).await {
+            Ok(Some(context)) => Some(context),
+            Ok(None) => {
+                return HwiResponse::SignTx(HwiSignTxResponse {
+                    psbt: original,
+                    signed: false,
+                });
+            }
+            Err(err) => {
+                return HwiResponse::Error(HwiError::new(HwiErrorCode::BadArgument, err));
+            }
+        }
+    } else {
+        None
+    };
+
+    match device.device().sign_tx(parsed, context).await {
+        Ok(signed_psbt) => {
+            let signed = signed_psbt.to_string();
+            HwiResponse::SignTx(HwiSignTxResponse {
+                signed: signed != original,
+                psbt: signed,
+            })
+        }
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+async fn sign_message(
+    selector: DeviceSelector,
+    message: String,
+    path: DerivationPath,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let device_type = device.device_type();
+    match device.device().sign_message(message.as_bytes(), path).await {
+        Ok((header, signature)) => HwiResponse::SignMessage(HwiSignMessageResponse {
+            signature: message_signature_base64(
+                python_hwi_message_header(device_type, header),
+                &signature,
+            ),
+        }),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+fn python_hwi_message_header(device_type: DeviceType, header: u8) -> u8 {
+    if device_type == DeviceType::Coldcard && header >= 8 {
+        // Python HWI normalizes Coldcard's compact-signature header by
+        // clearing the device-specific compressed/pubkey offset.
+        header - 8
+    } else {
+        header
+    }
+}
+
+fn message_signature_base64(
+    header: u8,
+    signature: &bitcoin::secp256k1::ecdsa::Signature,
+) -> String {
+    let mut payload = [0u8; 65];
+    payload[0] = header;
+    payload[1..].copy_from_slice(&signature.serialize_compact());
+    BASE64_STANDARD.encode(payload)
+}
+
 async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) -> HwiResponse {
     if selector.device_type.is_none() && selector.fingerprint.is_none() {
         return HwiResponse::Error(HwiError::new(
@@ -354,6 +527,303 @@ async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) 
             err.to_string(),
         )),
     }
+}
+
+async fn ledger_signing_context(
+    device: &mut Device,
+    psbt: &Psbt,
+) -> Result<Option<DeviceContext>, String> {
+    let fingerprint = device.fingerprint().await.map_err(|err| err.to_string())?;
+    if let Some(context) = ledger_singlesig_context(device, psbt, fingerprint).await? {
+        return Ok(Some(context));
+    }
+    if let Some(context) = ledger_multisig_context(device, psbt, fingerprint).await? {
+        return Ok(Some(context));
+    }
+    Ok(None)
+}
+
+async fn ledger_singlesig_context(
+    device: &mut Device,
+    psbt: &Psbt,
+    fingerprint: Fingerprint,
+) -> Result<Option<DeviceContext>, String> {
+    let Some(path) = ledger_singlesig_account_path(psbt, fingerprint)? else {
+        return Ok(None);
+    };
+    let xpub = device
+        .device()
+        .get_extended_pubkey(path.clone(), false)
+        .await
+        .map_err(|err| err.to_string())?;
+    let policy = singlesig_wallet_policy(&extend_account_path_for_policy(&path), fingerprint, xpub)
+        .map_err(|err| err.to_string())?;
+    Ok(Some(DeviceContext::Ledger {
+        wallet_policy: LedgerWalletPolicy::new(String::new(), Version::V2, policy),
+        wallet_hmac: None,
+    }))
+}
+
+async fn ledger_multisig_context(
+    device: &mut Device,
+    psbt: &Psbt,
+    fingerprint: Fingerprint,
+) -> Result<Option<DeviceContext>, String> {
+    let Some(policy) = ledger_multisig_policy(psbt, fingerprint)? else {
+        return Ok(None);
+    };
+    let name = ledger_multisig_wallet_name(&policy);
+    let hmac = device
+        .device()
+        .register_wallet(&name, &policy)
+        .await
+        .map_err(|err| err.to_string())?;
+    let wallet_policy = WalletPolicy::from_str(&policy).map_err(|err| err.to_string())?;
+    Ok(Some(DeviceContext::Ledger {
+        wallet_policy: LedgerWalletPolicy::new(name, Version::V2, wallet_policy),
+        wallet_hmac: Some(hmac),
+    }))
+}
+
+fn ledger_singlesig_account_path(
+    psbt: &Psbt,
+    fingerprint: Fingerprint,
+) -> Result<Option<DerivationPath>, String> {
+    let mut account_path = None;
+    for input in &psbt.inputs {
+        if multisig_script(input).is_some() {
+            continue;
+        }
+        for (origin_fingerprint, path) in input.bip32_derivation.values() {
+            if *origin_fingerprint != fingerprint || !is_standard_singlesig_path(path) {
+                continue;
+            }
+            let candidate = account_path_from_full_path(path)?;
+            match &account_path {
+                Some(existing) if existing != &candidate => {
+                    return Err("Conflicting Ledger single-sig account paths in PSBT".to_owned());
+                }
+                Some(_) => {}
+                None => account_path = Some(candidate),
+            }
+        }
+    }
+    Ok(account_path)
+}
+
+fn ledger_multisig_policy(psbt: &Psbt, fingerprint: Fingerprint) -> Result<Option<String>, String> {
+    let mut policy = None;
+    for input in &psbt.inputs {
+        let Some((address_type, script)) = multisig_script(input) else {
+            continue;
+        };
+        let Some((threshold, pubkeys)) = parse_multisig_script(&script)? else {
+            continue;
+        };
+        if !pubkeys.iter().any(|pubkey| {
+            input
+                .bip32_derivation
+                .get(&pubkey.inner)
+                .is_some_and(|(key_fingerprint, _)| *key_fingerprint == fingerprint)
+        }) {
+            continue;
+        }
+
+        let mut keys = Vec::with_capacity(pubkeys.len());
+        let mut complete = true;
+        for pubkey in pubkeys {
+            let Some(key_source) = input.bip32_derivation.get(&pubkey.inner) else {
+                complete = false;
+                break;
+            };
+            let Some(key) = global_xpub_key_expression(psbt, key_source) else {
+                complete = false;
+                break;
+            };
+            keys.push(format!("{key}/<0;1>/*"));
+        }
+        if !complete {
+            continue;
+        }
+
+        let candidate = multisig_policy_descriptor(address_type, threshold, &keys);
+        match &policy {
+            Some(existing) if existing != &candidate => {
+                return Err("Conflicting Ledger multisig policies in PSBT".to_owned());
+            }
+            Some(_) => {}
+            None => policy = Some(candidate),
+        }
+    }
+    Ok(policy)
+}
+
+fn account_path_from_full_path(path: &DerivationPath) -> Result<DerivationPath, String> {
+    let children = path.as_ref();
+    if children.len() < 3 {
+        return Err("Derivation path is too short for Ledger account policy".to_owned());
+    }
+    Ok(DerivationPath::from(children[..3].to_vec()))
+}
+
+fn extend_account_path_for_policy(path: &DerivationPath) -> DerivationPath {
+    let mut children = path.as_ref().to_vec();
+    children.push(ChildNumber::from_normal_idx(0).expect("valid receive branch"));
+    children.push(ChildNumber::from_normal_idx(0).expect("valid address index"));
+    DerivationPath::from(children)
+}
+
+fn is_standard_singlesig_path(path: &DerivationPath) -> bool {
+    let children = path.as_ref();
+    if children.len() < 5 {
+        return false;
+    }
+    matches!(
+        children[0],
+        child if child == hardened(44)
+            || child == hardened(49)
+            || child == hardened(84)
+            || child == hardened(86)
+    ) && children[1].is_hardened()
+        && children[2].is_hardened()
+        && !children[3].is_hardened()
+        && !children[4].is_hardened()
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum LedgerMultisigAddressType {
+    Legacy,
+    ShWit,
+    Wit,
+}
+
+fn multisig_script(input: &Input) -> Option<(LedgerMultisigAddressType, ScriptBuf)> {
+    if let Some(witness_script) = &input.witness_script {
+        let address_type = if input.redeem_script.as_ref().is_some_and(|s| s.is_p2wsh()) {
+            LedgerMultisigAddressType::ShWit
+        } else {
+            LedgerMultisigAddressType::Wit
+        };
+        return Some((address_type, witness_script.clone()));
+    }
+    input
+        .redeem_script
+        .as_ref()
+        .map(|script| (LedgerMultisigAddressType::Legacy, script.clone()))
+}
+
+fn parse_multisig_script(script: &ScriptBuf) -> Result<Option<(usize, Vec<PublicKey>)>, String> {
+    let mut instructions = script.instructions();
+    let Some(first) = instructions.next() else {
+        return Ok(None);
+    };
+    let threshold = match first.map_err(|err| err.to_string())? {
+        Instruction::Op(op) => pushnum(op).filter(|n| *n <= 15),
+        Instruction::PushBytes(_) => None,
+    };
+    let Some(threshold) = threshold else {
+        return Ok(None);
+    };
+
+    let mut pubkeys = Vec::new();
+    let signer_count = loop {
+        let Some(instruction) = instructions.next() else {
+            return Ok(None);
+        };
+        match instruction.map_err(|err| err.to_string())? {
+            Instruction::PushBytes(bytes) if bytes.len() == 33 => {
+                let public_key = PublicKey::from_slice(push_bytes_as_bytes(bytes))
+                    .map_err(|err| err.to_string())?;
+                pubkeys.push(public_key);
+            }
+            Instruction::Op(op) => {
+                break pushnum(op);
+            }
+            Instruction::PushBytes(_) => return Ok(None),
+        }
+    };
+
+    let Some(signer_count) = signer_count else {
+        return Ok(None);
+    };
+    let Some(last) = instructions.next() else {
+        return Ok(None);
+    };
+    if last.map_err(|err| err.to_string())? != Instruction::Op(OP_CHECKMULTISIG)
+        || instructions.next().is_some()
+        || signer_count != pubkeys.len()
+        || threshold == 0
+        || threshold > signer_count
+    {
+        return Ok(None);
+    }
+    Ok(Some((threshold, pubkeys)))
+}
+
+fn global_xpub_key_expression(psbt: &Psbt, key_source: &KeySource) -> Option<String> {
+    let (fingerprint, key_path) = key_source;
+    psbt.xpub
+        .iter()
+        .find(|(_, (xpub_fingerprint, xpub_path))| {
+            xpub_fingerprint == fingerprint && path_starts_with(key_path, xpub_path)
+        })
+        .map(|(xpub, (_, xpub_path))| {
+            let origin = xpub_path.to_string();
+            let origin = origin.trim_start_matches('m').trim_start_matches('/');
+            if origin.is_empty() {
+                format!("[{fingerprint}]{xpub}")
+            } else {
+                format!("[{fingerprint}/{origin}]{xpub}")
+            }
+        })
+}
+
+fn path_starts_with(path: &DerivationPath, prefix: &DerivationPath) -> bool {
+    path.as_ref().starts_with(prefix.as_ref())
+}
+
+fn multisig_policy_descriptor(
+    address_type: LedgerMultisigAddressType,
+    threshold: usize,
+    keys: &[String],
+) -> String {
+    let body = format!("sortedmulti({threshold},{})", keys.join(","));
+    match address_type {
+        LedgerMultisigAddressType::Legacy => format!("sh({body})"),
+        LedgerMultisigAddressType::ShWit => format!("sh(wsh({body}))"),
+        LedgerMultisigAddressType::Wit => format!("wsh({body})"),
+    }
+}
+
+fn ledger_multisig_wallet_name(policy: &str) -> String {
+    let threshold = policy
+        .split_once("sortedmulti(")
+        .and_then(|(_, rest)| rest.split_once(','))
+        .and_then(|(threshold, _)| threshold.parse::<usize>().ok())
+        .unwrap_or(0);
+    let signers = policy
+        .matches("/**")
+        .count()
+        .max(policy.matches("/<0;1>/*").count());
+    format!("{threshold} of {signers} Multisig")
+}
+
+fn pushnum(op: bitcoin::blockdata::opcodes::Opcode) -> Option<usize> {
+    if op == OP_PUSHNUM_1 {
+        return Some(1);
+    }
+    if op.to_u8() >= OP_PUSHNUM_1.to_u8() && op.to_u8() <= OP_PUSHNUM_16.to_u8() {
+        return Some((op.to_u8() - OP_PUSHNUM_1.to_u8() + 1) as usize);
+    }
+    None
+}
+
+fn push_bytes_as_bytes(bytes: &PushBytes) -> &[u8] {
+    bytes.as_bytes()
+}
+
+fn hardened(index: u32) -> ChildNumber {
+    ChildNumber::from_hardened_idx(index).expect("valid hardened child")
 }
 
 fn master_xpub_path(
@@ -468,6 +938,8 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Getmasterxpub { addr_type, account } => {
             HwiCommand::GetMasterXpub { addr_type, account }
         }
+        HwiCliCommand::Signtx { psbt } => HwiCommand::SignTx { psbt },
+        HwiCliCommand::Signmessage { message, path } => HwiCommand::SignMessage { message, path },
         HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
         HwiCliCommand::External(argv) => {
             let command = argv
@@ -517,6 +989,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::{
+        Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Witness,
+        absolute::LockTime,
+        blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
+        secp256k1::Secp256k1,
+        transaction::Version as TxVersion,
+    };
 
     #[test]
     fn parses_enumerate_selector() {
@@ -661,6 +1140,55 @@ mod tests {
     }
 
     #[test]
+    fn parses_signtx_psbt_argument() {
+        let psbt = "cHNidP8BAHECAAAAAf//////////////////////////////////////////AAAAAAD/////AQAAAAAAAAAAAFYAAAAAAAABAR8AAAAAAAAAAFYA";
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "signtx",
+            psbt,
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.command,
+            HwiCommand::SignTx {
+                psbt: psbt.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_signmessage_arguments() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "signmessage",
+            "hello",
+            "m/44'/1'/0'/0",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.command,
+            HwiCommand::SignMessage {
+                message: "hello".to_owned(),
+                path: DerivationPath::from_str("m/44'/1'/0'/0").unwrap(),
+            }
+        );
+    }
+
+    #[test]
     fn accepts_python_hwi_version_flag() {
         let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
 
@@ -686,12 +1214,9 @@ mod tests {
 
     #[test]
     fn captures_unsupported_commands() {
-        let request = parse_args(["hwi", "signmessage"]).expect("unsupported command request");
+        let request = parse_args(["hwi", "setup"]).expect("unsupported command request");
 
-        assert_eq!(
-            request.command,
-            HwiCommand::Unsupported("signmessage".to_owned())
-        );
+        assert_eq!(request.command, HwiCommand::Unsupported("setup".to_owned()));
     }
 
     #[test]
@@ -758,6 +1283,23 @@ mod tests {
     }
 
     #[test]
+    fn signmessage_serializes_only_signature() {
+        let json = serde_json::to_value(HwiResponse::SignMessage(HwiSignMessageResponse {
+            signature: "base64-signature".to_owned(),
+        }))
+        .expect("json");
+
+        assert_eq!(json, serde_json::json!({ "signature": "base64-signature" }));
+    }
+
+    #[test]
+    fn signmessage_normalizes_coldcard_header_for_python_hwi() {
+        assert_eq!(python_hwi_message_header(DeviceType::Coldcard, 40), 32);
+        assert_eq!(python_hwi_message_header(DeviceType::Ledger, 32), 32);
+        assert_eq!(python_hwi_message_header(DeviceType::Jade, 31), 31);
+    }
+
+    #[test]
     fn getxpub_expert_serializes_python_hwi_field_names() {
         let xpub = sample_xpub();
 
@@ -817,8 +1359,183 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ledger_singlesig_account_path_accepts_standard_bip84() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+        let path = DerivationPath::from_str("m/84'/1'/0'/0/0").unwrap();
+        let psbt = psbt_with_input(Input {
+            bip32_derivation: [(sample_child_pubkey(0).inner, (fingerprint, path))].into(),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            ledger_singlesig_account_path(&psbt, fingerprint)
+                .unwrap()
+                .unwrap()
+                .to_string(),
+            "84'/1'/0'"
+        );
+    }
+
+    #[test]
+    fn ledger_singlesig_account_path_rejects_conflicting_accounts() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+        let psbt = psbt_with_inputs(vec![
+            Input {
+                bip32_derivation: [(
+                    sample_child_pubkey(0).inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/84'/1'/0'/0/0").unwrap(),
+                    ),
+                )]
+                .into(),
+                ..Default::default()
+            },
+            Input {
+                bip32_derivation: [(
+                    sample_child_pubkey(1).inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/84'/1'/1'/0/0").unwrap(),
+                    ),
+                )]
+                .into(),
+                ..Default::default()
+            },
+        ]);
+
+        let err = ledger_singlesig_account_path(&psbt, fingerprint).expect_err("conflict");
+        assert!(err.contains("Conflicting Ledger single-sig account paths"));
+    }
+
+    #[test]
+    fn ledger_multisig_policy_reconstructs_hwi_like_wsh_sortedmulti() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+        let account_path = DerivationPath::from_str("m/48'/1'/0'/2'").unwrap();
+        let xpub = sample_xpub();
+        let pubkey_a = sample_child_pubkey(0);
+        let pubkey_b = sample_child_pubkey(1);
+        let mut psbt = psbt_with_input(Input {
+            witness_script: Some(multisig_script_buf(2, &[pubkey_a, pubkey_b])),
+            bip32_derivation: [
+                (
+                    pubkey_a.inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/48'/1'/0'/2'/0/0").unwrap(),
+                    ),
+                ),
+                (
+                    pubkey_b.inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/48'/1'/0'/2'/0/1").unwrap(),
+                    ),
+                ),
+            ]
+            .into(),
+            ..Default::default()
+        });
+        psbt.xpub.insert(xpub, (fingerprint, account_path));
+
+        let policy = ledger_multisig_policy(&psbt, fingerprint)
+            .unwrap()
+            .expect("policy");
+
+        assert!(policy.starts_with("wsh(sortedmulti(2,"));
+        assert_eq!(policy.matches("/<0;1>/*").count(), 2);
+        assert!(policy.contains("[f5acc2fd/48'/1'/0'/2']"));
+    }
+
+    #[test]
+    fn ledger_multisig_policy_skips_missing_global_xpub() {
+        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+        let pubkey_a = sample_child_pubkey(0);
+        let pubkey_b = sample_child_pubkey(1);
+        let psbt = psbt_with_input(Input {
+            witness_script: Some(multisig_script_buf(2, &[pubkey_a, pubkey_b])),
+            bip32_derivation: [
+                (
+                    pubkey_a.inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/48'/1'/0'/2'/0/0").unwrap(),
+                    ),
+                ),
+                (
+                    pubkey_b.inner,
+                    (
+                        fingerprint,
+                        DerivationPath::from_str("m/48'/1'/0'/2'/0/1").unwrap(),
+                    ),
+                ),
+            ]
+            .into(),
+            ..Default::default()
+        });
+
+        assert!(
+            ledger_multisig_policy(&psbt, fingerprint)
+                .unwrap()
+                .is_none()
+        );
+    }
+
     fn sample_xpub() -> Xpub {
         Xpub::from_str("tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT")
             .expect("sample xpub")
+    }
+
+    fn sample_child_pubkey(index: u32) -> PublicKey {
+        let secp = Secp256k1::verification_only();
+        let xpub = sample_xpub()
+            .derive_pub(
+                &secp,
+                &[
+                    ChildNumber::from_normal_idx(0).unwrap(),
+                    ChildNumber::from_normal_idx(index).unwrap(),
+                ],
+            )
+            .expect("derive pubkey");
+        PublicKey::new(xpub.public_key)
+    }
+
+    fn multisig_script_buf(threshold: i64, pubkeys: &[PublicKey]) -> ScriptBuf {
+        let mut builder = Builder::new().push_int(threshold);
+        for pubkey in pubkeys {
+            builder = builder.push_slice(pubkey.inner.serialize());
+        }
+        builder
+            .push_int(pubkeys.len() as i64)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script()
+    }
+
+    fn psbt_with_input(input: Input) -> Psbt {
+        psbt_with_inputs(vec![input])
+    }
+
+    fn psbt_with_inputs(inputs: Vec<Input>) -> Psbt {
+        let unsigned_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: inputs
+                .iter()
+                .map(|_| TxIn {
+                    previous_output: OutPoint::null(),
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                })
+                .collect(),
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("psbt");
+        psbt.inputs = inputs;
+        psbt
     }
 }

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::OsString,
     io::{self, BufRead},
+    path::PathBuf,
     process::ExitCode,
     str::FromStr,
 };
@@ -30,8 +31,10 @@ use miniscript::{
 use serde::{Serialize, Serializer};
 
 use crate::{
-    Device, DeviceManager, DeviceType, config::DeviceSelector,
+    Device, DeviceManager, DeviceType,
+    config::DeviceSelector,
     get_descriptors::GetDescriptorOptions,
+    udev::{UdevRuleSelection, install_udev_rules},
 };
 
 type HwiResult<T> = std::result::Result<T, HwiError>;
@@ -145,6 +148,10 @@ pub enum HwiCliCommand {
         pin: String,
     },
     Togglepassphrase,
+    Installudevrules {
+        #[arg(long, default_value = "/etc/udev/rules.d/")]
+        location: PathBuf,
+    },
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -188,6 +195,9 @@ pub enum HwiCommand {
         path: Option<String>,
     },
     UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
+    InstallUdevRules {
+        location: PathBuf,
+    },
     Unsupported(String),
 }
 
@@ -251,6 +261,7 @@ pub enum HwiErrorCode {
     UnsupportedCommand,
     DeviceFailure,
     DeviceConnectionError,
+    NeedToBeRoot,
 }
 
 impl HwiErrorCode {
@@ -261,6 +272,7 @@ impl HwiErrorCode {
             HwiErrorCode::UnsupportedCommand => -9,
             HwiErrorCode::DeviceFailure => -13,
             HwiErrorCode::DeviceConnectionError => -3,
+            HwiErrorCode::NeedToBeRoot => -16,
         }
     }
 }
@@ -306,7 +318,13 @@ pub enum HwiResponse {
     SignTx(HwiSignTxResponse),
     SignMessage(HwiSignMessageResponse),
     DisplayAddress(HwiDisplayAddressResponse),
+    Success(HwiSuccessResponse),
     Error(HwiError),
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiSuccessResponse {
+    pub success: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -416,6 +434,7 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
+        HwiCommand::InstallUdevRules { location } => install_udev_rules_hwi(location),
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
             format!("Unsupported HWI command: {command}"),
@@ -524,6 +543,20 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
         });
     }
     HwiResponse::Enumerate(response)
+}
+
+fn install_udev_rules_hwi(location: PathBuf) -> HwiResponse {
+    match install_udev_rules(&location, UdevRuleSelection::All) {
+        Ok(()) => HwiResponse::Success(HwiSuccessResponse { success: true }),
+        Err(err) if err.needs_root() => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NeedToBeRoot,
+            "installudevrules failed: Need to be root.",
+        )),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceFailure,
+            format!("installudevrules failed: {err}"),
+        )),
+    }
 }
 
 async fn unsupported_device_action(
@@ -1928,6 +1961,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Togglepassphrase => {
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
         }
+        HwiCliCommand::Installudevrules { location } => HwiCommand::InstallUdevRules { location },
         HwiCliCommand::External(argv) => {
             let command = argv
                 .first()
@@ -2469,6 +2503,21 @@ mod tests {
         assert_eq!(
             togglepassphrase.command,
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
+        );
+    }
+
+    #[test]
+    fn parses_installudevrules_without_device_selection() {
+        let request = parse_args(["hwi", "installudevrules", "--location", "/tmp/bhwi-rules.d"])
+            .expect("installudevrules request");
+
+        assert_eq!(request.selector.device_type, None);
+        assert_eq!(request.selector.fingerprint, None);
+        assert_eq!(
+            request.command,
+            HwiCommand::InstallUdevRules {
+                location: PathBuf::from("/tmp/bhwi-rules.d"),
+            }
         );
     }
 

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -1,9 +1,11 @@
 use std::{
     ffi::OsString,
+    fs,
     io::{self, BufRead},
     path::PathBuf,
     process::ExitCode,
     str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use bhwi::{
@@ -637,34 +639,87 @@ async fn backup_device(
         }
     };
 
-    let unsupported = HwiUnsupportedDeviceAction::Backup {
-        label: label.clone(),
-        backup_passphrase: backup_passphrase.clone(),
-    };
-    if device.device_type() != DeviceType::BitBox02 {
-        return HwiResponse::Error(HwiError::new(
-            HwiErrorCode::UnsupportedCommand,
-            hwi_unavailable_action_message(device.device_type(), &unsupported),
-        ));
-    }
-    if !label.is_empty() || !backup_passphrase.is_empty() {
-        return HwiResponse::Error(HwiError::new(
-            HwiErrorCode::UnsupportedCommand,
-            "Label/passphrase not needed when exporting mnemonic from the BitBox02.",
-        ));
+    let device_type = device.device_type();
+    match device_type {
+        DeviceType::BitBox02 => {
+            if !label.is_empty() || !backup_passphrase.is_empty() {
+                return HwiResponse::Error(HwiError::new(
+                    HwiErrorCode::UnsupportedCommand,
+                    "Label/passphrase not needed when exporting mnemonic from the BitBox02.",
+                ));
+            }
+        }
+        DeviceType::Coldcard => {}
+        DeviceType::Ledger | DeviceType::Jade => {
+            let unsupported = HwiUnsupportedDeviceAction::Backup {
+                label,
+                backup_passphrase,
+            };
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::UnsupportedCommand,
+                hwi_unavailable_action_message(device_type, &unsupported),
+            ));
+        }
     }
 
     match device.device().backup_device().await {
         Ok(DeviceBackup::Complete) => HwiResponse::Success(HwiSuccessResponse { success: true }),
-        Ok(DeviceBackup::File(_)) => HwiResponse::Error(HwiError::new(
-            HwiErrorCode::DeviceFailure,
-            "BitBox02 backup unexpectedly returned file data",
-        )),
+        Ok(DeviceBackup::File(bytes)) => match write_hwi_backup_file(&bytes) {
+            Ok(()) => HwiResponse::Success(HwiSuccessResponse { success: true }),
+            Err(err) => HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceFailure,
+                format!("backup failed: {err}"),
+            )),
+        },
         Err(err) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::DeviceConnectionError,
             err.to_string(),
         )),
     }
+}
+
+fn write_hwi_backup_file(bytes: &[u8]) -> io::Result<()> {
+    fs::write(hwi_backup_filename()?, bytes)
+}
+
+fn hwi_backup_filename() -> io::Result<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?;
+    let timestamp = now.as_secs().try_into().map_err(io::Error::other)?;
+    let tm = local_time(timestamp)?;
+
+    Ok(format!(
+        "backup-{:04}{:02}{:02}-{:02}{:02}.7z",
+        tm.tm_year + 1900,
+        tm.tm_mon + 1,
+        tm.tm_mday,
+        tm.tm_hour,
+        tm.tm_min
+    ))
+}
+
+#[cfg(unix)]
+fn local_time(timestamp: libc::time_t) -> io::Result<libc::tm> {
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+    // Python HWI uses `time.strftime`, i.e. the process local timezone.
+    unsafe {
+        if libc::localtime_r(&timestamp, tm.as_mut_ptr()).is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(tm.assume_init())
+    }
+}
+
+#[cfg(windows)]
+fn local_time(timestamp: libc::time_t) -> io::Result<libc::tm> {
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+    // Windows uses the bounds-checked variant with destination first.
+    let code = unsafe { libc::localtime_s(tm.as_mut_ptr(), &timestamp) };
+    if code != 0 {
+        return Err(io::Error::from_raw_os_error(code));
+    }
+    Ok(unsafe { tm.assume_init() })
 }
 
 async fn get_master_xpub(

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -21,10 +21,16 @@ use bitcoin::{
     psbt::Input,
 };
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
-use miniscript::descriptor::WalletPolicy;
+use miniscript::{
+    Descriptor, DescriptorPublicKey,
+    descriptor::{DescriptorType, WalletPolicy, checksum},
+};
 use serde::{Serialize, Serializer};
 
-use crate::{Device, DeviceManager, DeviceType, config::DeviceSelector};
+use crate::{
+    Device, DeviceManager, DeviceType, config::DeviceSelector,
+    get_descriptors::GetDescriptorOptions,
+};
 
 type HwiResult<T> = std::result::Result<T, HwiError>;
 
@@ -78,6 +84,10 @@ pub enum HwiCliCommand {
         #[arg(value_parser = clap::value_parser!(DerivationPath))]
         path: DerivationPath,
     },
+    Getdescriptors {
+        #[arg(long, default_value_t = 0)]
+        account: u32,
+    },
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -105,6 +115,9 @@ pub enum HwiCommand {
     GetXpub {
         path: DerivationPath,
         expert: bool,
+    },
+    GetDescriptors {
+        account: u32,
     },
     Unsupported(String),
 }
@@ -182,6 +195,7 @@ pub struct HwiEnumeratedDevice {
 pub enum HwiResponse {
     Enumerate(Vec<HwiEnumeratedDevice>),
     GetXpub(HwiGetXpubResponse),
+    GetDescriptors(HwiGetDescriptorsResponse),
     SignTx(HwiSignTxResponse),
     SignMessage(HwiSignMessageResponse),
     Error(HwiError),
@@ -221,6 +235,12 @@ pub struct HwiGetXpubResponse {
     pub pubkey: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct HwiGetDescriptorsResponse {
+    pub receive: Vec<String>,
+    pub internal: Vec<String>,
+}
+
 pub fn parse_args<I, T>(args: I) -> HwiResult<HwiRequest>
 where
     I: IntoIterator<Item = T>,
@@ -242,6 +262,7 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             sign_message(request.selector, message, path).await
         }
         HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
+        HwiCommand::GetDescriptors { account } => get_descriptors(request.selector, account).await,
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
             format!("Unsupported HWI command: {command}"),
@@ -527,6 +548,87 @@ async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) 
             err.to_string(),
         )),
     }
+}
+
+async fn get_descriptors(selector: DeviceSelector, account: u32) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let fingerprint = match device.fingerprint().await {
+        Ok(fingerprint) => fingerprint,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+    let device_type = device.device_type();
+    let model = device.model().to_owned();
+    let network = manager.selector.network;
+    let mut response = HwiGetDescriptorsResponse {
+        receive: Vec::new(),
+        internal: Vec::new(),
+    };
+
+    for internal in [false, true] {
+        for addr_type in hwi_descriptor_addr_types(device_type, &model) {
+            let descriptor_type = descriptor_type_for(addr_type);
+            let options = GetDescriptorOptions::with_account(
+                fingerprint,
+                account,
+                internal,
+                descriptor_type,
+                network,
+            );
+            let descriptor = match manager.get_descriptor(device.device(), options).await {
+                Ok(descriptor) => descriptor,
+                Err(err) => {
+                    return HwiResponse::Error(HwiError::new(
+                        HwiErrorCode::DeviceConnectionError,
+                        err.to_string(),
+                    ));
+                }
+            };
+            let descriptor = match hwi_descriptor_string(&descriptor) {
+                Ok(descriptor) => descriptor,
+                Err(err) => {
+                    return HwiResponse::Error(HwiError::new(
+                        HwiErrorCode::BadArgument,
+                        err.to_string(),
+                    ));
+                }
+            };
+            if internal {
+                response.internal.push(descriptor);
+            } else {
+                response.receive.push(descriptor);
+            }
+        }
+    }
+
+    HwiResponse::GetDescriptors(response)
 }
 
 async fn ledger_signing_context(
@@ -853,6 +955,44 @@ fn bip44_chain(network: Network) -> u32 {
     if network == Network::Bitcoin { 0 } else { 1 }
 }
 
+fn descriptor_type_for(addr_type: HwiAddressType) -> DescriptorType {
+    match addr_type {
+        HwiAddressType::Legacy => DescriptorType::Pkh,
+        HwiAddressType::ShWit => DescriptorType::ShWpkh,
+        HwiAddressType::Wit => DescriptorType::Wpkh,
+        HwiAddressType::Tap => DescriptorType::Tr,
+    }
+}
+
+fn hwi_descriptor_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAddressType> {
+    let mut types = vec![
+        HwiAddressType::Legacy,
+        HwiAddressType::Wit,
+        HwiAddressType::ShWit,
+    ];
+    if hwi_can_sign_taproot(device_type, model) {
+        types.push(HwiAddressType::Tap);
+    }
+    types
+}
+
+fn hwi_can_sign_taproot(device_type: DeviceType, model: &str) -> bool {
+    match device_type {
+        DeviceType::Ledger => true,
+        DeviceType::Jade => false,
+        DeviceType::Coldcard => model.contains("edge"),
+    }
+}
+
+fn hwi_descriptor_string(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+) -> Result<String, checksum::Error> {
+    let descriptor = format!("{descriptor:#}").replace('\'', "h");
+    let mut checksum = checksum::Engine::new();
+    checksum.input(&descriptor)?;
+    Ok(format!("{descriptor}#{}", checksum.checksum()))
+}
+
 fn get_xpub_response(xpub: Xpub, expert: bool) -> HwiGetXpubResponse {
     if !expert {
         return HwiGetXpubResponse {
@@ -941,6 +1081,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Signtx { psbt } => HwiCommand::SignTx { psbt },
         HwiCliCommand::Signmessage { message, path } => HwiCommand::SignMessage { message, path },
         HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
+        HwiCliCommand::Getdescriptors { account } => HwiCommand::GetDescriptors { account },
         HwiCliCommand::External(argv) => {
             let command = argv
                 .first()
@@ -1189,6 +1330,25 @@ mod tests {
     }
 
     #[test]
+    fn parses_getdescriptors_account() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "getdescriptors",
+            "--account",
+            "3",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(request.command, HwiCommand::GetDescriptors { account: 3 });
+    }
+
+    #[test]
     fn accepts_python_hwi_version_flag() {
         let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
 
@@ -1293,10 +1453,74 @@ mod tests {
     }
 
     #[test]
+    fn getdescriptors_serializes_receive_and_internal() {
+        let json = serde_json::to_value(HwiResponse::GetDescriptors(HwiGetDescriptorsResponse {
+            receive: vec!["wpkh(...)#receive".to_owned()],
+            internal: vec!["wpkh(...)#internal".to_owned()],
+        }))
+        .expect("json");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "receive": ["wpkh(...)#receive"],
+                "internal": ["wpkh(...)#internal"],
+            })
+        );
+    }
+
+    #[test]
     fn signmessage_normalizes_coldcard_header_for_python_hwi() {
         assert_eq!(python_hwi_message_header(DeviceType::Coldcard, 40), 32);
         assert_eq!(python_hwi_message_header(DeviceType::Ledger, 32), 32);
         assert_eq!(python_hwi_message_header(DeviceType::Jade, 31), 31);
+    }
+
+    #[test]
+    fn hwi_descriptor_string_uses_hardened_h_and_recomputes_checksum() {
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(
+            "wpkh([f5acc2fd/84'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/0/*)",
+        )
+        .expect("descriptor");
+
+        let descriptor = hwi_descriptor_string(&descriptor).expect("descriptor string");
+
+        assert!(descriptor.contains("/84h/1h/0h]"));
+        assert!(!descriptor.contains('\''));
+        checksum::verify_checksum(&descriptor).expect("valid checksum");
+    }
+
+    #[test]
+    fn descriptor_addr_types_match_python_hwi_taproot_capabilities() {
+        assert_eq!(
+            hwi_descriptor_addr_types(DeviceType::Ledger, "ledger_nano_s_simulator"),
+            vec![
+                HwiAddressType::Legacy,
+                HwiAddressType::Wit,
+                HwiAddressType::ShWit,
+                HwiAddressType::Tap,
+            ]
+        );
+        assert_eq!(
+            hwi_descriptor_addr_types(DeviceType::Jade, "jade_simulator"),
+            vec![
+                HwiAddressType::Legacy,
+                HwiAddressType::Wit,
+                HwiAddressType::ShWit,
+            ]
+        );
+        assert_eq!(
+            hwi_descriptor_addr_types(DeviceType::Coldcard, "coldcard_simulator"),
+            vec![
+                HwiAddressType::Legacy,
+                HwiAddressType::Wit,
+                HwiAddressType::ShWit,
+            ]
+        );
+        assert!(hwi_can_sign_taproot(
+            DeviceType::Coldcard,
+            "coldcard_simulator_edge"
+        ));
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -7,9 +7,9 @@ use std::{
 
 use bitcoin::{
     Network, NetworkKind,
-    bip32::{DerivationPath, Fingerprint, Xpub},
+    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
 };
-use clap::{Parser, Subcommand, error::ErrorKind};
+use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use serde::{Serialize, Serializer};
 
 use crate::{DeviceManager, DeviceType, config::DeviceSelector};
@@ -48,6 +48,12 @@ pub struct HwiCli {
 #[derive(Debug, Clone, Subcommand)]
 pub enum HwiCliCommand {
     Enumerate,
+    Getmasterxpub {
+        #[arg(long = "addr-type", value_enum, default_value = "wit")]
+        addr_type: HwiAddressType,
+        #[arg(long, default_value_t = 0)]
+        account: u32,
+    },
     Getxpub {
         #[arg(value_parser = clap::value_parser!(DerivationPath))]
         path: DerivationPath,
@@ -65,8 +71,27 @@ pub struct HwiRequest {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum HwiCommand {
     Enumerate,
-    GetXpub { path: DerivationPath, expert: bool },
+    GetMasterXpub {
+        addr_type: HwiAddressType,
+        account: u32,
+    },
+    GetXpub {
+        path: DerivationPath,
+        expert: bool,
+    },
     Unsupported(String),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum HwiAddressType {
+    #[value(name = "legacy")]
+    Legacy,
+    #[value(name = "sh_wit")]
+    ShWit,
+    #[value(name = "wit")]
+    Wit,
+    #[value(name = "tap")]
+    Tap,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
@@ -169,6 +194,9 @@ where
 pub async fn process_request(request: HwiRequest) -> HwiResponse {
     match request.command {
         HwiCommand::Enumerate => enumerate(request.selector).await,
+        HwiCommand::GetMasterXpub { addr_type, account } => {
+            get_master_xpub(request.selector, addr_type, account).await
+        }
         HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
@@ -280,6 +308,20 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
     HwiResponse::Enumerate(response)
 }
 
+async fn get_master_xpub(
+    selector: DeviceSelector,
+    addr_type: HwiAddressType,
+    account: u32,
+) -> HwiResponse {
+    let path = match master_xpub_path(addr_type, selector.network, account) {
+        Ok(path) => path,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(HwiErrorCode::BadArgument, err.to_string()));
+        }
+    };
+    get_xpub(selector, path, false).await
+}
+
 async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) -> HwiResponse {
     if selector.device_type.is_none() && selector.fingerprint.is_none() {
         return HwiResponse::Error(HwiError::new(
@@ -312,6 +354,33 @@ async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) 
             err.to_string(),
         )),
     }
+}
+
+fn master_xpub_path(
+    addr_type: HwiAddressType,
+    network: Network,
+    account: u32,
+) -> Result<DerivationPath, bitcoin::bip32::Error> {
+    Ok([
+        ChildNumber::from_hardened_idx(bip44_purpose(addr_type))?,
+        ChildNumber::from_hardened_idx(bip44_chain(network))?,
+        ChildNumber::from_hardened_idx(account)?,
+    ]
+    .as_ref()
+    .into())
+}
+
+fn bip44_purpose(addr_type: HwiAddressType) -> u32 {
+    match addr_type {
+        HwiAddressType::Legacy => 44,
+        HwiAddressType::ShWit => 49,
+        HwiAddressType::Wit => 84,
+        HwiAddressType::Tap => 86,
+    }
+}
+
+fn bip44_chain(network: Network) -> u32 {
+    if network == Network::Bitcoin { 0 } else { 1 }
 }
 
 fn get_xpub_response(xpub: Xpub, expert: bool) -> HwiGetXpubResponse {
@@ -396,6 +465,9 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
     let network = parse_chain(&args.chain)?;
     let command = match args.command {
         HwiCliCommand::Enumerate => HwiCommand::Enumerate,
+        HwiCliCommand::Getmasterxpub { addr_type, account } => {
+            HwiCommand::GetMasterXpub { addr_type, account }
+        }
         HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
         HwiCliCommand::External(argv) => {
             let command = argv
@@ -544,6 +616,51 @@ mod tests {
     }
 
     #[test]
+    fn parses_getmasterxpub_defaults() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "--emulators",
+            "getmasterxpub",
+        ])
+        .expect("request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::GetMasterXpub {
+                addr_type: HwiAddressType::Wit,
+                account: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_getmasterxpub_addr_type_and_account() {
+        let request = parse_args([
+            "hwi",
+            "--device-type",
+            "ledger",
+            "getmasterxpub",
+            "--addr-type",
+            "sh_wit",
+            "--account",
+            "7",
+        ])
+        .expect("request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::GetMasterXpub {
+                addr_type: HwiAddressType::ShWit,
+                account: 7,
+            }
+        );
+    }
+
+    #[test]
     fn accepts_python_hwi_version_flag() {
         let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
 
@@ -569,11 +686,11 @@ mod tests {
 
     #[test]
     fn captures_unsupported_commands() {
-        let request = parse_args(["hwi", "getmasterxpub"]).expect("unsupported command request");
+        let request = parse_args(["hwi", "signmessage"]).expect("unsupported command request");
 
         assert_eq!(
             request.command,
-            HwiCommand::Unsupported("getmasterxpub".to_owned())
+            HwiCommand::Unsupported("signmessage".to_owned())
         );
     }
 
@@ -662,6 +779,42 @@ mod tests {
         assert_eq!(json["pubkey"], hex::encode(xpub.public_key.serialize()));
         assert!(!object.contains_key("child_index"));
         assert!(!object.contains_key("chain_code"));
+    }
+
+    #[test]
+    fn master_xpub_path_matches_python_hwi_addr_types() {
+        for (addr_type, expected) in [
+            (HwiAddressType::Legacy, "44'/1'/7'"),
+            (HwiAddressType::ShWit, "49'/1'/7'"),
+            (HwiAddressType::Wit, "84'/1'/7'"),
+            (HwiAddressType::Tap, "86'/1'/7'"),
+        ] {
+            let path = master_xpub_path(addr_type, Network::Testnet, 7).unwrap();
+            assert_eq!(path.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn master_xpub_path_uses_mainnet_coin_type_only_for_mainnet() {
+        assert_eq!(
+            master_xpub_path(HwiAddressType::Wit, Network::Bitcoin, 0)
+                .unwrap()
+                .to_string(),
+            "84'/0'/0'"
+        );
+        for network in [
+            Network::Testnet,
+            Network::Testnet4,
+            Network::Signet,
+            Network::Regtest,
+        ] {
+            assert_eq!(
+                master_xpub_path(HwiAddressType::Wit, network, 0)
+                    .unwrap()
+                    .to_string(),
+                "84'/1'/0'"
+            );
+        }
     }
 
     fn sample_xpub() -> Xpub {

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -532,8 +532,8 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
         };
         response.push(HwiEnumeratedDevice {
             device_type: device.device_type().to_string(),
-            model: device.model().to_owned(),
-            path: device.path().to_owned(),
+            model: hwi_enumerate_model(device.device_type(), device.model(), device.is_emulated()),
+            path: hwi_enumerate_path(device.device_type(), device.path(), device.is_emulated()),
             label: label_for(device.device_type()),
             fingerprint,
             needs_pin_sent: false,
@@ -1757,8 +1757,22 @@ fn get_xpub_response(xpub: Xpub, expert: bool) -> HwiGetXpubResponse {
 
 fn label_for(device_type: DeviceType) -> Option<Option<String>> {
     match device_type {
-        DeviceType::BitBox02 | DeviceType::Coldcard | DeviceType::Ledger => Some(None),
-        DeviceType::Jade => None,
+        DeviceType::Coldcard | DeviceType::Ledger => Some(None),
+        DeviceType::BitBox02 | DeviceType::Jade => None,
+    }
+}
+
+fn hwi_enumerate_model(device_type: DeviceType, model: &str, is_emulated: bool) -> String {
+    match (device_type, is_emulated) {
+        (DeviceType::BitBox02, true) => "bitbox02_multi".to_owned(),
+        _ => model.to_owned(),
+    }
+}
+
+fn hwi_enumerate_path(device_type: DeviceType, path: &str, is_emulated: bool) -> String {
+    match (device_type, is_emulated) {
+        (DeviceType::BitBox02, true) => path.strip_prefix("tcp:").unwrap_or(path).to_owned(),
+        _ => path.to_owned(),
     }
 }
 
@@ -2641,6 +2655,26 @@ mod tests {
 
         assert!(json.get("label").is_none());
         assert!(json.get("fingerprint").is_none());
+    }
+
+    #[test]
+    fn bitbox_emulator_enumerate_shape_matches_python_hwi() {
+        let json = serde_json::to_value(HwiEnumeratedDevice {
+            device_type: "bitbox02".to_owned(),
+            model: hwi_enumerate_model(DeviceType::BitBox02, "bitbox02_simulator", true),
+            path: hwi_enumerate_path(DeviceType::BitBox02, "tcp:127.0.0.1:15423", true),
+            label: label_for(DeviceType::BitBox02),
+            fingerprint: None,
+            needs_pin_sent: false,
+            needs_passphrase_sent: false,
+            error: None,
+            code: None,
+        })
+        .expect("json");
+
+        assert_eq!(json["model"], "bitbox02_multi");
+        assert_eq!(json["path"], "127.0.0.1:15423");
+        assert!(json.get("label").is_none());
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -893,7 +893,7 @@ async fn get_descriptors(selector: DeviceSelector, account: u32) -> HwiResponse 
     };
 
     for internal in [false, true] {
-        for addr_type in hwi_descriptor_addr_types(device_type, &model) {
+        for addr_type in hwi_getdescriptors_addr_types(device_type, &model) {
             let descriptor_type = descriptor_type_for(addr_type);
             let options = GetDescriptorOptions::with_account(
                 fingerprint,
@@ -1679,6 +1679,13 @@ fn hwi_descriptor_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAdd
         types.push(HwiAddressType::Tap);
     }
     types
+}
+
+fn hwi_getdescriptors_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAddressType> {
+    match device_type {
+        DeviceType::BitBox02 => vec![HwiAddressType::Wit, HwiAddressType::ShWit],
+        _ => hwi_descriptor_addr_types(device_type, model),
+    }
 }
 
 fn hwi_can_sign_taproot(device_type: DeviceType, model: &str) -> bool {
@@ -2914,6 +2921,10 @@ mod tests {
                 HwiAddressType::Wit,
                 HwiAddressType::ShWit,
             ]
+        );
+        assert_eq!(
+            hwi_getdescriptors_addr_types(DeviceType::BitBox02, "bitbox02_multi"),
+            vec![HwiAddressType::Wit, HwiAddressType::ShWit]
         );
         assert!(hwi_can_sign_taproot(
             DeviceType::Coldcard,

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -7,9 +7,10 @@ use std::{
 
 use bhwi::{
     bitcoin::psbt::Psbt,
+    common::{MultisigAddressType, MultisigDisplayAddress, MultisigDisplayKey},
     ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
 };
-use bhwi_async::DeviceContext;
+use bhwi_async::{DeviceContext, DisplayAddress};
 use bitcoin::{
     Network, NetworkKind, PublicKey, ScriptBuf,
     base64::prelude::{BASE64_STANDARD, Engine as _},
@@ -19,8 +20,9 @@ use bitcoin::{
         script::{Instruction, PushBytes},
     },
     psbt::Input,
+    secp256k1::{PublicKey as SecpPublicKey, XOnlyPublicKey},
 };
-use clap::{ArgAction, Parser, Subcommand, ValueEnum, error::ErrorKind};
+use clap::{ArgAction, ArgGroup, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use miniscript::{
     Descriptor, DescriptorPublicKey,
     descriptor::{DescriptorType, WalletPolicy, checksum},
@@ -80,6 +82,19 @@ pub enum HwiCliCommand {
         #[arg(value_parser = clap::value_parser!(DerivationPath))]
         path: DerivationPath,
     },
+    #[command(group(
+        ArgGroup::new("address_target")
+            .required(true)
+            .args(["path", "desc"])
+    ))]
+    Displayaddress {
+        #[arg(long, conflicts_with = "desc")]
+        path: Option<DerivationPath>,
+        #[arg(long, conflicts_with = "path")]
+        desc: Option<String>,
+        #[arg(long = "addr-type", value_enum, default_value = "wit")]
+        addr_type: HwiAddressType,
+    },
     Getxpub {
         #[arg(value_parser = clap::value_parser!(DerivationPath))]
         path: DerivationPath,
@@ -130,6 +145,7 @@ pub enum HwiCommand {
         message: String,
         path: DerivationPath,
     },
+    DisplayAddress(HwiDisplayAddressRequest),
     GetXpub {
         path: DerivationPath,
         expert: bool,
@@ -148,6 +164,17 @@ pub enum HwiCommand {
         path: Option<String>,
     },
     Unsupported(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum HwiDisplayAddressRequest {
+    Path {
+        path: DerivationPath,
+        addr_type: HwiAddressType,
+    },
+    Descriptor {
+        descriptor: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
@@ -173,6 +200,7 @@ pub enum HwiErrorCode {
     NoDeviceType,
     BadArgument,
     UnsupportedCommand,
+    DeviceFailure,
     DeviceConnectionError,
 }
 
@@ -182,6 +210,7 @@ impl HwiErrorCode {
             HwiErrorCode::NoDeviceType => -1,
             HwiErrorCode::BadArgument => -7,
             HwiErrorCode::UnsupportedCommand => -9,
+            HwiErrorCode::DeviceFailure => -13,
             HwiErrorCode::DeviceConnectionError => -3,
         }
     }
@@ -227,6 +256,7 @@ pub enum HwiResponse {
     GetKeypool(Vec<HwiGetKeypoolEntry>),
     SignTx(HwiSignTxResponse),
     SignMessage(HwiSignMessageResponse),
+    DisplayAddress(HwiDisplayAddressResponse),
     Error(HwiError),
 }
 
@@ -239,6 +269,11 @@ pub struct HwiSignTxResponse {
 #[derive(Debug, Serialize)]
 pub struct HwiSignMessageResponse {
     pub signature: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiDisplayAddressResponse {
+    pub address: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -301,6 +336,7 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
         HwiCommand::SignMessage { message, path } => {
             sign_message(request.selector, message, path).await
         }
+        HwiCommand::DisplayAddress(address) => display_address(request.selector, address).await,
         HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
         HwiCommand::GetDescriptors { account } => get_descriptors(request.selector, account).await,
         HwiCommand::GetKeypool {
@@ -558,6 +594,79 @@ async fn sign_message(
             HwiErrorCode::DeviceConnectionError,
             err.to_string(),
         )),
+    }
+}
+
+async fn display_address(
+    selector: DeviceSelector,
+    request: HwiDisplayAddressRequest,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let display = match request {
+        HwiDisplayAddressRequest::Path { path, addr_type } => {
+            if device.device_type() == DeviceType::Coldcard && addr_type == HwiAddressType::Tap {
+                return HwiResponse::Error(HwiError::new(
+                    HwiErrorCode::UnsupportedCommand,
+                    "Coldcard does not support displaying Taproot addresses yet",
+                ));
+            }
+            if device.device_type() == DeviceType::Jade && addr_type == HwiAddressType::Tap {
+                return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceFailure, "tap"));
+            }
+            Ok(DisplayAddress::ByPath {
+                path,
+                display: true,
+                address_format: Some(address_type_for(addr_type)),
+            })
+        }
+        HwiDisplayAddressRequest::Descriptor { descriptor } => {
+            match singlesig_display_address_from_descriptor(&mut device, &descriptor).await {
+                Ok(address) => Ok(address),
+                Err(single_sig_error) => {
+                    if device.device_type() == DeviceType::Coldcard {
+                        match multisig_display_address_from_descriptor(&descriptor) {
+                            Ok(address) => Ok(DisplayAddress::ByMultisig(address)),
+                            Err(_) => return HwiResponse::Error(single_sig_error),
+                        }
+                    } else {
+                        return HwiResponse::Error(single_sig_error);
+                    }
+                }
+            }
+        }
+    };
+
+    let display = match display {
+        Ok(display) => display,
+        Err(error) => return HwiResponse::Error(error),
+    };
+
+    match device.device().display_address(display, None).await {
+        Ok(address) => HwiResponse::DisplayAddress(HwiDisplayAddressResponse { address }),
+        Err(err) => display_address_error(err.to_string()),
     }
 }
 
@@ -1157,6 +1266,283 @@ fn descriptor_type_for(addr_type: HwiAddressType) -> DescriptorType {
     }
 }
 
+fn address_type_for(addr_type: HwiAddressType) -> bitcoin::address::AddressType {
+    match addr_type {
+        HwiAddressType::Legacy => bitcoin::address::AddressType::P2pkh,
+        HwiAddressType::ShWit => bitcoin::address::AddressType::P2sh,
+        HwiAddressType::Wit => bitcoin::address::AddressType::P2wpkh,
+        HwiAddressType::Tap => bitcoin::address::AddressType::P2tr,
+    }
+}
+
+async fn singlesig_display_address_from_descriptor(
+    device: &mut Device,
+    descriptor: &str,
+) -> Result<DisplayAddress, HwiError> {
+    let descriptor = strip_descriptor_checksum(descriptor);
+    let parsed = parse_singlesig_display_descriptor(descriptor)?;
+    let fingerprint = device
+        .fingerprint()
+        .await
+        .map_err(|err| HwiError::new(HwiErrorCode::DeviceConnectionError, err.to_string()))?;
+    if parsed.fingerprint != fingerprint {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Descriptor fingerprint does not match device: {descriptor}"),
+        ));
+    }
+
+    let xpub = device
+        .device()
+        .get_extended_pubkey(parsed.origin_path.clone(), false)
+        .await
+        .map_err(|err| HwiError::new(HwiErrorCode::DeviceConnectionError, err.to_string()))?;
+
+    if !descriptor_key_matches_xpub(&parsed.key, xpub) {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Key in descriptor does not match device: {descriptor}"),
+        ));
+    }
+
+    Ok(DisplayAddress::ByPath {
+        path: parsed.full_path,
+        display: true,
+        address_format: Some(address_type_for(parsed.addr_type)),
+    })
+}
+
+#[derive(Debug)]
+struct ParsedSingleSigDisplayDescriptor {
+    addr_type: HwiAddressType,
+    fingerprint: Fingerprint,
+    origin_path: DerivationPath,
+    full_path: DerivationPath,
+    key: String,
+}
+
+fn parse_singlesig_display_descriptor(
+    descriptor: &str,
+) -> Result<ParsedSingleSigDisplayDescriptor, HwiError> {
+    let (addr_type, key_expr) = if let Some(inner) = descriptor
+        .strip_prefix("sh(wpkh(")
+        .and_then(|value| value.strip_suffix("))"))
+    {
+        (HwiAddressType::ShWit, inner)
+    } else if let Some(inner) = descriptor
+        .strip_prefix("wpkh(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        (HwiAddressType::Wit, inner)
+    } else if let Some(inner) = descriptor
+        .strip_prefix("pkh(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        (HwiAddressType::Legacy, inner)
+    } else if let Some(inner) = descriptor
+        .strip_prefix("tr(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        (HwiAddressType::Tap, inner)
+    } else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Unsupported displayaddress descriptor: {descriptor}"),
+        ));
+    };
+
+    let Some(rest) = key_expr.strip_prefix('[') else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Descriptor missing origin info: {descriptor}"),
+        ));
+    };
+    let Some((origin, key_and_suffix)) = rest.split_once(']') else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Descriptor missing origin info: {descriptor}"),
+        ));
+    };
+    let (fingerprint, origin_path) = parse_key_origin(origin)?;
+    let (key, suffix_path) = split_key_suffix(key_and_suffix)?;
+    validate_singlesig_display_key(key)?;
+    let full_path = join_derivation_path(&origin_path, &suffix_path);
+
+    Ok(ParsedSingleSigDisplayDescriptor {
+        addr_type,
+        fingerprint,
+        origin_path,
+        full_path,
+        key: key.to_owned(),
+    })
+}
+
+fn validate_singlesig_display_key(key: &str) -> Result<(), HwiError> {
+    if SecpPublicKey::from_str(key).is_ok() || XOnlyPublicKey::from_str(key).is_ok() {
+        return Ok(());
+    }
+
+    Xpub::from_str(key).map(|_| ()).map_err(|err| {
+        let error = invalid_base58_character(key).map_or_else(
+            || err.to_string(),
+            |ch| format!("Character '{ch}' is not a valid base58 character"),
+        );
+        HwiError::new(HwiErrorCode::BadArgument, error)
+    })
+}
+
+fn invalid_base58_character(value: &str) -> Option<char> {
+    const BASE58_ALPHABET: &str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+    value.chars().find(|ch| !BASE58_ALPHABET.contains(*ch))
+}
+
+fn multisig_display_address_from_descriptor(
+    descriptor: &str,
+) -> Result<MultisigDisplayAddress, HwiError> {
+    let descriptor = strip_descriptor_checksum(descriptor);
+    let (address_type, inner) = if let Some(inner) = descriptor
+        .strip_prefix("sh(wsh(sortedmulti(")
+        .and_then(|value| value.strip_suffix(")))"))
+    {
+        (MultisigAddressType::ShWit, inner)
+    } else if let Some(inner) = descriptor
+        .strip_prefix("wsh(sortedmulti(")
+        .and_then(|value| value.strip_suffix("))"))
+    {
+        (MultisigAddressType::Wit, inner)
+    } else if let Some(inner) = descriptor
+        .strip_prefix("sh(sortedmulti(")
+        .and_then(|value| value.strip_suffix("))"))
+    {
+        (MultisigAddressType::Legacy, inner)
+    } else if descriptor.contains("multi(") {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Coldcards only allow sortedmulti descriptors",
+        ));
+    } else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            format!("Unsupported displayaddress descriptor: {descriptor}"),
+        ));
+    };
+
+    let mut parts = inner.split(',');
+    let threshold = parts
+        .next()
+        .ok_or_else(|| {
+            HwiError::new(
+                HwiErrorCode::BadArgument,
+                format!("Invalid multisig descriptor: {descriptor}"),
+            )
+        })?
+        .parse::<u8>()
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    let mut keys = parts
+        .map(parse_multisig_display_key)
+        .collect::<Result<Vec<_>, _>>()?;
+    if keys.is_empty() || threshold == 0 || usize::from(threshold) > keys.len() {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Either the redeem script provided is invalid or the keypaths provided are insufficient",
+        ));
+    }
+    keys.sort_by_key(|key| key.public_key.serialize());
+
+    Ok(MultisigDisplayAddress {
+        threshold,
+        address_type,
+        keys,
+    })
+}
+
+fn parse_multisig_display_key(key_expr: &str) -> Result<MultisigDisplayKey, HwiError> {
+    let Some(rest) = key_expr.strip_prefix('[') else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Coldcard multisig display requires key origin information",
+        ));
+    };
+    let Some((origin, key_and_suffix)) = rest.split_once(']') else {
+        return Err(HwiError::new(
+            HwiErrorCode::BadArgument,
+            "Coldcard multisig display requires key origin information",
+        ));
+    };
+    let (fingerprint, origin_path) = parse_key_origin(origin)?;
+    let (key, suffix_path) = split_key_suffix(key_and_suffix)?;
+    let public_key = SecpPublicKey::from_str(key)
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    Ok(MultisigDisplayKey {
+        fingerprint,
+        path: join_derivation_path(&origin_path, &suffix_path),
+        public_key,
+    })
+}
+
+fn strip_descriptor_checksum(descriptor: &str) -> &str {
+    descriptor
+        .split_once('#')
+        .map_or(descriptor, |(desc, _)| desc)
+}
+
+fn parse_key_origin(origin: &str) -> Result<(Fingerprint, DerivationPath), HwiError> {
+    let (fingerprint, path) = origin
+        .split_once('/')
+        .map_or((origin, ""), |(fp, path)| (fp, path));
+    let fingerprint = Fingerprint::from_str(fingerprint)
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    let path = if path.is_empty() {
+        DerivationPath::master()
+    } else {
+        DerivationPath::from_str(&format!("m/{path}"))
+            .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?
+    };
+    Ok((fingerprint, path))
+}
+
+fn split_key_suffix(key_and_suffix: &str) -> Result<(&str, DerivationPath), HwiError> {
+    let Some((key, suffix)) = key_and_suffix.split_once('/') else {
+        return Ok((key_and_suffix, DerivationPath::master()));
+    };
+    let suffix = DerivationPath::from_str(&format!("m/{suffix}"))
+        .map_err(|err| HwiError::new(HwiErrorCode::BadArgument, err.to_string()))?;
+    Ok((key, suffix))
+}
+
+fn join_derivation_path(base: &DerivationPath, suffix: &DerivationPath) -> DerivationPath {
+    let mut children = base.as_ref().to_vec();
+    children.extend_from_slice(suffix.as_ref());
+    DerivationPath::from(children)
+}
+
+fn descriptor_key_matches_xpub(key: &str, xpub: Xpub) -> bool {
+    key == xpub.to_string()
+        || key.eq_ignore_ascii_case(&hex::encode(xpub.public_key.serialize()))
+        || key.eq_ignore_ascii_case(&hex::encode(
+            xpub.public_key.x_only_public_key().0.serialize(),
+        ))
+}
+
+fn display_address_error(error: String) -> HwiResponse {
+    let error = match error.find("Coldcard Error:") {
+        Some(idx) => error[idx..].to_owned(),
+        None => error,
+    };
+    let code = if error.contains("unsupported display address")
+        || error.contains("does not support displaying")
+        || error.contains("does not support this path address format")
+    {
+        HwiErrorCode::UnsupportedCommand
+    } else if error.contains("Coldcard Error:") {
+        HwiErrorCode::BadArgument
+    } else {
+        HwiErrorCode::DeviceConnectionError
+    };
+    HwiResponse::Error(HwiError::new(code, error))
+}
+
 fn hwi_descriptor_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAddressType> {
     let mut types = vec![
         HwiAddressType::Legacy,
@@ -1303,6 +1689,24 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         }
         HwiCliCommand::Signtx { psbt } => HwiCommand::SignTx { psbt },
         HwiCliCommand::Signmessage { message, path } => HwiCommand::SignMessage { message, path },
+        HwiCliCommand::Displayaddress {
+            path,
+            desc,
+            addr_type,
+        } => match (path, desc) {
+            (Some(path), None) => {
+                HwiCommand::DisplayAddress(HwiDisplayAddressRequest::Path { path, addr_type })
+            }
+            (None, Some(descriptor)) => {
+                HwiCommand::DisplayAddress(HwiDisplayAddressRequest::Descriptor { descriptor })
+            }
+            _ => {
+                return Err(HwiError::new(
+                    HwiErrorCode::BadArgument,
+                    "displayaddress requires exactly one of --path or --desc",
+                ));
+            }
+        },
         HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
         HwiCliCommand::Getdescriptors { account } => HwiCommand::GetDescriptors { account },
         HwiCliCommand::Getkeypool {
@@ -1573,6 +1977,56 @@ mod tests {
     }
 
     #[test]
+    fn parses_displayaddress_path() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "displayaddress",
+            "--addr-type",
+            "sh_wit",
+            "--path",
+            "m/49h/1h/0h/0/0",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.command,
+            HwiCommand::DisplayAddress(HwiDisplayAddressRequest::Path {
+                path: DerivationPath::from_str("m/49h/1h/0h/0/0").unwrap(),
+                addr_type: HwiAddressType::ShWit,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_displayaddress_descriptor() {
+        let descriptor = "wpkh([f5acc2fd/84h/1h/0h]tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/0/0)";
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "displayaddress",
+            "--desc",
+            descriptor,
+        ])
+        .expect("request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::DisplayAddress(HwiDisplayAddressRequest::Descriptor {
+                descriptor: descriptor.to_owned(),
+            })
+        );
+    }
+
+    #[test]
     fn parses_getdescriptors_account() {
         let request = parse_args([
             "hwi",
@@ -1797,6 +2251,16 @@ mod tests {
     }
 
     #[test]
+    fn displayaddress_serializes_only_address() {
+        let json = serde_json::to_value(HwiResponse::DisplayAddress(HwiDisplayAddressResponse {
+            address: "tb1qexample".to_owned(),
+        }))
+        .expect("json");
+
+        assert_eq!(json, serde_json::json!({ "address": "tb1qexample" }));
+    }
+
+    #[test]
     fn getdescriptors_serializes_receive_and_internal() {
         let json = serde_json::to_value(HwiResponse::GetDescriptors(HwiGetDescriptorsResponse {
             receive: vec!["wpkh(...)#receive".to_owned()],
@@ -1911,6 +2375,70 @@ mod tests {
 
         assert_eq!(err.code, HwiErrorCode::BadArgument.code());
         assert_eq!(err.error, "Path must end with /*");
+    }
+
+    #[test]
+    fn parses_singlesig_display_descriptor() {
+        let descriptor = "sh(wpkh([f5acc2fd/49h/1h/0h]tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT/0/7))#checksum";
+
+        let parsed = parse_singlesig_display_descriptor(strip_descriptor_checksum(descriptor))
+            .expect("display descriptor");
+
+        assert_eq!(parsed.addr_type, HwiAddressType::ShWit);
+        assert_eq!(
+            parsed.fingerprint,
+            Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd])
+        );
+        assert_eq!(
+            parsed.origin_path,
+            DerivationPath::from_str("m/49h/1h/0h").unwrap()
+        );
+        assert_eq!(
+            parsed.full_path,
+            DerivationPath::from_str("m/49h/1h/0h/0/7").unwrap()
+        );
+        assert_eq!(
+            parsed.key,
+            "tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
+        );
+    }
+
+    #[test]
+    fn display_descriptor_requires_origin() {
+        let err = parse_singlesig_display_descriptor("wpkh(tpubDD8d3xExampleKeyMaterial/0/7)")
+            .expect_err("missing origin");
+
+        assert_eq!(err.code, HwiErrorCode::BadArgument.code());
+        assert!(err.error.contains("Descriptor missing origin info"));
+    }
+
+    #[test]
+    fn display_descriptor_rejects_invalid_base58_key_like_python_hwi() {
+        let err = parse_singlesig_display_descriptor("wpkh([0f056943/84h/1h/0h]not_an_xpub/0/0)")
+            .expect_err("invalid key");
+
+        assert_eq!(err.code, HwiErrorCode::BadArgument.code());
+        assert_eq!(err.error, "Character '_' is not a valid base58 character");
+    }
+
+    #[test]
+    fn parses_coldcard_sortedmulti_display_descriptor() {
+        let descriptor = "sh(wsh(sortedmulti(2,[f5acc2fd/48h/1h/0h/0h/0]0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,[aaaaaaaa/48h/1h/1h/0h/0]03f028892bad7ed57d2fb57bf33081d5cfcf6f9ed3d3d7f159c2e2fff579dc341a)))";
+
+        let parsed = multisig_display_address_from_descriptor(descriptor)
+            .expect("multisig display descriptor");
+
+        assert_eq!(parsed.threshold, 2);
+        assert!(matches!(parsed.address_type, MultisigAddressType::ShWit));
+        assert_eq!(parsed.keys.len(), 2);
+        assert_eq!(
+            parsed.keys[0].path,
+            DerivationPath::from_str("m/48h/1h/0h/0h/0").unwrap()
+        );
+        assert_eq!(
+            parsed.keys[1].path,
+            DerivationPath::from_str("m/48h/1h/1h/0h/0").unwrap()
+        );
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -121,6 +121,30 @@ pub enum HwiCliCommand {
         #[arg(long)]
         path: Option<String>,
     },
+    Setup {
+        #[arg(long, short = 'l', default_value = "")]
+        label: String,
+        #[arg(long = "backup_passphrase", short = 'b', default_value = "")]
+        backup_passphrase: String,
+    },
+    Wipe,
+    Restore {
+        #[arg(long = "word_count", short = 'w', default_value_t = 24)]
+        word_count: i32,
+        #[arg(long, short = 'l', default_value = "")]
+        label: String,
+    },
+    Backup {
+        #[arg(long, short = 'l', default_value = "")]
+        label: String,
+        #[arg(long = "backup_passphrase", short = 'b', default_value = "")]
+        backup_passphrase: String,
+    },
+    Promptpin,
+    Sendpin {
+        pin: String,
+    },
+    Togglepassphrase,
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -163,7 +187,32 @@ pub enum HwiCommand {
         all: bool,
         path: Option<String>,
     },
+    UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
     Unsupported(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum HwiUnsupportedDeviceAction {
+    Setup {
+        interactive: bool,
+        label: String,
+        backup_passphrase: String,
+    },
+    Wipe,
+    Restore {
+        interactive: bool,
+        word_count: i32,
+        label: String,
+    },
+    Backup {
+        label: String,
+        backup_passphrase: String,
+    },
+    PromptPin,
+    SendPin {
+        pin: String,
+    },
+    TogglePassphrase,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -364,6 +413,9 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             )
             .await
         }
+        HwiCommand::UnsupportedDeviceAction(action) => {
+            unsupported_device_action(request.selector, action).await
+        }
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
             format!("Unsupported HWI command: {command}"),
@@ -472,6 +524,47 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
         });
     }
     HwiResponse::Enumerate(response)
+}
+
+async fn unsupported_device_action(
+    selector: DeviceSelector,
+    action: HwiUnsupportedDeviceAction,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let error = match action {
+        HwiUnsupportedDeviceAction::Setup { interactive, .. } if !interactive => {
+            "setup requires interactive mode".to_owned()
+        }
+        HwiUnsupportedDeviceAction::Restore { interactive, .. } if !interactive => {
+            "restore requires interactive mode".to_owned()
+        }
+        action => hwi_unavailable_action_message(device.device_type(), &action),
+    };
+
+    HwiResponse::Error(HwiError::new(HwiErrorCode::UnsupportedCommand, error))
 }
 
 async fn get_master_xpub(
@@ -1635,6 +1728,78 @@ fn label_for(device_type: DeviceType) -> Option<Option<String>> {
     }
 }
 
+fn hwi_unavailable_action_message(
+    device_type: DeviceType,
+    action: &HwiUnsupportedDeviceAction,
+) -> String {
+    match (device_type, action) {
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::Setup { .. }) => {
+            "The Ledger Nano S and X do not support software setup"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::Wipe) => {
+            "The Ledger Nano S and X do not support wiping via software"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::Restore { .. }) => {
+            "The Ledger Nano S and X do not support restoring via software"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::Backup { .. }) => {
+            "The Ledger Nano S and X do not support creating a backup via software"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::PromptPin) => {
+            "The Ledger Nano S and X do not need a PIN sent from the host"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::SendPin { .. }) => {
+            "The Ledger Nano S and X do not need a PIN sent from the host"
+        }
+        (DeviceType::Ledger, HwiUnsupportedDeviceAction::TogglePassphrase) => {
+            "The Ledger Nano S and X do not support toggling passphrase from the host"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::Setup { .. }) => {
+            "Blockstream Jade does not support software setup"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::Wipe) => {
+            "Blockstream Jade does not support wiping via software"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::Restore { .. }) => {
+            "Blockstream Jade does not support restoring via software"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::Backup { .. }) => {
+            "Blockstream Jade does not support creating a backup via software"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::PromptPin) => {
+            "Blockstream Jade does not need a PIN sent from the host"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::SendPin { .. }) => {
+            "Blockstream Jade does not need a PIN sent from the host"
+        }
+        (DeviceType::Jade, HwiUnsupportedDeviceAction::TogglePassphrase) => {
+            "Blockstream Jade does not support toggling passphrase from the host"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::Setup { .. }) => {
+            "The Coldcard does not support software setup"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::Wipe) => {
+            "The Coldcard does not support wiping via software"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::Restore { .. }) => {
+            "The Coldcard does not support restoring via software"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::Backup { .. }) => {
+            "The Coldcard does not support creating a backup via software"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::PromptPin) => {
+            "The Coldcard does not need a PIN sent from the host"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::SendPin { .. }) => {
+            "The Coldcard does not need a PIN sent from the host"
+        }
+        (DeviceType::Coldcard, HwiUnsupportedDeviceAction::TogglePassphrase) => {
+            "The Coldcard does not support toggling passphrase from the host"
+        }
+    }
+    .to_owned()
+}
+
 fn print_response(response: HwiResponse) -> ExitCode {
     match response {
         HwiResponse::Error(error) => {
@@ -1729,6 +1894,40 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
             all,
             path,
         },
+        HwiCliCommand::Setup {
+            label,
+            backup_passphrase,
+        } => HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Setup {
+            interactive: args.interactive,
+            label,
+            backup_passphrase,
+        }),
+        HwiCliCommand::Wipe => {
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Wipe)
+        }
+        HwiCliCommand::Restore { word_count, label } => {
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Restore {
+                interactive: args.interactive,
+                word_count,
+                label,
+            })
+        }
+        HwiCliCommand::Backup {
+            label,
+            backup_passphrase,
+        } => HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Backup {
+            label,
+            backup_passphrase,
+        }),
+        HwiCliCommand::Promptpin => {
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::PromptPin)
+        }
+        HwiCliCommand::Sendpin { pin } => {
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::SendPin { pin })
+        }
+        HwiCliCommand::Togglepassphrase => {
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
+        }
         HwiCliCommand::External(argv) => {
             let command = argv
                 .first()
@@ -2171,10 +2370,153 @@ mod tests {
     }
 
     #[test]
-    fn captures_unsupported_commands() {
-        let request = parse_args(["hwi", "setup"]).expect("unsupported command request");
+    fn parses_setup_unsupported_action() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--device-type",
+            "ledger",
+            "--interactive",
+            "setup",
+            "-l",
+            "HWI Ledger",
+            "-b",
+            "backup passphrase",
+        ])
+        .expect("unsupported setup request");
 
-        assert_eq!(request.command, HwiCommand::Unsupported("setup".to_owned()));
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert_eq!(
+            request.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Setup {
+                interactive: true,
+                label: "HWI Ledger".to_owned(),
+                backup_passphrase: "backup passphrase".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_restore_unsupported_action() {
+        let request = parse_args([
+            "hwi",
+            "--device-type",
+            "jade",
+            "--interactive",
+            "restore",
+            "--word_count",
+            "12",
+            "--label",
+            "HWI Jade",
+        ])
+        .expect("unsupported restore request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Restore {
+                interactive: true,
+                word_count: 12,
+                label: "HWI Jade".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_backup_unsupported_action() {
+        let request = parse_args([
+            "hwi",
+            "--device-type",
+            "coldcard",
+            "backup",
+            "--label",
+            "HWI Coldcard",
+            "--backup_passphrase",
+            "backup passphrase",
+        ])
+        .expect("unsupported backup request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Backup {
+                label: "HWI Coldcard".to_owned(),
+                backup_passphrase: "backup passphrase".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_pin_and_passphrase_unsupported_actions() {
+        let promptpin = parse_args(["hwi", "--device-type", "ledger", "promptpin"])
+            .expect("unsupported promptpin request");
+        assert_eq!(
+            promptpin.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::PromptPin)
+        );
+
+        let sendpin = parse_args(["hwi", "--device-type", "ledger", "sendpin", "1234"])
+            .expect("unsupported sendpin request");
+        assert_eq!(
+            sendpin.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::SendPin {
+                pin: "1234".to_owned()
+            })
+        );
+
+        let togglepassphrase = parse_args(["hwi", "--device-type", "ledger", "togglepassphrase"])
+            .expect("unsupported togglepassphrase request");
+        assert_eq!(
+            togglepassphrase.command,
+            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
+        );
+    }
+
+    #[test]
+    fn captures_unknown_unsupported_commands() {
+        let request = parse_args(["hwi", "unknowncommand"]).expect("unsupported command request");
+
+        assert_eq!(
+            request.command,
+            HwiCommand::Unsupported("unknowncommand".to_owned())
+        );
+    }
+
+    #[test]
+    fn unsupported_action_without_selector_returns_no_device_type() {
+        let request = parse_args(["hwi", "wipe"]).expect("unsupported wipe request");
+        let response = futures::executor::block_on(process_request(request));
+        let HwiResponse::Error(error) = response else {
+            panic!("expected HWI error");
+        };
+
+        assert_eq!(error.code, HwiErrorCode::NoDeviceType.code());
+        assert_eq!(
+            error.error,
+            "You must specify a device type or fingerprint for all commands except enumerate"
+        );
+    }
+
+    #[test]
+    fn unsupported_action_messages_match_python_hwi() {
+        assert_eq!(
+            hwi_unavailable_action_message(DeviceType::Ledger, &HwiUnsupportedDeviceAction::Wipe),
+            "The Ledger Nano S and X do not support wiping via software"
+        );
+        assert_eq!(
+            hwi_unavailable_action_message(
+                DeviceType::Jade,
+                &HwiUnsupportedDeviceAction::TogglePassphrase,
+            ),
+            "Blockstream Jade does not support toggling passphrase from the host"
+        );
+        assert_eq!(
+            hwi_unavailable_action_message(
+                DeviceType::Coldcard,
+                &HwiUnsupportedDeviceAction::PromptPin,
+            ),
+            "The Coldcard does not need a PIN sent from the host"
+        );
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -1683,6 +1683,7 @@ fn hwi_descriptor_addr_types(device_type: DeviceType, model: &str) -> Vec<HwiAdd
 
 fn hwi_can_sign_taproot(device_type: DeviceType, model: &str) -> bool {
     match device_type {
+        DeviceType::BitBox02 => false,
         DeviceType::Ledger => true,
         DeviceType::Jade => false,
         DeviceType::Coldcard => model.contains("edge"),
@@ -1828,6 +1829,27 @@ fn hwi_unavailable_action_message(
         }
         (DeviceType::Coldcard, HwiUnsupportedDeviceAction::TogglePassphrase) => {
             "The Coldcard does not support toggling passphrase from the host"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::Setup { .. }) => {
+            "BitBox02 software setup is not implemented"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::Wipe) => {
+            "BitBox02 software wiping is not implemented"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::Restore { .. }) => {
+            "BitBox02 software restore is not implemented"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::Backup { .. }) => {
+            "BitBox02 software backup is not implemented"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::PromptPin) => {
+            "BitBox02 does not need a PIN sent from the host"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::SendPin { .. }) => {
+            "BitBox02 does not need a PIN sent from the host"
+        }
+        (DeviceType::BitBox02, HwiUnsupportedDeviceAction::TogglePassphrase) => {
+            "BitBox02 passphrase toggling is not implemented"
         }
     }
     .to_owned()

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -5,7 +5,10 @@ use std::{
     str::FromStr,
 };
 
-use bitcoin::{Network, bip32::Fingerprint};
+use bitcoin::{
+    Network, NetworkKind,
+    bip32::{DerivationPath, Fingerprint, Xpub},
+};
 use clap::{Parser, Subcommand, error::ErrorKind};
 use serde::{Serialize, Serializer};
 
@@ -45,6 +48,10 @@ pub struct HwiCli {
 #[derive(Debug, Clone, Subcommand)]
 pub enum HwiCliCommand {
     Enumerate,
+    Getxpub {
+        #[arg(value_parser = clap::value_parser!(DerivationPath))]
+        path: DerivationPath,
+    },
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -58,6 +65,7 @@ pub struct HwiRequest {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum HwiCommand {
     Enumerate,
+    GetXpub { path: DerivationPath, expert: bool },
     Unsupported(String),
 }
 
@@ -69,6 +77,7 @@ pub struct HwiError {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum HwiErrorCode {
+    NoDeviceType,
     BadArgument,
     UnsupportedCommand,
     DeviceConnectionError,
@@ -77,9 +86,10 @@ pub enum HwiErrorCode {
 impl HwiErrorCode {
     fn code(self) -> i32 {
         match self {
+            HwiErrorCode::NoDeviceType => -1,
             HwiErrorCode::BadArgument => -7,
             HwiErrorCode::UnsupportedCommand => -9,
-            HwiErrorCode::DeviceConnectionError => -10,
+            HwiErrorCode::DeviceConnectionError => -3,
         }
     }
 }
@@ -119,7 +129,31 @@ pub struct HwiEnumeratedDevice {
 #[serde(untagged)]
 pub enum HwiResponse {
     Enumerate(Vec<HwiEnumeratedDevice>),
+    GetXpub(HwiGetXpubResponse),
     Error(HwiError),
+}
+
+#[derive(Debug, Serialize)]
+pub struct HwiGetXpubResponse {
+    pub xpub: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub testnet: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u8>,
+    #[serde(
+        default,
+        serialize_with = "option_fingerprint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_fingerprint: Option<Fingerprint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub child_num: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chaincode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<String>,
 }
 
 pub fn parse_args<I, T>(args: I) -> HwiResult<HwiRequest>
@@ -135,6 +169,7 @@ where
 pub async fn process_request(request: HwiRequest) -> HwiResponse {
     match request.command {
         HwiCommand::Enumerate => enumerate(request.selector).await,
+        HwiCommand::GetXpub { path, expert } => get_xpub(request.selector, path, expert).await,
         HwiCommand::Unsupported(command) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::UnsupportedCommand,
             format!("Unsupported HWI command: {command}"),
@@ -245,6 +280,66 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
     HwiResponse::Enumerate(response)
 }
 
+async fn get_xpub(selector: DeviceSelector, path: DerivationPath, expert: bool) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    match device.device().get_extended_pubkey(path, false).await {
+        Ok(xpub) => HwiResponse::GetXpub(get_xpub_response(xpub, expert)),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+fn get_xpub_response(xpub: Xpub, expert: bool) -> HwiGetXpubResponse {
+    if !expert {
+        return HwiGetXpubResponse {
+            xpub: xpub.to_string(),
+            testnet: None,
+            private: None,
+            depth: None,
+            parent_fingerprint: None,
+            child_num: None,
+            chaincode: None,
+            pubkey: None,
+        };
+    }
+
+    HwiGetXpubResponse {
+        xpub: xpub.to_string(),
+        testnet: Some(xpub.network == NetworkKind::Test),
+        private: Some(false),
+        depth: Some(xpub.depth),
+        parent_fingerprint: Some(xpub.parent_fingerprint),
+        child_num: Some(u32::from(xpub.child_number)),
+        chaincode: Some(hex::encode(xpub.chain_code)),
+        pubkey: Some(hex::encode(xpub.public_key.serialize())),
+    }
+}
+
 fn label_for(device_type: DeviceType) -> Option<Option<String>> {
     match device_type {
         DeviceType::BitBox02 | DeviceType::Coldcard | DeviceType::Ledger => Some(None),
@@ -290,9 +385,9 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         args.debug,
         args.stdin,
         args.interactive,
-        args.expert,
         args.stdinpass,
     );
+    let expert = args.expert;
     let device_type = args
         .device_type
         .as_deref()
@@ -301,6 +396,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
     let network = parse_chain(&args.chain)?;
     let command = match args.command {
         HwiCliCommand::Enumerate => HwiCommand::Enumerate,
+        HwiCliCommand::Getxpub { path } => HwiCommand::GetXpub { path, expert },
         HwiCliCommand::External(argv) => {
             let command = argv
                 .first()
@@ -421,6 +517,33 @@ mod tests {
     }
 
     #[test]
+    fn parses_getxpub_with_expert_flag() {
+        let request = parse_args([
+            "hwi",
+            "--chain",
+            "test",
+            "--expert",
+            "--device-type",
+            "ledger",
+            "--emulators",
+            "getxpub",
+            "m/44h/1h/0h/0/3",
+        ])
+        .expect("request");
+
+        assert_eq!(request.selector.network, Network::Testnet);
+        assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
+        assert!(request.selector.include_emulators);
+        assert_eq!(
+            request.command,
+            HwiCommand::GetXpub {
+                path: DerivationPath::from_str("m/44h/1h/0h/0/3").unwrap(),
+                expert: true,
+            }
+        );
+    }
+
+    #[test]
     fn accepts_python_hwi_version_flag() {
         let error = HwiCli::try_parse_from(["hwi", "--version"]).expect_err("version exits");
 
@@ -446,12 +569,11 @@ mod tests {
 
     #[test]
     fn captures_unsupported_commands() {
-        let request =
-            parse_args(["hwi", "getxpub", "m/84h/0h/0h"]).expect("unsupported command request");
+        let request = parse_args(["hwi", "getmasterxpub"]).expect("unsupported command request");
 
         assert_eq!(
             request.command,
-            HwiCommand::Unsupported("getxpub".to_owned())
+            HwiCommand::Unsupported("getmasterxpub".to_owned())
         );
     }
 
@@ -506,5 +628,44 @@ mod tests {
 
         assert!(json.get("label").is_none());
         assert!(json.get("fingerprint").is_none());
+    }
+
+    #[test]
+    fn getxpub_non_expert_serializes_only_xpub() {
+        let xpub = sample_xpub();
+
+        let json = serde_json::to_value(HwiResponse::GetXpub(get_xpub_response(xpub, false)))
+            .expect("json");
+
+        assert_eq!(json, serde_json::json!({ "xpub": xpub.to_string() }));
+    }
+
+    #[test]
+    fn getxpub_expert_serializes_python_hwi_field_names() {
+        let xpub = sample_xpub();
+
+        let json =
+            serde_json::to_value(HwiResponse::GetXpub(get_xpub_response(xpub, true))).unwrap();
+        let object = json.as_object().expect("expert getxpub object");
+
+        assert_eq!(object.len(), 8);
+        assert_eq!(json["xpub"], xpub.to_string());
+        assert_eq!(json["testnet"], true);
+        assert_eq!(json["private"], false);
+        assert_eq!(json["depth"], xpub.depth);
+        assert_eq!(
+            json["parent_fingerprint"],
+            xpub.parent_fingerprint.to_string()
+        );
+        assert_eq!(json["child_num"], u32::from(xpub.child_number));
+        assert_eq!(json["chaincode"], hex::encode(xpub.chain_code));
+        assert_eq!(json["pubkey"], hex::encode(xpub.public_key.serialize()));
+        assert!(!object.contains_key("child_index"));
+        assert!(!object.contains_key("chain_code"));
+    }
+
+    fn sample_xpub() -> Xpub {
+        Xpub::from_str("tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT")
+            .expect("sample xpub")
     }
 }

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -11,7 +11,7 @@ use bhwi::{
     common::{MultisigAddressType, MultisigDisplayAddress, MultisigDisplayKey},
     ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
 };
-use bhwi_async::{DeviceContext, DisplayAddress};
+use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress};
 use bitcoin::{
     Network, NetworkKind, PublicKey, ScriptBuf,
     base64::prelude::{BASE64_STANDARD, Engine as _},
@@ -193,6 +193,10 @@ pub enum HwiCommand {
         addr_type: HwiAddressType,
         all: bool,
         path: Option<String>,
+    },
+    Backup {
+        label: String,
+        backup_passphrase: String,
     },
     UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
     InstallUdevRules {
@@ -431,6 +435,10 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             )
             .await
         }
+        HwiCommand::Backup {
+            label,
+            backup_passphrase,
+        } => backup_device(request.selector, label, backup_passphrase).await,
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
@@ -598,6 +606,65 @@ async fn unsupported_device_action(
     };
 
     HwiResponse::Error(HwiError::new(HwiErrorCode::UnsupportedCommand, error))
+}
+
+async fn backup_device(
+    selector: DeviceSelector,
+    label: String,
+    backup_passphrase: String,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    let unsupported = HwiUnsupportedDeviceAction::Backup {
+        label: label.clone(),
+        backup_passphrase: backup_passphrase.clone(),
+    };
+    if device.device_type() != DeviceType::BitBox02 {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            hwi_unavailable_action_message(device.device_type(), &unsupported),
+        ));
+    }
+    if !label.is_empty() || !backup_passphrase.is_empty() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "Label/passphrase not needed when exporting mnemonic from the BitBox02.",
+        ));
+    }
+
+    match device.device().backup_device().await {
+        Ok(DeviceBackup::Complete) => HwiResponse::Success(HwiSuccessResponse { success: true }),
+        Ok(DeviceBackup::File(_)) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceFailure,
+            "BitBox02 backup unexpectedly returned file data",
+        )),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
 }
 
 async fn get_master_xpub(
@@ -1984,10 +2051,10 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Backup {
             label,
             backup_passphrase,
-        } => HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Backup {
+        } => HwiCommand::Backup {
             label,
             backup_passphrase,
-        }),
+        },
         HwiCliCommand::Promptpin => {
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::PromptPin)
         }
@@ -2494,7 +2561,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_backup_unsupported_action() {
+    fn parses_backup_action() {
         let request = parse_args([
             "hwi",
             "--device-type",
@@ -2509,10 +2576,10 @@ mod tests {
 
         assert_eq!(
             request.command,
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Backup {
+            HwiCommand::Backup {
                 label: "HWI Coldcard".to_owned(),
                 backup_passphrase: "backup passphrase".to_owned(),
-            })
+            }
         );
     }
 

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod hid;
 pub mod hwi;
 pub mod jade;
 pub mod ledger;
+pub mod udev;
 
 #[derive(Serialize)]
 pub struct Device {

--- a/bhwi-cli/src/udev.rs
+++ b/bhwi-cli/src/udev.rs
@@ -1,0 +1,379 @@
+use std::{
+    env,
+    error::Error,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use crate::DeviceType;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum UdevRuleSelection {
+    All,
+    Devices(Vec<DeviceType>),
+}
+
+#[derive(Debug)]
+pub enum UdevInstallError {
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    CommandSpawn {
+        program: String,
+        source: io::Error,
+    },
+    CommandFailed {
+        program: String,
+        args: Vec<String>,
+        code: Option<i32>,
+    },
+    MissingUser,
+}
+
+impl UdevInstallError {
+    pub fn needs_root(&self) -> bool {
+        match self {
+            Self::Io { source, .. } => source.kind() == io::ErrorKind::PermissionDenied,
+            Self::CommandFailed { .. } => true,
+            Self::CommandSpawn { .. } | Self::MissingUser => false,
+        }
+    }
+}
+
+impl fmt::Display for UdevInstallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "failed to {action} {}: {source}", path.display()),
+            Self::CommandSpawn { program, source } => {
+                write!(f, "failed to run {program}: {source}")
+            }
+            Self::CommandFailed {
+                program,
+                args,
+                code,
+            } => {
+                write!(
+                    f,
+                    "{} {} failed with status {}",
+                    program,
+                    args.join(" "),
+                    code.map_or_else(|| "unknown".to_owned(), |code| code.to_string())
+                )
+            }
+            Self::MissingUser => write!(f, "could not determine current user"),
+        }
+    }
+}
+
+impl Error for UdevInstallError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io { source, .. } | Self::CommandSpawn { source, .. } => Some(source),
+            Self::CommandFailed { .. } | Self::MissingUser => None,
+        }
+    }
+}
+
+pub fn install_udev_rules(
+    location: &Path,
+    selection: UdevRuleSelection,
+) -> Result<(), UdevInstallError> {
+    let user = current_user()?;
+    let mut runner = SystemCommandRunner;
+    install_udev_rules_with_runner(location, &selection, &mut runner, &user)
+}
+
+pub fn udev_rule_names(selection: &UdevRuleSelection) -> Vec<&'static str> {
+    rules_for_selection(selection)
+        .into_iter()
+        .map(|rule| rule.name)
+        .collect()
+}
+
+fn install_udev_rules_with_runner(
+    location: &Path,
+    selection: &UdevRuleSelection,
+    runner: &mut dyn CommandRunner,
+    user: &str,
+) -> Result<(), UdevInstallError> {
+    copy_udev_rule_files(location, selection)?;
+    runner.run("udevadm", &["trigger"])?;
+    runner.run("udevadm", &["control", "--reload-rules"])?;
+    match runner.run("groupadd", &["plugdev"]) {
+        Ok(()) => {}
+        Err(UdevInstallError::CommandFailed { code: Some(9), .. }) => {}
+        Err(err) => return Err(err),
+    }
+    runner.run("usermod", &["-aG", "plugdev", user])?;
+    Ok(())
+}
+
+fn copy_udev_rule_files(
+    location: &Path,
+    selection: &UdevRuleSelection,
+) -> Result<(), UdevInstallError> {
+    for rule in rules_for_selection(selection) {
+        let path = location.join(rule.name);
+        fs::write(&path, rule.contents).map_err(|source| UdevInstallError::Io {
+            action: "write",
+            path: path.clone(),
+            source,
+        })?;
+
+        #[cfg(unix)]
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).map_err(|source| {
+            UdevInstallError::Io {
+                action: "chmod",
+                path: path.clone(),
+                source,
+            }
+        })?;
+    }
+    Ok(())
+}
+
+fn current_user() -> Result<String, UdevInstallError> {
+    ["SUDO_USER", "USER", "LOGNAME"]
+        .into_iter()
+        .find_map(|name| env::var(name).ok().filter(|value| !value.is_empty()))
+        .ok_or(UdevInstallError::MissingUser)
+}
+
+trait CommandRunner {
+    fn run(&mut self, program: &str, args: &[&str]) -> Result<(), UdevInstallError>;
+}
+
+struct SystemCommandRunner;
+
+impl CommandRunner for SystemCommandRunner {
+    fn run(&mut self, program: &str, args: &[&str]) -> Result<(), UdevInstallError> {
+        let status = Command::new(program)
+            .args(args)
+            .status()
+            .map_err(|source| UdevInstallError::CommandSpawn {
+                program: program.to_owned(),
+                source,
+            })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(UdevInstallError::CommandFailed {
+                program: program.to_owned(),
+                args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+                code: status.code(),
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+struct UdevRule {
+    name: &'static str,
+    contents: &'static str,
+    device_type: Option<DeviceType>,
+}
+
+fn rules_for_selection(selection: &UdevRuleSelection) -> Vec<&'static UdevRule> {
+    match selection {
+        UdevRuleSelection::All => UDEV_RULES.iter().collect(),
+        UdevRuleSelection::Devices(device_types) => UDEV_RULES
+            .iter()
+            .filter(|rule| {
+                rule.device_type
+                    .is_some_and(|device_type| device_types.contains(&device_type))
+            })
+            .collect(),
+    }
+}
+
+const UDEV_RULES: &[UdevRule] = &[
+    UdevRule {
+        name: "20-hw1.rules",
+        contents: include_str!("udev/20-hw1.rules"),
+        device_type: Some(DeviceType::Ledger),
+    },
+    UdevRule {
+        name: "51-coinkite.rules",
+        contents: include_str!("udev/51-coinkite.rules"),
+        device_type: Some(DeviceType::Coldcard),
+    },
+    UdevRule {
+        name: "51-hid-digitalbitbox.rules",
+        contents: include_str!("udev/51-hid-digitalbitbox.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "51-trezor.rules",
+        contents: include_str!("udev/51-trezor.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "51-usb-keepkey.rules",
+        contents: include_str!("udev/51-usb-keepkey.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "52-hid-digitalbitbox.rules",
+        contents: include_str!("udev/52-hid-digitalbitbox.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "53-hid-bitbox02.rules",
+        contents: include_str!("udev/53-hid-bitbox02.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "54-hid-bitbox02.rules",
+        contents: include_str!("udev/54-hid-bitbox02.rules"),
+        device_type: None,
+    },
+    UdevRule {
+        name: "55-usb-jade.rules",
+        contents: include_str!("udev/55-usb-jade.rules"),
+        device_type: Some(DeviceType::Jade),
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn selects_native_device_rule_files() {
+        assert_eq!(
+            udev_rule_names(&UdevRuleSelection::Devices(vec![DeviceType::Ledger])),
+            vec!["20-hw1.rules"]
+        );
+        assert_eq!(
+            udev_rule_names(&UdevRuleSelection::Devices(vec![DeviceType::Coldcard])),
+            vec!["51-coinkite.rules"]
+        );
+        assert_eq!(
+            udev_rule_names(&UdevRuleSelection::Devices(vec![DeviceType::Jade])),
+            vec!["55-usb-jade.rules"]
+        );
+    }
+
+    #[test]
+    fn selects_all_hwi_rule_files() {
+        assert_eq!(
+            udev_rule_names(&UdevRuleSelection::All),
+            vec![
+                "20-hw1.rules",
+                "51-coinkite.rules",
+                "51-hid-digitalbitbox.rules",
+                "51-trezor.rules",
+                "51-usb-keepkey.rules",
+                "52-hid-digitalbitbox.rules",
+                "53-hid-bitbox02.rules",
+                "54-hid-bitbox02.rules",
+                "55-usb-jade.rules",
+            ]
+        );
+    }
+
+    #[test]
+    fn copies_files_and_runs_install_commands() {
+        let temp = test_dir("copies_files_and_runs_install_commands");
+        fs::create_dir_all(&temp).expect("temp dir");
+        let mut runner = FakeCommandRunner::default();
+
+        install_udev_rules_with_runner(
+            &temp,
+            &UdevRuleSelection::Devices(vec![DeviceType::Ledger, DeviceType::Jade]),
+            &mut runner,
+            "alice",
+        )
+        .expect("install rules");
+
+        assert!(temp.join("20-hw1.rules").exists());
+        assert!(temp.join("55-usb-jade.rules").exists());
+        assert!(!temp.join("51-coinkite.rules").exists());
+        assert_eq!(
+            runner.commands,
+            vec![
+                command("udevadm", &["trigger"]),
+                command("udevadm", &["control", "--reload-rules"]),
+                command("groupadd", &["plugdev"]),
+                command("usermod", &["-aG", "plugdev", "alice"]),
+            ]
+        );
+        fs::remove_dir_all(temp).ok();
+    }
+
+    #[test]
+    fn ignores_existing_plugdev_group() {
+        let temp = test_dir("ignores_existing_plugdev_group");
+        fs::create_dir_all(&temp).expect("temp dir");
+        let mut runner = FakeCommandRunner {
+            failures: VecDeque::from([None, None, Some(9)]),
+            ..FakeCommandRunner::default()
+        };
+
+        install_udev_rules_with_runner(
+            &temp,
+            &UdevRuleSelection::Devices(vec![DeviceType::Coldcard]),
+            &mut runner,
+            "alice",
+        )
+        .expect("install rules");
+
+        assert_eq!(
+            runner.commands.last(),
+            Some(&command("usermod", &["-aG", "plugdev", "alice"]))
+        );
+        fs::remove_dir_all(temp).ok();
+    }
+
+    #[test]
+    fn reports_permission_denied_as_needs_root() {
+        let error = UdevInstallError::Io {
+            action: "write",
+            path: PathBuf::from("/etc/udev/rules.d/20-hw1.rules"),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "denied"),
+        };
+        assert!(error.needs_root());
+    }
+
+    #[derive(Default)]
+    struct FakeCommandRunner {
+        commands: Vec<Vec<String>>,
+        failures: VecDeque<Option<i32>>,
+    }
+
+    impl CommandRunner for FakeCommandRunner {
+        fn run(&mut self, program: &str, args: &[&str]) -> Result<(), UdevInstallError> {
+            self.commands.push(command(program, args));
+            if let Some(code) = self.failures.pop_front().flatten() {
+                Err(UdevInstallError::CommandFailed {
+                    program: program.to_owned(),
+                    args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+                    code: Some(code),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn command(program: &str, args: &[&str]) -> Vec<String> {
+        std::iter::once(program.to_owned())
+            .chain(args.iter().map(|arg| (*arg).to_owned()))
+            .collect()
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        env::temp_dir().join(format!("bhwi-udev-{name}-{}", std::process::id()))
+    }
+}

--- a/bhwi-cli/src/udev/20-hw1.rules
+++ b/bhwi-cli/src/udev/20-hw1.rules
@@ -1,0 +1,8 @@
+# HW.1, Nano
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl"
+
+# Blue, NanoS, Aramis, HW.2, Nano X, NanoSP, Stax, Ledger Test,
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", TAG+="uaccess", TAG+="udev-acl"
+
+# Same, but with hidraw-based library (instead of libusb)
+KERNEL=="hidraw*", ATTRS{idVendor}=="2c97", MODE="0666"

--- a/bhwi-cli/src/udev/51-coinkite.rules
+++ b/bhwi-cli/src/udev/51-coinkite.rules
@@ -1,0 +1,8 @@
+
+# probably not needed:
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+
+# required:
+# from <https://github.com/signal11/hidapi/blob/master/udev/99-hid.rules>
+KERNEL=="hidraw*", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+

--- a/bhwi-cli/src/udev/51-hid-digitalbitbox.rules
+++ b/bhwi-cli/src/udev/51-hid-digitalbitbox.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"

--- a/bhwi-cli/src/udev/51-trezor.rules
+++ b/bhwi-cli/src/udev/51-trezor.rules
@@ -1,0 +1,17 @@
+# TREZOR: The Original Hardware Wallet
+# https://trezor.io/
+#
+# Put this file into /etc/udev/rules.d
+#
+# If you are creating a distribution package,
+# put this into /usr/lib/udev/rules.d or /lib/udev/rules.d
+# depending on your distribution
+
+# TREZOR
+SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001",  MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+
+# TREZOR v2
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c0", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c1", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c1",  MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"

--- a/bhwi-cli/src/udev/51-usb-keepkey.rules
+++ b/bhwi-cli/src/udev/51-usb-keepkey.rules
@@ -1,0 +1,11 @@
+# KeepKey: Your Private Bitcoin Vault
+# http://www.keepkey.com/
+# Put this file into /usr/lib/udev/rules.d or /etc/udev/rules.d
+
+# KeepKey HID Firmware/Bootloader
+SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0001", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="keepkey%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+
+# KeepKey WebUSB Firmware/Bootloader
+SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0002", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="keepkey%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0002",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"

--- a/bhwi-cli/src/udev/52-hid-digitalbitbox.rules
+++ b/bhwi-cli/src/udev/52-hid-digitalbitbox.rules
@@ -1,0 +1,1 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"

--- a/bhwi-cli/src/udev/53-hid-bitbox02.rules
+++ b/bhwi-cli/src/udev/53-hid-bitbox02.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="bitbox02_%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403"

--- a/bhwi-cli/src/udev/54-hid-bitbox02.rules
+++ b/bhwi-cli/src/udev/54-hid-bitbox02.rules
@@ -1,0 +1,1 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="bitbox02-%n"

--- a/bhwi-cli/src/udev/55-usb-jade.rules
+++ b/bhwi-cli/src/udev/55-usb-jade.rules
@@ -1,0 +1,3 @@
+KERNEL=="ttyUSB*", SUBSYSTEMS=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="jade%n"
+KERNEL=="ttyACM*", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="jade%n"
+KERNEL=="ttyACM*", SUBSYSTEMS=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4001", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="jade%n"

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use bitcoin::address::AddressType;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
 use prost::Message;
@@ -264,6 +265,25 @@ fn simple_type_from_path(path: &DerivationPath) -> pb::btc_script_config::Simple
         Some(ChildNumber::Hardened { index: 49 }) => SimpleType::P2wpkhP2sh,
         Some(ChildNumber::Hardened { index: 86 }) => SimpleType::P2tr,
         _ => SimpleType::P2wpkh,
+    }
+}
+
+fn simple_type_from_address_format(
+    path: &DerivationPath,
+    address_format: Option<AddressType>,
+) -> Result<pb::btc_script_config::SimpleType, BitBoxError> {
+    use pb::btc_script_config::SimpleType;
+    match address_format {
+        None => Ok(simple_type_from_path(path)),
+        Some(AddressType::P2sh) => Ok(SimpleType::P2wpkhP2sh),
+        Some(AddressType::P2wpkh) => Ok(SimpleType::P2wpkh),
+        Some(AddressType::P2tr) => Ok(SimpleType::P2tr),
+        Some(AddressType::P2pkh | AddressType::P2wsh) => Err(BitBoxError::InvalidInput(
+            "BitBox does not support this address format",
+        )),
+        _ => Err(BitBoxError::InvalidInput(
+            "BitBox does not support this address format",
+        )),
     }
 }
 
@@ -1024,10 +1044,18 @@ impl TryFrom<Command> for BitBoxCommand {
                 keypath: path,
                 display,
             }),
-            Command::DisplayAddress(DisplayAddress::ByPath { path, display, .. }, _) => {
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    display,
+                    address_format,
+                },
+                _,
+            ) => {
+                let simple_type = simple_type_from_address_format(&path, address_format)?;
                 Ok(BitBoxCommand::ShowSimpleAddress {
                     keypath: path,
-                    simple_type: pb::btc_script_config::SimpleType::P2wpkh,
+                    simple_type,
                     display,
                 })
             }
@@ -1153,6 +1181,23 @@ mod tests {
         assert_eq!(simple("m/86'/0'/0'/0/0"), SimpleType::P2tr);
         // Unknown/legacy purposes fall back to native segwit.
         assert_eq!(simple("m/44'/0'/0'/0/0"), SimpleType::P2wpkh);
+    }
+
+    #[test]
+    fn display_path_address_format_selects_simple_type() {
+        use pb::btc_script_config::SimpleType;
+        let path = DerivationPath::from_str("m/49'/0'/0'/0/0").unwrap();
+
+        let nested = simple_type_from_address_format(&path, Some(AddressType::P2sh)).unwrap();
+        let native = simple_type_from_address_format(&path, Some(AddressType::P2wpkh)).unwrap();
+        let taproot = simple_type_from_address_format(&path, Some(AddressType::P2tr)).unwrap();
+        let default = simple_type_from_address_format(&path, None).unwrap();
+
+        assert_eq!(nested, SimpleType::P2wpkhP2sh);
+        assert_eq!(native, SimpleType::P2wpkh);
+        assert_eq!(taproot, SimpleType::P2tr);
+        assert_eq!(default, SimpleType::P2wpkhP2sh);
+        assert!(simple_type_from_address_format(&path, Some(AddressType::P2pkh)).is_err());
     }
 
     #[test]

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -1057,6 +1057,9 @@ impl TryFrom<Command> for BitBoxCommand {
                     display,
                 })
             }
+            Command::DisplayAddress(DisplayAddress::ByMultisig(_), _) => Err(
+                BitBoxError::InvalidInput("BitBox raw multisig display is not implemented"),
+            ),
             Command::RegisterWallet { name, policy } => Ok(BitBoxCommand::RegisterScriptConfig {
                 policy: policy::Policy::from_wallet_policy(&policy)?,
                 name,

--- a/bhwi/src/coldcard/api.rs
+++ b/bhwi/src/coldcard/api.rs
@@ -1,6 +1,8 @@
 // See https://github.com/Coldcard/ckcc-protocol for implementation details.
 pub mod request {
-    use bitcoin::bip32::DerivationPath;
+    use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint};
+
+    use crate::common::MultisigDisplayKey;
 
     pub const MAX_UPLOAD_CHUNK_LEN: usize = 2048;
 
@@ -43,7 +45,7 @@ pub mod request {
         pub fn from_address_type(addr_type: bitcoin::address::AddressType) -> u32 {
             match addr_type {
                 bitcoin::address::AddressType::P2pkh => AF_P2PKH,
-                bitcoin::address::AddressType::P2sh => AF_P2SH,
+                bitcoin::address::AddressType::P2sh => AF_P2WPKH_P2SH,
                 bitcoin::address::AddressType::P2wpkh => AF_P2WPKH,
                 bitcoin::address::AddressType::P2wsh => AF_P2WSH,
                 bitcoin::address::AddressType::P2tr => AF_P2TR,
@@ -57,6 +59,38 @@ pub mod request {
         data.extend(addr_fmt.to_le_bytes());
         data.extend(path.to_string().as_bytes());
         data
+    }
+
+    pub fn show_p2sh_address(
+        threshold: u8,
+        keys: &[MultisigDisplayKey],
+        redeem_script: &[u8],
+        addr_fmt: u32,
+    ) -> Vec<u8> {
+        let mut data = b"p2sh".to_vec();
+        data.extend(addr_fmt.to_le_bytes());
+        data.push(threshold);
+        data.push(keys.len() as u8);
+        data.extend((redeem_script.len() as u16).to_le_bytes());
+        data.extend(redeem_script);
+        for key in keys {
+            let path = coldcard_xfp_path(key.fingerprint, &key.path);
+            data.push(path.len() as u8);
+            for child in path {
+                data.extend(child.to_le_bytes());
+            }
+        }
+        data
+    }
+
+    fn coldcard_xfp_path(fingerprint: Fingerprint, path: &DerivationPath) -> Vec<u32> {
+        let mut result = vec![u32::from_le_bytes(fingerprint.to_bytes())];
+        result.extend(path.as_ref().iter().copied().map(child_number_u32));
+        result
+    }
+
+    fn child_number_u32(child: ChildNumber) -> u32 {
+        u32::from(child)
     }
 
     pub fn miniscript_address(name: &str, change: bool, index: u32) -> Vec<u8> {
@@ -171,6 +205,14 @@ mod tests {
         assert_eq!(&req[..4], b"enrl");
         assert_eq!(u32::from_le_bytes(req[4..8].try_into().unwrap()), 321);
         assert_eq!(&req[8..], &hash);
+    }
+
+    #[test]
+    fn p2sh_address_type_maps_to_nested_segwit_for_path_display() {
+        assert_eq!(
+            super::request::addr_fmt::from_address_type(bitcoin::address::AddressType::P2sh),
+            super::request::addr_fmt::AF_P2WPKH_P2SH
+        );
     }
 
     #[test]
@@ -351,6 +393,9 @@ pub mod response {
                 Ok(ColdcardResponse::Address(address))
             }
             (ResponseMessage::Refu, _) => Ok(ColdcardResponse::Ok),
+            (ResponseMessage::Err_, data) => Err(ColdcardError::Device(
+                String::from_utf8_lossy(data).into_owned(),
+            )),
             (msg, _) => Err(ColdcardError::unexpected_response_message(
                 msg,
                 &[ResponseMessage::Asci, ResponseMessage::Refu],
@@ -365,6 +410,9 @@ pub mod response {
                 Ok(ColdcardResponse::Address(address))
             }
             (ResponseMessage::Refu, _) => Ok(ColdcardResponse::Ok),
+            (ResponseMessage::Err_, data) => Err(ColdcardError::Device(
+                String::from_utf8_lossy(data).into_owned(),
+            )),
             (msg, _) => Err(ColdcardError::unexpected_response_message(
                 msg,
                 &[ResponseMessage::Asci, ResponseMessage::Refu],

--- a/bhwi/src/coldcard/api.rs
+++ b/bhwi/src/coldcard/api.rs
@@ -2,8 +2,6 @@
 pub mod request {
     use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint};
 
-    use crate::common::MultisigDisplayKey;
-
     pub const MAX_UPLOAD_CHUNK_LEN: usize = 2048;
 
     pub fn start_encryption(version: Option<u32>, key: &[u8; 64]) -> Vec<u8> {
@@ -63,18 +61,18 @@ pub mod request {
 
     pub fn show_p2sh_address(
         threshold: u8,
-        keys: &[MultisigDisplayKey],
+        key_paths: &[(Fingerprint, DerivationPath)],
         redeem_script: &[u8],
         addr_fmt: u32,
     ) -> Vec<u8> {
         let mut data = b"p2sh".to_vec();
         data.extend(addr_fmt.to_le_bytes());
         data.push(threshold);
-        data.push(keys.len() as u8);
+        data.push(key_paths.len() as u8);
         data.extend((redeem_script.len() as u16).to_le_bytes());
         data.extend(redeem_script);
-        for key in keys {
-            let path = coldcard_xfp_path(key.fingerprint, &key.path);
+        for (fingerprint, derivation_path) in key_paths {
+            let path = coldcard_xfp_path(*fingerprint, derivation_path);
             data.push(path.len() as u8);
             for child in path {
                 data.extend(child.to_le_bytes());

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -3,15 +3,12 @@ pub mod encrypt;
 
 use std::string::FromUtf8Error;
 
+use bitcoin::PublicKey;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder};
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
-use bitcoin::secp256k1::ecdsa::Signature;
-use miniscript::{
-    Descriptor, Miniscript, ScriptContext, Terminal,
-    descriptor::{DescriptorPublicKey, ShInner, WalletPolicy, Wildcard},
-};
+use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature};
 
 use crate::Interpreter;
 use crate::coldcard::api::response::ResponseMessage;
@@ -20,6 +17,10 @@ use crate::common::{
     MultisigDisplayAddress, Recipient, Response, Transmit,
 };
 use crate::device::DeviceId;
+use crate::miniscript::{
+    Descriptor, Miniscript, ScriptContext, Terminal,
+    descriptor::{DescriptorPublicKey, ShInner, SinglePubKey, WalletPolicy, Wildcard},
+};
 
 pub const DEFAULT_CKCC_SOCKET: &str = "/tmp/ckcc-simulator.sock";
 pub const COLDCARD_DEVICE_ID: DeviceId = DeviceId::new(0xd13e)
@@ -83,7 +84,7 @@ pub enum ColdcardCommand {
         addr_fmt: u32,
     },
     ShowP2shAddress {
-        address: MultisigDisplayAddress,
+        address: ColdcardMultisigDisplayAddress,
     },
     MiniscriptAddress {
         name: String,
@@ -96,6 +97,18 @@ pub enum ColdcardCommand {
     RegisterWallet {
         payload: Vec<u8>,
     },
+}
+
+pub struct ColdcardMultisigDisplayAddress {
+    threshold: u8,
+    address_type: MultisigAddressType,
+    keys: Vec<ColdcardMultisigDisplayKey>,
+}
+
+struct ColdcardMultisigDisplayKey {
+    fingerprint: Fingerprint,
+    path: DerivationPath,
+    public_key: PublicKey,
 }
 
 pub enum ColdcardResponse {
@@ -252,7 +265,11 @@ where
             ColdcardCommand::ShowP2shAddress { address } => request(
                 api::request::show_p2sh_address(
                     address.threshold,
-                    &address.keys,
+                    &address
+                        .keys
+                        .iter()
+                        .map(|key| (key.fingerprint, key.path.clone()))
+                        .collect::<Vec<_>>(),
                     &multisig_redeem_script(address)?,
                     multisig_addr_fmt(address.address_type),
                 ),
@@ -591,7 +608,9 @@ impl TryFrom<Command> for ColdcardCommand {
                 index,
             }),
             Command::DisplayAddress(DisplayAddress::ByMultisig(address), ..) => {
-                Ok(Self::ShowP2shAddress { address })
+                Ok(Self::ShowP2shAddress {
+                    address: coldcard_multisig_display_address(address)?,
+                })
             }
             Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
                 payload: coldcard_registration_payload(&name, &policy)?,
@@ -724,10 +743,76 @@ fn multisig_addr_fmt(address_type: MultisigAddressType) -> u32 {
     }
 }
 
-fn multisig_redeem_script(address: &MultisigDisplayAddress) -> Result<Vec<u8>, ColdcardError> {
+fn coldcard_multisig_display_address(
+    address: MultisigDisplayAddress,
+) -> Result<ColdcardMultisigDisplayAddress, ColdcardError> {
+    if !address.sorted {
+        return Err(ColdcardError::Device(
+            "Coldcards only allow sortedmulti descriptors".to_string(),
+        ));
+    }
+    let secp = Secp256k1::verification_only();
+    let mut keys = address
+        .keys
+        .into_iter()
+        .map(|key| match key {
+            DescriptorPublicKey::Single(single) => {
+                let (fingerprint, path) = single.origin.ok_or_else(|| {
+                    ColdcardError::Serialization(
+                        "Coldcard multisig display requires key origin information".to_string(),
+                    )
+                })?;
+                let SinglePubKey::FullKey(public_key) = single.key else {
+                    return Err(ColdcardError::Serialization(
+                        "Coldcard multisig display requires full public keys".to_string(),
+                    ));
+                };
+                Ok(ColdcardMultisigDisplayKey {
+                    fingerprint,
+                    path,
+                    public_key,
+                })
+            }
+            DescriptorPublicKey::XPub(xpub) => {
+                if xpub.wildcard != Wildcard::None {
+                    return Err(ColdcardError::Serialization(
+                        "Coldcard multisig display requires a concrete derivation path".to_string(),
+                    ));
+                }
+                let (fingerprint, origin_path) = xpub.origin.ok_or_else(|| {
+                    ColdcardError::Serialization(
+                        "Coldcard multisig display requires key origin information".to_string(),
+                    )
+                })?;
+                let derived = xpub
+                    .xkey
+                    .derive_pub(&secp, &xpub.derivation_path)
+                    .map_err(|err| ColdcardError::Serialization(err.to_string()))?;
+                Ok(ColdcardMultisigDisplayKey {
+                    fingerprint,
+                    path: origin_path.extend(&xpub.derivation_path),
+                    public_key: PublicKey::new(derived.public_key),
+                })
+            }
+            DescriptorPublicKey::MultiXPub(_) => Err(ColdcardError::Serialization(
+                "Coldcard multisig display does not support multipath keys".to_string(),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    keys.sort_by_key(|key| key.public_key.inner.serialize());
+    Ok(ColdcardMultisigDisplayAddress {
+        threshold: address.threshold,
+        address_type: address.address_type,
+        keys,
+    })
+}
+
+fn multisig_redeem_script(
+    address: &ColdcardMultisigDisplayAddress,
+) -> Result<Vec<u8>, ColdcardError> {
     let mut builder = Builder::new().push_int(i64::from(address.threshold));
     for key in &address.keys {
-        builder = builder.push_slice(key.public_key.serialize());
+        builder = builder.push_key(&key.public_key);
     }
     let signer_count = i64::try_from(address.keys.len()).map_err(|_| {
         ColdcardError::Serialization("too many multisig keys for Coldcard".to_string())

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -4,6 +4,7 @@ pub mod encrypt;
 use std::string::FromUtf8Error;
 
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
+use bitcoin::blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder};
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
@@ -15,7 +16,8 @@ use miniscript::{
 use crate::Interpreter;
 use crate::coldcard::api::response::ResponseMessage;
 use crate::common::{
-    Command, DeviceBackup, DisplayAddress, Error, Info, Recipient, Response, Transmit,
+    Command, DeviceBackup, DisplayAddress, Error, Info, MultisigAddressType,
+    MultisigDisplayAddress, Recipient, Response, Transmit,
 };
 use crate::device::DeviceId;
 
@@ -32,6 +34,9 @@ pub enum ColdcardError {
 
     #[error("missing command info: {0}")]
     MissingCommandInfo(&'static str),
+
+    #[error("Coldcard Error: {0}")]
+    Device(String),
 
     #[error("no error or result returned")]
     NoErrorOrResult,
@@ -76,6 +81,9 @@ pub enum ColdcardCommand {
     ShowAddress {
         path: DerivationPath,
         addr_fmt: u32,
+    },
+    ShowP2shAddress {
+        address: MultisigDisplayAddress,
     },
     MiniscriptAddress {
         name: String,
@@ -241,6 +249,15 @@ where
             ColdcardCommand::ShowAddress { path, addr_fmt } => {
                 request(api::request::show_address(path, *addr_fmt), self.encryption)?
             }
+            ColdcardCommand::ShowP2shAddress { address } => request(
+                api::request::show_p2sh_address(
+                    address.threshold,
+                    &address.keys,
+                    &multisig_redeem_script(address)?,
+                    multisig_addr_fmt(address.address_type),
+                ),
+                self.encryption,
+            )?,
             ColdcardCommand::MiniscriptAddress {
                 name,
                 change,
@@ -320,6 +337,11 @@ where
                 Ok(None)
             }
             State::Running(ColdcardCommand::ShowAddress { .. }) => {
+                let data = self.encryption.decrypt(data)?;
+                self.state = State::Finished(api::response::show_address(&data)?);
+                Ok(None)
+            }
+            State::Running(ColdcardCommand::ShowP2shAddress { .. }) => {
                 let data = self.encryption.decrypt(data)?;
                 self.state = State::Finished(api::response::show_address(&data)?);
                 Ok(None)
@@ -568,6 +590,9 @@ impl TryFrom<Command> for ColdcardCommand {
                 change,
                 index,
             }),
+            Command::DisplayAddress(DisplayAddress::ByMultisig(address), ..) => {
+                Ok(Self::ShowP2shAddress { address })
+            }
             Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
                 payload: coldcard_registration_payload(&name, &policy)?,
             }),
@@ -691,6 +716,29 @@ fn validate_coldcard_registration_key(key: &DescriptorPublicKey) -> Result<(), C
     }
 }
 
+fn multisig_addr_fmt(address_type: MultisigAddressType) -> u32 {
+    match address_type {
+        MultisigAddressType::Legacy => api::request::addr_fmt::AF_P2SH,
+        MultisigAddressType::ShWit => api::request::addr_fmt::AF_P2WSH_P2SH,
+        MultisigAddressType::Wit => api::request::addr_fmt::AF_P2WSH,
+    }
+}
+
+fn multisig_redeem_script(address: &MultisigDisplayAddress) -> Result<Vec<u8>, ColdcardError> {
+    let mut builder = Builder::new().push_int(i64::from(address.threshold));
+    for key in &address.keys {
+        builder = builder.push_slice(key.public_key.serialize());
+    }
+    let signer_count = i64::try_from(address.keys.len()).map_err(|_| {
+        ColdcardError::Serialization("too many multisig keys for Coldcard".to_string())
+    })?;
+    Ok(builder
+        .push_int(signer_count)
+        .push_opcode(OP_CHECKMULTISIG)
+        .into_script()
+        .to_bytes())
+}
+
 impl From<ColdcardResponse> for Response {
     fn from(res: ColdcardResponse) -> Response {
         match res {
@@ -737,6 +785,7 @@ impl From<ColdcardError> for Error {
         match error {
             ColdcardError::Encryption(e) => Error::Encryption(e),
             ColdcardError::MissingCommandInfo(e) => Error::MissingCommandInfo(e),
+            ColdcardError::Device(s) => Error::Device(format!("Coldcard Error: {s}")),
             ColdcardError::NoErrorOrResult => Error::NoErrorOrResult,
             ColdcardError::Serialization(s) => Error::Serialization(s),
             ColdcardError::InvalidInput(s) => Error::InvalidInput(s),

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -26,21 +26,35 @@ pub enum DisplayAddress {
         display: bool,
         descriptor_name: String,
     },
+    /// Display a multisig address from the same inputs as Python HWI's
+    /// `display_multisig_address(addr_type, multisig)` API.
     ByMultisig(MultisigDisplayAddress),
 }
 
+/// Sans-I/O representation of Python HWI's `AddressType` and
+/// `MultisigDescriptor` arguments to `display_multisig_address`.
+///
+/// `threshold`, `sorted`, and `keys` correspond to HWI's
+/// `MultisigDescriptor.thresh`, `is_sorted`, and `pubkeys`, respectively.
 #[derive(Clone, Debug)]
 pub struct MultisigDisplayAddress {
+    /// Number of keys required to authorize a spend.
     pub threshold: u8,
+    /// Script wrapper used to derive the address.
     pub address_type: MultisigAddressType,
+    /// Whether keys use BIP67 sorting (`sortedmulti` rather than `multi`).
     pub sorted: bool,
+    /// Descriptor keys, including origins and concrete address derivations.
     pub keys: Vec<DescriptorPublicKey>,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub enum MultisigAddressType {
+    /// Legacy P2SH multisig.
     Legacy,
+    /// P2SH-wrapped P2WSH multisig.
     ShWit,
+    /// Native P2WSH multisig.
     Wit,
 }
 

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -6,7 +6,7 @@ use bitcoin::Network;
 use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
-use bitcoin::secp256k1::ecdsa::Signature;
+use bitcoin::secp256k1::{PublicKey, ecdsa::Signature};
 
 #[derive(Default)]
 pub struct UnlockOptions {
@@ -26,6 +26,28 @@ pub enum DisplayAddress {
         display: bool,
         descriptor_name: String,
     },
+    ByMultisig(MultisigDisplayAddress),
+}
+
+#[derive(Clone, Debug)]
+pub struct MultisigDisplayAddress {
+    pub threshold: u8,
+    pub address_type: MultisigAddressType,
+    pub keys: Vec<MultisigDisplayKey>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum MultisigAddressType {
+    Legacy,
+    ShWit,
+    Wit,
+}
+
+#[derive(Clone, Debug)]
+pub struct MultisigDisplayKey {
+    pub fingerprint: Fingerprint,
+    pub path: DerivationPath,
+    pub public_key: PublicKey,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -131,6 +153,9 @@ pub enum Error {
 
     #[error("missing command info: {0}")]
     MissingCommandInfo(&'static str),
+
+    #[error("{0}")]
+    Device(String),
 
     #[error("unexpected result for {1}: {0:x?}")]
     UnexpectedResult(Vec<u8>, String),

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "bitbox")]
 use crate::bitbox;
-use crate::miniscript::descriptor::WalletPolicy;
+use crate::miniscript::descriptor::{DescriptorPublicKey, WalletPolicy};
 use crate::{coldcard, jade, ledger};
 use bitcoin::Network;
 use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
-use bitcoin::secp256k1::{PublicKey, ecdsa::Signature};
+use bitcoin::secp256k1::ecdsa::Signature;
 
 #[derive(Default)]
 pub struct UnlockOptions {
@@ -33,7 +33,8 @@ pub enum DisplayAddress {
 pub struct MultisigDisplayAddress {
     pub threshold: u8,
     pub address_type: MultisigAddressType,
-    pub keys: Vec<MultisigDisplayKey>,
+    pub sorted: bool,
+    pub keys: Vec<DescriptorPublicKey>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -41,13 +42,6 @@ pub enum MultisigAddressType {
     Legacy,
     ShWit,
     Wit,
-}
-
-#[derive(Clone, Debug)]
-pub struct MultisigDisplayKey {
-    pub fingerprint: Fingerprint,
-    pub path: DerivationPath,
-    pub public_key: PublicKey,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/bhwi/src/jade/api.rs
+++ b/bhwi/src/jade/api.rs
@@ -207,6 +207,38 @@ pub struct PathAddressParams<'a> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct MultisigAddressParams<'a> {
+    pub network: &'a str,
+    pub paths: Vec<Vec<u32>>,
+    pub multisig_name: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultisigSigner {
+    #[serde(with = "serde_bytes")]
+    pub fingerprint: Vec<u8>,
+    pub derivation: Vec<u32>,
+    pub xpub: String,
+    pub path: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultisigDescriptor {
+    pub variant: String,
+    pub sorted: bool,
+    pub threshold: u8,
+    pub signers: Vec<MultisigSigner>,
+    pub master_blinding_key: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterMultisigParams<'a> {
+    pub network: &'a str,
+    pub multisig_name: &'a str,
+    pub descriptor: MultisigDescriptor,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SignPsbtParams<'a> {
     pub network: &'a str,
     #[serde(with = "serde_bytes")]

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -490,6 +490,11 @@ impl TryFrom<Command> for JadeCommand {
                 path,
                 variant: jade_path_variant(address_format)?,
             })),
+            Command::DisplayAddress(DisplayAddress::ByMultisig(_), _) => {
+                Err(Error::UnsupportedDisplayAddress(
+                    "Jade raw multisig display is not implemented".into(),
+                ))
+            }
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetInfo),
             Command::RegisterWallet { name, policy } => {

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -8,18 +8,24 @@ use base64ct::{Base64, Encoding};
 use bitcoin::Network;
 use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
+use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::Interpreter;
-use crate::common::{Command, DisplayAddress, Error, Info, Recipient, Response, Transmit};
+use crate::common::{
+    Command, DisplayAddress, Error, Info, MultisigAddressType, MultisigDisplayAddress, Recipient,
+    Response, Transmit,
+};
 use crate::device::DeviceId;
 use crate::jade::api::GetInfoResponse;
+use crate::miniscript::descriptor::{DescriptorPublicKey, Wildcard};
 
 pub const JADE_NETWORK_MAINNET: &str = "mainnet";
 pub const JADE_NETWORK_TESTNET: &str = "testnet";
+pub const JADE_NETWORK_LOCALTEST: &str = "localtest";
 
 pub const JADE_DEVICE_IDS: [DeviceId; 6] = [
     DeviceId::new(0x10c4).with_pid(0xea60),
@@ -52,6 +58,11 @@ pub enum JadeCommand {
         descriptor: String,
         datavalues: BTreeMap<String, String>,
     },
+    RegisterMultisig {
+        multisig_name: String,
+        descriptor: api::MultisigDescriptor,
+        paths: Vec<Vec<u32>>,
+    },
     SignMessage {
         message: Vec<u8>,
         path: DerivationPath,
@@ -70,6 +81,10 @@ pub enum ReceiveAddress {
     Path {
         path: DerivationPath,
         variant: &'static str,
+    },
+    Multisig {
+        paths: Vec<Vec<u32>>,
+        multisig_name: String,
     },
 }
 
@@ -130,6 +145,7 @@ impl<C, T, R, E> JadeInterpreter<C, T, R, E> {
     pub fn with_network(mut self, network: Network) -> Self {
         self.network = match network {
             Network::Bitcoin => JADE_NETWORK_MAINNET,
+            Network::Regtest => JADE_NETWORK_LOCALTEST,
             _ => JADE_NETWORK_TESTNET,
         };
         self
@@ -251,6 +267,17 @@ where
                         variant,
                     }),
                 ),
+                ReceiveAddress::Multisig {
+                    paths,
+                    multisig_name,
+                } => request(
+                    "get_receive_address",
+                    Some(api::MultisigAddressParams {
+                        network: self.network,
+                        paths: paths.clone(),
+                        multisig_name,
+                    }),
+                ),
             },
             JadeCommand::RegisterDescriptor {
                 descriptor_name,
@@ -263,6 +290,18 @@ where
                     descriptor_name,
                     descriptor: descriptor.clone(),
                     datavalues: datavalues.clone(),
+                }),
+            ),
+            JadeCommand::RegisterMultisig {
+                multisig_name,
+                descriptor,
+                ..
+            } => request(
+                "register_multisig",
+                Some(api::RegisterMultisigParams {
+                    network: self.network,
+                    multisig_name,
+                    descriptor: descriptor.clone(),
                 }),
             ),
             JadeCommand::GetInfo => request("get_version_info", None::<api::EmptyRequest>),
@@ -435,6 +474,33 @@ where
                 response = Some(JadeResponse::RegisteredDescriptor);
                 None
             }
+            State::Running(JadeCommand::RegisterMultisig {
+                multisig_name,
+                paths,
+                ..
+            }) => {
+                let registered: bool = from_response(&data)?.into_result()?;
+                if !registered {
+                    return Err(JadeError::UnexpectedResult(
+                        "register_multisig returned false".to_string(),
+                    )
+                    .into());
+                }
+                next_state = Some(State::Running(JadeCommand::GetReceiveAddress(
+                    ReceiveAddress::Multisig {
+                        paths: paths.clone(),
+                        multisig_name: multisig_name.clone(),
+                    },
+                )));
+                Some(request(
+                    "get_receive_address",
+                    Some(api::MultisigAddressParams {
+                        network: self.network,
+                        paths: paths.clone(),
+                        multisig_name,
+                    }),
+                )?)
+            }
             State::Running(JadeCommand::GetInfo) => {
                 let info: GetInfoResponse = from_response(&data)?.into_result()?;
                 response = Some(JadeResponse::GetInfo(info));
@@ -490,10 +556,8 @@ impl TryFrom<Command> for JadeCommand {
                 path,
                 variant: jade_path_variant(address_format)?,
             })),
-            Command::DisplayAddress(DisplayAddress::ByMultisig(_), _) => {
-                Err(Error::UnsupportedDisplayAddress(
-                    "Jade raw multisig display is not implemented".into(),
-                ))
+            Command::DisplayAddress(DisplayAddress::ByMultisig(address), _) => {
+                jade_multisig_command(address)
             }
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
             Command::GetVersion => Ok(Self::GetInfo),
@@ -517,6 +581,65 @@ impl TryFrom<Command> for JadeCommand {
             Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
         }
     }
+}
+
+fn jade_multisig_command(address: MultisigDisplayAddress) -> Result<JadeCommand, Error> {
+    let variant = match address.address_type {
+        MultisigAddressType::Legacy => "sh(multi(k))",
+        MultisigAddressType::Wit => "wsh(multi(k))",
+        MultisigAddressType::ShWit => "sh(wsh(multi(k)))",
+    };
+    let mut signer_origins = Vec::with_capacity(address.keys.len());
+    let mut signers = Vec::with_capacity(address.keys.len());
+    let mut paths = Vec::with_capacity(address.keys.len());
+
+    for key in address.keys {
+        let DescriptorPublicKey::XPub(key) = key else {
+            return Err(Error::InvalidInput(
+                "Jade multisig display requires extended public keys".into(),
+            ));
+        };
+        if key.wildcard != Wildcard::None {
+            return Err(Error::InvalidInput(
+                "Jade multisig display requires concrete key derivation paths".into(),
+            ));
+        }
+        let (fingerprint, origin_path) = key.origin.ok_or_else(|| {
+            Error::InvalidInput("Jade multisig display requires key origin information".into())
+        })?;
+        let origin = origin_path.to_u32_vec();
+        signer_origins.push((fingerprint.to_bytes(), origin.clone()));
+        signers.push(api::MultisigSigner {
+            fingerprint: fingerprint.to_bytes().to_vec(),
+            derivation: origin,
+            xpub: key.xkey.to_string(),
+            path: Vec::new(),
+        });
+        paths.push(key.derivation_path.to_u32_vec());
+    }
+
+    signer_origins.sort();
+    let mut summary = format!("{variant}|{}|", address.threshold);
+    for (fingerprint, path) in signer_origins {
+        summary.push_str(&hex::encode(fingerprint));
+        summary.push('|');
+        summary.push_str(&format!("{path:?}"));
+        summary.push('|');
+    }
+    let digest = sha256::Hash::hash(summary.as_bytes());
+    let multisig_name = format!("hwi{}", &digest.to_string()[..12]);
+
+    Ok(JadeCommand::RegisterMultisig {
+        multisig_name,
+        descriptor: api::MultisigDescriptor {
+            variant: variant.to_string(),
+            sorted: address.sorted,
+            threshold: address.threshold,
+            signers,
+            master_blinding_key: None,
+        },
+        paths,
+    })
 }
 
 fn jade_path_variant(address_format: Option<AddressType>) -> Result<&'static str, Error> {
@@ -596,9 +719,14 @@ impl From<JadeError> for Error {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::Interpreter;
-    use crate::common::{Command, DisplayAddress, JadeInterpreter};
+    use crate::common::{
+        Command, DisplayAddress, JadeInterpreter, MultisigAddressType, MultisigDisplayAddress,
+    };
+    use crate::miniscript::descriptor::DescriptorPublicKey;
     use crate::miniscript::descriptor::WalletPolicy;
     use serde::Deserialize;
 
@@ -754,5 +882,44 @@ mod tests {
                 .to_string()
                 .contains("register_descriptor returned false")
         );
+    }
+
+    #[test]
+    fn multisig_display_uses_upstream_hwi_registration_shape_and_name() {
+        let keys = [
+            "[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/0/7",
+            "[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/0/7",
+        ]
+        .map(|key| DescriptorPublicKey::from_str(key).unwrap())
+        .to_vec();
+
+        let command = jade_multisig_command(MultisigDisplayAddress {
+            threshold: 2,
+            address_type: MultisigAddressType::Wit,
+            sorted: true,
+            keys,
+        })
+        .unwrap();
+
+        let JadeCommand::RegisterMultisig {
+            multisig_name,
+            descriptor,
+            paths,
+        } = command
+        else {
+            panic!("expected multisig registration");
+        };
+        assert_eq!(multisig_name, "hwi78631c5c8b92");
+        assert_eq!(descriptor.variant, "wsh(multi(k))");
+        assert!(descriptor.sorted);
+        assert_eq!(descriptor.threshold, 2);
+        assert_eq!(descriptor.signers.len(), 2);
+        assert!(
+            descriptor
+                .signers
+                .iter()
+                .all(|signer| signer.path.is_empty())
+        );
+        assert_eq!(paths, vec![vec![0, 7], vec![0, 7]]);
     }
 }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -518,6 +518,12 @@ where
                             Some(cmd),
                         )
                     }
+                    DisplayAddress::ByMultisig(_) => {
+                        return Err(LedgerError::UnsupportedDisplayAddress(
+                            "Ledger raw multisig display is not implemented".into(),
+                        )
+                        .into());
+                    }
                 }
             }
             State::GetWalletAddress(GetWalletAddressStep::Xpub {
@@ -558,6 +564,12 @@ where
                                 "Ledger requires DeviceContext::Ledger for descriptor-based address display",
                             ))?;
                         (wallet_policy, wallet_hmac, change, index)
+                    }
+                    DisplayAddress::ByMultisig(_) => {
+                        return Err(LedgerError::UnsupportedDisplayAddress(
+                            "Ledger raw multisig display is not implemented".into(),
+                        )
+                        .into());
                     }
                 };
                 let store = Some(ledger_policy.to_store().map_err(LedgerError::from)?);
@@ -772,7 +784,14 @@ impl TryFrom<Command> for LedgerCommand {
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
             Command::GetXpub { path, display } => Ok(Self::GetXpub { path, display }),
             Command::DisplayAddress(addr, ctx) => Ok(Self::GetWalletAddress {
-                address: addr,
+                address: match addr {
+                    DisplayAddress::ByMultisig(_) => {
+                        return Err(LedgerError::UnsupportedDisplayAddress(
+                            "Ledger raw multisig display is not implemented".into(),
+                        ));
+                    }
+                    address => address,
+                },
                 context: ctx,
             }),
             Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -653,7 +653,30 @@ where
                             )
                         }
                     }
+                    LedgerCommand::GetXpub {
+                        ref path,
+                        display: false,
+                    } if res.status_word == StatusWord::NotSupported => {
+                        let retry = LedgerCommand::GetXpub {
+                            path: path.clone(),
+                            display: true,
+                        };
+                        let transmit =
+                            Self::Transmit::from(command::get_extended_pubkey(path, true));
+                        self.state = State::Running {
+                            store: None,
+                            command: retry,
+                        };
+                        return Ok(Some(transmit));
+                    }
                     LedgerCommand::GetXpub { .. } => {
+                        if res.status_word != StatusWord::OK {
+                            return Err(LedgerError::unexpected_result(
+                                res.data,
+                                "get extended pubkey status",
+                            )
+                            .into());
+                        }
                         let xpub = Xpub::from_str(&String::from_utf8_lossy(&res.data))
                             .map_err(|_| LedgerError::unexpected_result(res.data, "xpub string"))?;
                         (State::Finished(LedgerResponse::Xpub(xpub)), None)
@@ -863,6 +886,8 @@ impl From<LedgerError> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Interpreter;
+    use std::str::FromStr;
 
     const XONLY: [u8; 32] = [
         0x4f, 0x35, 0x5b, 0xdc, 0xb7, 0xcc, 0x0a, 0xf7, 0x28, 0xef, 0x3c, 0xce, 0xb9, 0x61, 0x5d,
@@ -938,5 +963,24 @@ mod tests {
         payload.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
 
         assert_ignored(&payload, 11);
+    }
+
+    #[test]
+    fn nonstandard_xpub_path_retries_with_display() {
+        let path = DerivationPath::from_str("m/0h/0h/4h").unwrap();
+        let command = crate::common::Command::GetXpub {
+            path,
+            display: false,
+        };
+        let mut interpreter = crate::common::LedgerInterpreter::default();
+
+        let initial = interpreter.start(command).unwrap();
+        assert_eq!(initial.payload[5], 0);
+
+        let retry = interpreter
+            .exchange(vec![0x6a, 0x82])
+            .unwrap()
+            .expect("non-standard path should be retried");
+        assert_eq!(retry.payload[5], 1);
     }
 }

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -657,6 +657,9 @@ where
                         ref path,
                         display: false,
                     } if res.status_word == StatusWord::NotSupported => {
+                        // Ledger rejects non-standard derivation paths when the xpub is
+                        // requested silently. As in Python HWI's `get_pubkey_at_path`, retry
+                        // with display enabled so the user can approve the unusual path.
                         let retry = LedgerCommand::GetXpub {
                             path: path.clone(),
                             display: true,

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -35,7 +35,7 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 |`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software setup for the unchecked devices.         |
 |`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software wipe for the unchecked devices.          |
 |`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
-|`backup`          |`n/a` |`n/a`|`[ ]`   |`n/a` |`n/a`  |`[ ]`   |`[x]`   |BitBox02 mnemonic-export backup is covered. Coldcard and BitBox01 remain open.|
+|`backup`          |`n/a` |`n/a`|`[x]`   |`n/a` |`n/a`  |`[ ]`   |`[x]`   |Coldcard file backup and BitBox02 mnemonic-export backup are covered. BitBox01 remains open.|
 |`promptpin`       |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
 |`sendpin`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
 |`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -1,0 +1,66 @@
+# HWI Compatibility
+
+BHWI includes an `hwi` compatibility binary for users and tooling that expect
+Python HWI's command-line interface. This page tracks feature parity by command
+and device family.
+
+The device-applicability entries follow Python HWI's
+[support matrix](https://hwi.readthedocs.io/en/latest/devices/index.html#support-matrix):
+features marked unsupported by the device firmware are shown as `n/a` here.
+
+## Status Key
+
+|Status|Meaning                                   |
+|------|------------------------------------------|
+|`[x]` |Parity covered for this device and command|
+|`[~]` |Partial parity or a known caveat remains  |
+|`[ ]` |Missing or not implemented                |
+|`n/a` |Not supported by the device firmware or not a device command|
+
+For device-management commands that are not applicable to Ledger, Jade, and
+Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
+
+## Feature Parity
+
+|Command           |Ledger|Jade |Coldcard|Trezor|KeepKey|BitBox01|BitBox02|Notes                                                                 |
+|------------------|------|-----|--------|------|-------|--------|--------|----------------------------------------------------------------------|
+|`enumerate`       |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for expected Python HWI fields and global selection arguments.|
+|`getmasterxpub`   |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for supported address types.                                  |
+|`getxpub`         |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for normal and expert output shape.                           |
+|`getdescriptors`  |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for account descriptors.                                      |
+|`getkeypool`      |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for receive/change ranges and address types.                  |
+|`signtx`          |`[~]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Ledger registered-wallet and non-default policy signing remains open. |
+|`signmessage`     |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for emulator-supported paths.                                 |
+|`displayaddress`  |`[x]` |`[x]`|`[~]`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Coldcard registered multisig display coverage remains open.           |
+|`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software setup for the unchecked devices.         |
+|`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software wipe for the unchecked devices.          |
+|`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
+|`backup`          |`n/a` |`n/a`|`[ ]`   |`n/a` |`n/a`  |`[ ]`   |`[ ]`   |Python HWI supports backup for Coldcard, BitBox01, and BitBox02.      |
+|`promptpin`       |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
+|`sendpin`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
+|`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
+|`installudevrules`|`n/a` |`n/a`|`n/a`   |`n/a` |`n/a`  |`n/a`   |`n/a`   |Host-side Python HWI command not yet implemented.                     |
+
+## Running Parity Tests
+
+The HWI parity tests compare BHWI's `hwi` binary against the pinned Python HWI
+reference for the selected emulator. The Nix runners build the CLI binary,
+start the matching emulator environment, and run the focused parity package.
+
+```sh
+nix run .#hwi-parity-ledger
+nix run .#hwi-parity-jade
+nix run .#hwi-parity-coldcard
+```
+
+To pass additional Cargo test filters or flags, append them after `--`:
+
+```sh
+nix run .#hwi-parity-ledger -- candidate_getxpub_matches_reference -- --nocapture
+```
+
+When running inside a matching Nix development shell, the lower-level command is:
+
+```sh
+cargo test -p bhwi-e2e-hwi-parity
+```

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -39,7 +39,7 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 |`promptpin`       |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
 |`sendpin`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
 |`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
-|`installudevrules`|`n/a` |`n/a`|`n/a`   |`n/a` |`n/a`  |`n/a`   |`n/a`   |Host-side Python HWI command not yet implemented.                     |
+|`installudevrules`|`n/a` |`n/a`|`n/a`   |`n/a` |`n/a`  |`n/a`   |`n/a`   |Host-side Python HWI command covered by the shared udev installer.    |
 
 ## Running Parity Tests
 

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -35,7 +35,7 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 |`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software setup for the unchecked devices.         |
 |`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software wipe for the unchecked devices.          |
 |`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
-|`backup`          |`n/a` |`n/a`|`[ ]`   |`n/a` |`n/a`  |`[ ]`   |`[ ]`   |Python HWI supports backup for Coldcard, BitBox01, and BitBox02.      |
+|`backup`          |`n/a` |`n/a`|`[ ]`   |`n/a` |`n/a`  |`[ ]`   |`[x]`   |BitBox02 mnemonic-export backup is covered. Coldcard and BitBox01 remain open.|
 |`promptpin`       |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
 |`sendpin`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
 |`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -24,14 +24,14 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 
 |Command           |Ledger|Jade |Coldcard|Trezor|KeepKey|BitBox01|BitBox02|Notes                                                                 |
 |------------------|------|-----|--------|------|-------|--------|--------|----------------------------------------------------------------------|
-|`enumerate`       |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for expected Python HWI fields and global selection arguments.|
-|`getmasterxpub`   |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for supported address types.                                  |
-|`getxpub`         |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for normal and expert output shape.                           |
-|`getdescriptors`  |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for account descriptors.                                      |
-|`getkeypool`      |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for receive/change ranges and address types.                  |
-|`signtx`          |`[~]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Ledger registered-wallet and non-default policy signing remains open. |
-|`signmessage`     |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Covered for emulator-supported paths.                                 |
-|`displayaddress`  |`[x]` |`[x]`|`[~]`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Coldcard registered multisig display coverage remains open.           |
+|`enumerate`       |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for expected Python HWI fields and global selection arguments.|
+|`getmasterxpub`   |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for supported address types.                                  |
+|`getxpub`         |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for normal and expert output shape.                           |
+|`getdescriptors`  |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for account descriptors.                                      |
+|`getkeypool`      |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for receive/change ranges and address types.                  |
+|`signtx`          |`[~]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Ledger registered-wallet and non-default policy signing remains open. |
+|`signmessage`     |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for emulator-supported paths.                                 |
+|`displayaddress`  |`[x]` |`[x]`|`[~]`   |`[ ]` |`[ ]`  |`n/a`   |`[x]`   |Coldcard registered multisig display coverage remains open.           |
 |`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software setup for the unchecked devices.         |
 |`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software wipe for the unchecked devices.          |
 |`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
@@ -51,6 +51,7 @@ start the matching emulator environment, and run the focused parity package.
 nix run .#hwi-parity-ledger
 nix run .#hwi-parity-jade
 nix run .#hwi-parity-coldcard
+nix run .#hwi-parity-bitbox
 ```
 
 To pass additional Cargo test filters or flags, append them after `--`:

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -42,7 +42,7 @@ mirrors each with its own `--emulators` enumerate.
 | Device    | HWI parity | Notes |
 |-----------|------------|-------|
 | Ledger    | Wired      | `hwi-parity-ledger`, in Emulator CI. |
-| Coldcard  | Wired      | `hwi-parity-coldcard`, in Emulator CI. |
+| Coldcard  | Wired      | `hwi-parity-coldcard`, in Emulator CI, including file-producing `backup`. |
 | Jade      | Wired      | `hwi-parity-jade`, in Emulator CI. |
 | BitBox02  | Wired      | `hwi-parity-bitbox`, in Emulator CI. |
 

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -13,8 +13,8 @@ commands and devices where parity is claimed.
   `nix run .#hwi-parity-<device>`. Each builds `bhwi-cli --bins`, then runs
   `bhwi-e2e-hwi-parity`, comparing `REFERENCE_HWI_BIN` against the candidate
   `hwi` for the emulated device.
-- The suite currently asserts `enumerate` parity (device type, model, and JSON
-  shape) with the intended emulator family active.
+- The suite asserts parity for the implemented HWI command set with the
+  intended emulator family active.
 - Emulator CI (`.github/workflows/emulators.yml`) runs the matching
   `hwi-parity-<device>` app inside each device job.
 
@@ -31,6 +31,7 @@ starts the emulator on the exact transport that backend already probes:
 | Coldcard | Unix socket `/tmp/ckcc-simulator.sock`             | `nix run .#coldcard` |
 | Ledger   | Speculos APDU server over TCP `localhost:9999`     | `nix run .#ledger` |
 | Jade     | QEMU serial over TCP `localhost:30121`             | `nix run .#jade` + `jade-init` |
+| BitBox02 | Firmware simulator TCP `localhost:15423`           | `nix run .#bitbox` |
 
 The flake env blocks only supply build/runtime libraries; they do not tell HWI
 where the emulator is — the backend already knows. Our candidate `bhwi hwi`
@@ -43,40 +44,16 @@ mirrors each with its own `--emulators` enumerate.
 | Ledger    | Wired      | `hwi-parity-ledger`, in Emulator CI. |
 | Coldcard  | Wired      | `hwi-parity-coldcard`, in Emulator CI. |
 | Jade      | Wired      | `hwi-parity-jade`, in Emulator CI. |
-| BitBox02  | **Gap**    | Not wired — see below. |
+| BitBox02  | Wired      | `hwi-parity-bitbox`, in Emulator CI. |
 
-## BitBox02 parity gap (intentional)
+## BitBox02 parity notes
 
-BitBox02 is intentionally excluded from HWI parity today. Unlike the wired
-devices, the blocker is on the **reference** side, not ours:
+BitBox02 parity is wired against Python HWI's built-in simulator transport. The
+pinned reference backend probes `127.0.0.1:15423`, so the BitBox emulator must be
+running and initialized before `hwi-parity-bitbox` starts.
 
-- Upstream Python HWI's BitBox02 backend talks to the device over **USB HID
-  only** (via the `bitbox02` Python library). It has no `--emulators` /
-  TCP-simulator enumerate path, so the reference `hwi enumerate` cannot see the
-  firmware TCP simulator on `:15423` the way it sees the Coldcard socket, Ledger
-  Speculos, or Jade QEMU. There is no upstream simulator enumerate to lean on.
-- On top of that, the reference HWI restricts recognized devices to
-  `commands.all_devs = ["ledger", "coldcard", "jade"]` in
-  [`flake.nix`](../flake.nix), deliberately excluding BitBox02.
-- The parity harness (`e2e/hwi-parity`) has no BitBox normalization case, and
-  there is no `hwi-parity-bitbox` flake app or CI job.
-
-The candidate side is already ready: `bhwi hwi --emulators --device-type
-bitbox02 enumerate` works against the firmware TCP simulator (the CLI gained a
-simulator transport, and `parse_device_type` accepts `bitbox02`). Enabling
-parity requires:
-
-1. Add `"bitbox02"` to `commands.all_devs` in the reference HWI.
-2. **Verify the upstream `hwilib` BitBox02 backend can reach the pinned firmware
-   TCP simulator** (`tcp:127.0.0.1:15423`). Upstream HWI drives BitBox02 through
-   the `bitbox02` Python library over USB; whether it can enumerate this
-   firmware simulator over TCP is unverified and is the main open question. If it
-   cannot, parity against this simulator is not achievable without a different
-   reference transport, and this row should stay a documented gap.
-3. Add a BitBox02 normalization/device case to `e2e/hwi-parity`.
-4. Add a `hwi-parity-bitbox` flake app (`mkHwiParityRunner … "bitbox02" …`) and
-   expose it under `apps`.
-5. Add the parity step to the `bitbox-e2e` job in
-   `.github/workflows/emulators.yml`.
-
-Until step 2 is confirmed, BitBox02 HWI parity remains an explicit, tracked gap.
+The suite covers the same implemented read/sign/display command set as the
+other wired devices. Device-management commands (`setup`, `wipe`, `restore`,
+`backup`, `togglepassphrase`) remain separate tracked gaps because Python HWI has
+stateful BitBox implementations for some of them and BHWI has not claimed that
+compatibility surface yet.

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -16,7 +16,35 @@ commands and devices where parity is claimed.
 - The suite asserts parity for the implemented HWI command set with the
   intended emulator family active.
 - Emulator CI (`.github/workflows/emulators.yml`) runs the matching
-  `hwi-parity-<device>` app inside each device job.
+  `hwi-parity-<device>` app inside each device job, then stops the shared
+  emulator and runs the pinned upstream HWI suite as that job's final test
+  gate.
+
+## Final acceptance gate
+
+Parity is accepted only when the unmodified Bitcoin Core HWI 3.2.0 device
+suite passes against BHWI's CLI adapter. The flake exposes a tailored app for
+each supported emulator:
+
+```sh
+nix run .#hwi-upstream-bitbox
+nix run .#hwi-upstream-coldcard
+nix run .#hwi-upstream-ledger
+nix run .#hwi-upstream-jade
+```
+
+Each app builds `target/debug/hwi`, prepares the pinned simulator in the layout
+expected by upstream HWI, and runs `test/run_tests.py --device-only
+--interface=cli`. The upstream source and tests are copied only to a temporary
+writable directory; BHWI does not patch test cases or add project-owned skips.
+Only skips already authored by upstream HWI are accepted. Coldcard's final
+gate does apply HWI's own `test/data/coldcard-multisig.patch` to a separate
+simulator build; that compatibility patch changes the emulator firmware, not
+the upstream test suite.
+
+The generic dispatcher remains available as `nix run .#hwi-upstream-suite --
+<device>`. CI gives the final gates bounded runtimes of 45 minutes for
+BitBox02, 90 minutes for Coldcard and Ledger, and 120 minutes for Jade.
 
 ### Why the reference side works for the wired devices
 
@@ -39,12 +67,12 @@ mirrors each with its own `--emulators` enumerate.
 
 ## Support matrix
 
-| Device    | HWI parity | Notes |
-|-----------|------------|-------|
-| Ledger    | Wired      | `hwi-parity-ledger`, in Emulator CI. |
-| Coldcard  | Wired      | `hwi-parity-coldcard`, in Emulator CI, including file-producing `backup`. |
-| Jade      | Wired      | `hwi-parity-jade`, in Emulator CI. |
-| BitBox02  | Wired      | `hwi-parity-bitbox`, in Emulator CI. |
+| Device    | Differential parity | Upstream final gate |
+|-----------|---------------------|---------------------|
+| Ledger    | `hwi-parity-ledger` | `hwi-upstream-ledger` |
+| Coldcard  | `hwi-parity-coldcard`, including file-producing `backup` | `hwi-upstream-coldcard` |
+| Jade      | `hwi-parity-jade` | `hwi-upstream-jade` |
+| BitBox02  | `hwi-parity-bitbox` | `hwi-upstream-bitbox` |
 
 ## BitBox02 parity notes
 

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -53,7 +53,7 @@ pinned reference backend probes `127.0.0.1:15423`, so the BitBox emulator must b
 running and initialized before `hwi-parity-bitbox` starts.
 
 The suite covers the same implemented read/sign/display command set as the
-other wired devices. Device-management commands (`setup`, `wipe`, `restore`,
-`backup`, `togglepassphrase`) remain separate tracked gaps because Python HWI has
-stateful BitBox implementations for some of them and BHWI has not claimed that
+other wired devices, plus BitBox02 mnemonic-export `backup`. The remaining
+stateful BitBox device-management commands (`setup`, `wipe`, `restore`,
+`togglepassphrase`) stay as tracked gaps because BHWI has not claimed that
 compatibility surface yet.

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -61,6 +61,10 @@ Apps:
 - `nix run .#ledger`
 - `nix run .#ledger-build-app`
 - `nix run .#hwi-upstream-suite`
+- `nix run .#hwi-upstream-bitbox`
+- `nix run .#hwi-upstream-coldcard`
+- `nix run .#hwi-upstream-ledger`
+- `nix run .#hwi-upstream-jade`
 - `nix run .#jade-pinserver`
 - `nix run .#jade`
 - `nix run .#jade-init`
@@ -145,39 +149,36 @@ nc -z localhost 8096 && nc -z localhost 30121
 
 ## Upstream HWI Suite
 
-BHWI pins Bitcoin Core HWI 3.2.0 and exposes two parity helpers:
+BHWI pins Bitcoin Core HWI 3.2.0 and exposes two kinds of parity helper:
 
 - `hwi-reference`: runs Python HWI directly.
 - `hwi-upstream-suite`: runs HWI's upstream `test/` suite in `--interface=cli`
   mode against a BHWI binary named by `HWI_BIN`.
 
 The upstream suite is the final parity gate for every HWI-supported device that
-BHWI claims to support. New device onboarding should enable that device's
-upstream HWI suite once BHWI has the matching device support.
-
-Ledger can use the existing pinned app-builder and Speculos wrapper:
+BHWI claims to support. Each tailored app builds the BHWI `hwi` binary and
+prepares its pinned simulator automatically:
 
 ```sh
-cargo build -p bhwi-cli --bin hwi
-HWI_BIN="$PWD/target/debug/hwi" nix run .#hwi-upstream-suite -- ledger
+nix run .#hwi-upstream-bitbox
+nix run .#hwi-upstream-coldcard
+nix run .#hwi-upstream-ledger
+nix run .#hwi-upstream-jade
 ```
 
-Coldcard and Jade need HWI-compatible simulator artifacts because upstream HWI's
-tests start their own emulator processes:
+The generic dispatcher is also available:
 
 ```sh
-cargo build -p bhwi-cli --bin hwi
-HWI_BIN="$PWD/target/debug/hwi" \
-HWI_COLDCARD_SIMULATOR=/path/to/firmware/unix/simulator.py \
+nix run .#hwi-upstream-suite -- bitbox02
 nix run .#hwi-upstream-suite -- coldcard
-
-HWI_BIN="$PWD/target/debug/hwi" \
-HWI_JADE_SIMULATOR_DIR=/path/to/hwi-style/jade/simulator \
+nix run .#hwi-upstream-suite -- ledger
 nix run .#hwi-upstream-suite -- jade
 ```
 
-The runner also accepts `HWI_BITCOIND` to override the `bitcoind` used by the
-upstream suite, and `HWI_LEDGER_APP_ELF` to use a prebuilt Ledger app.
+The runner uses the pinned HWI Python interpreter and unmodified HWI 3.2.0
+tests. It accepts `HWI_BIN` and `HWI_BITCOIND` overrides,
+`HWI_LEDGER_APP_ELF` for a prebuilt Ledger app, and pre-prepared
+`HWI_COLDCARD_SIMULATOR` or `HWI_JADE_SIMULATOR_DIR` paths for debugging.
 
 ## Device Details
 
@@ -195,12 +196,15 @@ Coldcard:
 - Uses pinned `Coldcard/firmware`.
 - Builds the Unix simulator in `$XDG_CACHE_HOME/bhwi/coldcard`. On macOS applies
   the upstream `macos-mpy.patch` and links against `DYLD_LIBRARY_PATH`.
+- The upstream HWI gate uses a separate `-hwi` simulator cache with HWI's own
+  `coldcard-multisig.patch`; the normal Coldcard emulator remains unpatched.
 - Starts `simulator.py --headless`.
 - Exposes `/tmp/ckcc-simulator.sock`.
 
 Ledger:
 
-- Uses pinned `LedgerHQ/app-bitcoin-new`.
+- Uses `LedgerHQ/app-bitcoin-new` pinned to the app version declared by the
+  upstream HWI suite, currently `2.4.1`.
 - Builds the Nano X Bitcoin app ELF through Ledger's app-builder container and
   caches it under `$XDG_CACHE_HOME/bhwi/ledger`.
 - Starts Speculos through Ledger's app-builder container on APDU

--- a/e2e/hwi-parity/Cargo.toml
+++ b/e2e/hwi-parity/Cargo.toml
@@ -7,4 +7,5 @@ license-file.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bitcoin = { workspace = true, features = ["base64"] }
 serde_json.workspace = true

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -343,6 +343,36 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_displayaddress_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for case in displayaddress_arg_cases(&device_type)? {
+            match case.expect {
+                ExpectedResult::Success => assert_displayaddress_parity(case.args.clone())
+                    .with_context(|| {
+                        format!("displayaddress parity failed for args: {:?}", case.args)
+                    })?,
+                ExpectedResult::Error => {
+                    assert_error_json_parity(case.args.clone()).with_context(|| {
+                        format!(
+                            "displayaddress error parity failed for args: {:?}",
+                            case.args
+                        )
+                    })?
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -499,6 +529,28 @@ mod tests {
         Ok(())
     }
 
+    fn assert_displayaddress_parity(args: Vec<String>) -> Result<()> {
+        prepare_displayaddress_run(&args)?;
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_displayaddress_shape("reference", &reference.json)?;
+
+        prepare_displayaddress_run(&args)?;
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_displayaddress_shape("candidate", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI displayaddress JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
     fn assert_signtx_parity(args: Vec<String>, case: &SigntxCase) -> Result<()> {
         prepare_signtx_run(&args, case)?;
         let reference = HwiBinary::reference()?.run(args.clone())?;
@@ -561,6 +613,12 @@ mod tests {
                 serde_json::to_string_pretty(json)?
             );
         }
+        Ok(())
+    }
+
+    fn assert_displayaddress_shape(label: &str, json: &Value) -> Result<()> {
+        assert_exact_keys(label, "displayaddress", json, &["address"])?;
+        assert_string_json_field(label, json, "address")?;
         Ok(())
     }
 
@@ -1311,6 +1369,27 @@ mod tests {
         Xpub::from_str(xpub).context("reference xpub was invalid")
     }
 
+    struct ExpertXpub {
+        pubkey: String,
+    }
+
+    fn reference_expert_xpub(device_type: &str, path: &str) -> Result<ExpertXpub> {
+        let output = HwiBinary::reference()?.run(args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--expert",
+            "--device-type",
+            device_type,
+            "getxpub",
+            path,
+        ]))?;
+        assert_success("reference", &output)?;
+        Ok(ExpertXpub {
+            pubkey: assert_string_json_field("reference", &output.json, "pubkey")?.to_owned(),
+        })
+    }
+
     fn signtx_args(device_type: &str, psbt: &str) -> Vec<String> {
         args([
             "--emulators",
@@ -1332,6 +1411,118 @@ mod tests {
         Ok(vec![("hello", path), ("hello world", path)])
     }
 
+    fn displayaddress_arg_cases(device_type: &str) -> Result<Vec<CommandCase>> {
+        let fingerprint = reference_fingerprint(device_type)?;
+        let wit_xpub = reference_xpub(device_type, "m/84'/1'/0'")?;
+        let sh_wit_xpub = reference_xpub(device_type, "m/49'/1'/0'")?;
+        let legacy_xpub = reference_xpub(device_type, "m/44'/1'/0'")?;
+        let fingerprint = fingerprint.to_string();
+        let wit_xpub_string = wit_xpub.to_string();
+        let wit_pubkey = lower_hex(&wit_xpub.public_key.serialize());
+        let sh_wit_xpub = sh_wit_xpub.to_string();
+        let legacy_xpub = legacy_xpub.to_string();
+
+        let mut cases = vec![
+            CommandCase {
+                args: displayaddress_path_args(device_type, "legacy", "m/44h/1h/0h/0/0"),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_path_args(device_type, "sh_wit", "m/49h/1h/0h/0/0"),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_path_args(device_type, "wit", "m/84h/1h/0h/0/0"),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_desc_args(
+                    device_type,
+                    &format!("wpkh([{fingerprint}/84h/1h/0h]{wit_xpub_string}/0/0)"),
+                ),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_desc_args(
+                    device_type,
+                    &format!("wpkh([{fingerprint}/84h/1h/0h]{wit_pubkey}/0/0)"),
+                ),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_desc_args(
+                    device_type,
+                    &format!("sh(wpkh([{fingerprint}/49h/1h/0h]{sh_wit_xpub}/0/0))"),
+                ),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: displayaddress_desc_args(
+                    device_type,
+                    &format!("pkh([{fingerprint}/44h/1h/0h]{legacy_xpub}/0/0)"),
+                ),
+                expect: ExpectedResult::Success,
+            },
+        ];
+
+        cases.push(CommandCase {
+            args: displayaddress_path_args(device_type, "tap", "m/86h/1h/0h/0/0"),
+            expect: if device_type == "ledger" {
+                ExpectedResult::Success
+            } else {
+                ExpectedResult::Error
+            },
+        });
+        cases.push(CommandCase {
+            args: displayaddress_desc_args(
+                device_type,
+                &format!("wpkh([00000000/84h/1h/0h]{wit_xpub_string}/0/0)"),
+            ),
+            expect: ExpectedResult::Error,
+        });
+        cases.push(CommandCase {
+            args: displayaddress_desc_args(
+                device_type,
+                &format!("wpkh([{fingerprint}/84h/1h/0h]not_an_xpub/0/0)"),
+            ),
+            expect: ExpectedResult::Error,
+        });
+        if device_type == "coldcard" {
+            // A standalone Python HWI displayaddress run cannot display a
+            // Coldcard multisig descriptor until the matching multisig wallet
+            // is registered in simulator state. Keep the unregistered-wallet
+            // contract in parity here; registered multisig display belongs in a
+            // setup-backed case.
+            for descriptor in coldcard_multisig_display_descriptors(device_type, &fingerprint)? {
+                cases.push(CommandCase {
+                    args: displayaddress_desc_args(device_type, &descriptor),
+                    expect: ExpectedResult::Error,
+                });
+            }
+        }
+
+        Ok(cases)
+    }
+
+    fn coldcard_multisig_display_descriptors(
+        device_type: &str,
+        fingerprint: &str,
+    ) -> Result<Vec<String>> {
+        let mut keys = Vec::new();
+        for account in 0..3 {
+            let origin_path = format!("48h/1h/{account}h/0h/0");
+            let full_path = format!("m/{origin_path}/0");
+            let expert = reference_expert_xpub(device_type, &full_path)?;
+            keys.push(format!("[{fingerprint}/{origin_path}/0]{}", expert.pubkey));
+        }
+        let keys = keys.join(",");
+        Ok(vec![
+            format!("sh(sortedmulti(2,{keys}))"),
+            format!("wsh(sortedmulti(2,{keys}))"),
+            format!("sh(wsh(sortedmulti(2,{keys})))"),
+        ])
+    }
+
     fn signmessage_args(device_type: &str, message: &str, path: &str) -> Vec<String> {
         args([
             "--emulators",
@@ -1345,12 +1536,54 @@ mod tests {
         ])
     }
 
+    fn displayaddress_path_args(device_type: &str, addr_type: &str, path: &str) -> Vec<String> {
+        args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "displayaddress",
+            "--addr-type",
+            addr_type,
+            "--path",
+            path,
+        ])
+    }
+
+    fn displayaddress_desc_args(device_type: &str, descriptor: &str) -> Vec<String> {
+        args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "displayaddress",
+            "--desc",
+            descriptor,
+        ])
+    }
+
     fn prepare_signmessage_run(args: &[String]) -> Result<()> {
         let Some(device_type) = arg_value(args, "--device-type") else {
             return Ok(());
         };
         match device_type {
             "ledger" => set_ledger_signmessage_automation(),
+            "coldcard" => {
+                spawn_coldcard_approval();
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn prepare_displayaddress_run(args: &[String]) -> Result<()> {
+        let Some(device_type) = arg_value(args, "--device-type") else {
+            return Ok(());
+        };
+        match device_type {
+            "ledger" => set_ledger_displayaddress_automation(),
             "coldcard" => {
                 spawn_coldcard_approval();
                 Ok(())
@@ -1391,6 +1624,13 @@ mod tests {
     fn set_ledger_signmessage_automation() -> Result<()> {
         let automation =
             serde_json::from_str(include_str!("../../ledger/automations/sign_message.json"))?;
+        post_speculos_automation(&automation)
+    }
+
+    fn set_ledger_displayaddress_automation() -> Result<()> {
+        let automation = serde_json::from_str(include_str!(
+            "../../ledger/automations/display_address.json"
+        ))?;
         post_speculos_automation(&automation)
     }
 
@@ -1801,5 +2041,15 @@ mod tests {
             "coldcard" | "jade" | "ledger" => Ok(device_type),
             _ => bail!("unsupported HWI_PARITY_DEVICE_TYPE {device_type:?}"),
         }
+    }
+
+    fn lower_hex(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        out
     }
 }

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -146,6 +146,25 @@ fn assert_success(label: &str, output: &HwiOutput) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        io::{Read, Write},
+        os::unix::net::UnixDatagram,
+        str::FromStr,
+        time::Duration,
+    };
+
+    use bitcoin::{
+        Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
+        absolute::LockTime,
+        address::Address,
+        base64::prelude::{BASE64_STANDARD, Engine as _},
+        bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub},
+        blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
+        psbt::{Input, Output as PsbtOutput, Psbt},
+        secp256k1::Secp256k1,
+        transaction::Version as TxVersion,
+    };
 
     #[test]
     fn reference_binary_enumerate_is_json_or_reports_clear_error() -> Result<()> {
@@ -234,6 +253,51 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_signtx_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        let singlesig = build_singlesig_signtx_case(&device_type)?;
+        assert_signtx_parity(signtx_args(&device_type, &singlesig.psbt), &singlesig)
+            .with_context(|| format!("signtx singlesig parity failed for {device_type}"))?;
+
+        if device_type == "ledger" {
+            let multisig = build_ledger_multisig_signtx_case(&device_type)?;
+            assert_signtx_parity(signtx_args(&device_type, &multisig.psbt), &multisig)
+                .context("signtx Ledger multisig parity failed")?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_signmessage_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for (message, path) in signmessage_arg_cases(&device_type)? {
+            assert_signmessage_parity(signmessage_args(&device_type, message, path))
+                .with_context(|| {
+                    format!(
+                        "signmessage parity failed for {device_type}, message {message:?}, path {path}"
+                    )
+                })?;
+        }
+
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -307,6 +371,50 @@ mod tests {
         Ok(())
     }
 
+    fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
+        prepare_signmessage_run(&args)?;
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_signmessage_shape("reference", &reference.json)?;
+
+        prepare_signmessage_run(&args)?;
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_signmessage_shape("candidate", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI signmessage JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_signtx_parity(args: Vec<String>, case: &SigntxCase) -> Result<()> {
+        prepare_signtx_run(&args, case)?;
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_signtx_shape("reference", &reference.json)?;
+        let reference_psbt = assert_signed_psbt("reference", &reference.json, case)?;
+
+        prepare_signtx_run(&args, case)?;
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_signtx_shape("candidate", &candidate.json)?;
+        let candidate_psbt = assert_signed_psbt("candidate", &candidate.json, case)?;
+
+        assert_eq!(reference.json["signed"], candidate.json["signed"]);
+        assert_eq!(
+            reference_psbt.unsigned_tx, candidate_psbt.unsigned_tx,
+            "reference and candidate signed different transactions"
+        );
+
+        Ok(())
+    }
+
     fn assert_enumerate_stdin_parity(device_type: &str) -> Result<()> {
         let stdin = format!("--emulators --device-type {device_type} enumerate\n\n");
         let reference = HwiBinary::reference()?.run_with_stdin(["--stdin"], &stdin)?;
@@ -332,6 +440,59 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    fn assert_signmessage_shape(label: &str, json: &Value) -> Result<()> {
+        assert_exact_keys(label, "signmessage", json, &["signature"])?;
+        let signature = assert_string_json_field(label, json, "signature")?;
+        let decoded = BASE64_STANDARD
+            .decode(signature)
+            .with_context(|| format!("{label} hwi signmessage signature was not base64"))?;
+        if decoded.len() != 65 {
+            bail!(
+                "{label} hwi signmessage signature was {} bytes, expected 65:\n{}",
+                decoded.len(),
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_signtx_shape(label: &str, json: &Value) -> Result<()> {
+        assert_exact_keys(label, "signtx", json, &["psbt", "signed"])?;
+        assert_string_json_field(label, json, "psbt")?;
+        if json.get("signed").and_then(Value::as_bool).is_none() {
+            bail!(
+                "{label} hwi signtx field \"signed\" was not a bool:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_signed_psbt(label: &str, json: &Value, case: &SigntxCase) -> Result<Psbt> {
+        if json.get("signed").and_then(Value::as_bool) != Some(true) {
+            bail!(
+                "{label} hwi signtx did not report signed=true:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        let signed_psbt = assert_string_json_field(label, json, "psbt")?;
+        let signed_psbt = Psbt::from_str(signed_psbt)
+            .with_context(|| format!("{label} hwi signtx returned invalid PSBT"))?;
+        if signed_psbt.unsigned_tx != case.original.unsigned_tx {
+            bail!("{label} hwi signtx changed the unsigned transaction");
+        }
+        if signed_psbt.inputs.len() != case.original.inputs.len() {
+            bail!("{label} hwi signtx changed the input count");
+        }
+        if !signed_psbt.inputs[0]
+            .partial_sigs
+            .contains_key(&case.expected_pubkey)
+        {
+            bail!("{label} hwi signtx did not add the expected device signature");
+        }
+        Ok(signed_psbt)
     }
 
     fn assert_getxpub_shape(label: &str, json: &Value, expert: bool) -> Result<()> {
@@ -623,6 +784,432 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    struct SigntxCase {
+        psbt: String,
+        original: Psbt,
+        expected_pubkey: PublicKey,
+        ledger_registers_wallet: bool,
+    }
+
+    fn build_singlesig_signtx_case(device_type: &str) -> Result<SigntxCase> {
+        let fingerprint = reference_fingerprint(device_type)?;
+        let account_xpub = reference_xpub(device_type, "m/84'/1'/0'")?;
+        let secp = Secp256k1::verification_only();
+        let input_path = DerivationPath::from_str("m/84'/1'/0'/0/0")?;
+        let change_path = DerivationPath::from_str("m/84'/1'/0'/1/0")?;
+        let input_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0)?,
+            ChildNumber::from_normal_idx(0)?,
+        ]);
+        let change_child_path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(1)?,
+            ChildNumber::from_normal_idx(0)?,
+        ]);
+        let input_xpub = account_xpub.derive_pub(&secp, &input_child_path)?;
+        let change_xpub = account_xpub.derive_pub(&secp, &change_child_path)?;
+        let input_pubkey = PublicKey::new(input_xpub.public_key);
+        let change_pubkey = PublicKey::new(change_xpub.public_key);
+        let input_script = Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let change_script =
+            Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let mut psbt = spending_psbt(input_script.clone(), change_script);
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(previous_tx(input_script.clone())),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script,
+            }),
+            bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
+            ..Default::default()
+        };
+        psbt.outputs[0] = PsbtOutput {
+            bip32_derivation: [(change_pubkey.inner, (fingerprint, change_path))].into(),
+            ..Default::default()
+        };
+
+        Ok(SigntxCase {
+            psbt: psbt.to_string(),
+            original: psbt,
+            expected_pubkey: input_pubkey,
+            ledger_registers_wallet: false,
+        })
+    }
+
+    fn build_ledger_multisig_signtx_case(device_type: &str) -> Result<SigntxCase> {
+        let fingerprint = reference_fingerprint(device_type)?;
+        let device_xpub = reference_xpub(device_type, "m/48'/1'/0'/2'")?;
+        let device_path = DerivationPath::from_str("m/48'/1'/0'/2'")?;
+        let secp = Secp256k1::new();
+        let change_suffix = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(1)?,
+            ChildNumber::from_normal_idx(0)?,
+        ]);
+        let (cosigner_fingerprint, cosigner_xpub, receive) =
+            ledger_multisig_cosigner(&secp, device_xpub, fingerprint, &device_path)?;
+        let change = sorted_multisig_keys(
+            &secp,
+            device_xpub,
+            fingerprint,
+            cosigner_xpub,
+            cosigner_fingerprint,
+            &change_suffix,
+        )?;
+        let input_script = multisig_script(2, &receive);
+        let change_script = multisig_script(2, &change);
+        let mut psbt = spending_psbt(input_script.to_p2wsh(), change_script.to_p2wsh());
+
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(previous_tx(input_script.to_p2wsh())),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: input_script.to_p2wsh(),
+            }),
+            witness_script: Some(input_script),
+            bip32_derivation: [
+                (
+                    receive[0].inner,
+                    (receive[0].fingerprint, receive[0].derivation_path.clone()),
+                ),
+                (
+                    receive[1].inner,
+                    (receive[1].fingerprint, receive[1].derivation_path.clone()),
+                ),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        psbt.outputs[0] = PsbtOutput {
+            witness_script: Some(change_script),
+            bip32_derivation: [
+                (
+                    change[0].inner,
+                    (change[0].fingerprint, change[0].derivation_path.clone()),
+                ),
+                (
+                    change[1].inner,
+                    (change[1].fingerprint, change[1].derivation_path.clone()),
+                ),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        psbt.xpub
+            .insert(device_xpub, (fingerprint, device_path.clone()));
+        psbt.xpub
+            .insert(cosigner_xpub, (cosigner_fingerprint, device_path));
+
+        let expected_pubkey = receive
+            .iter()
+            .find(|key| key.fingerprint == fingerprint)
+            .map(|key| PublicKey::new(key.inner))
+            .context("missing device multisig pubkey")?;
+
+        Ok(SigntxCase {
+            psbt: psbt.to_string(),
+            original: psbt,
+            expected_pubkey,
+            ledger_registers_wallet: true,
+        })
+    }
+
+    fn ledger_multisig_cosigner<
+        C: bitcoin::secp256k1::Signing + bitcoin::secp256k1::Verification,
+    >(
+        secp: &Secp256k1<C>,
+        device_xpub: Xpub,
+        device_fingerprint: Fingerprint,
+        device_path: &DerivationPath,
+    ) -> Result<(Fingerprint, Xpub, Vec<DerivedKey>)> {
+        let receive_suffix = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0)?,
+            ChildNumber::from_normal_idx(0)?,
+        ]);
+        for seed in 1..=255 {
+            let cosigner_master = Xpriv::new_master(bitcoin::NetworkKind::Test, &[seed; 32])?;
+            let cosigner_fingerprint = cosigner_master.fingerprint(secp);
+            let cosigner_xpriv = cosigner_master.derive_priv(secp, device_path)?;
+            let cosigner_xpub = Xpub::from_priv(secp, &cosigner_xpriv);
+            let receive = sorted_multisig_keys(
+                secp,
+                device_xpub,
+                device_fingerprint,
+                cosigner_xpub,
+                cosigner_fingerprint,
+                &receive_suffix,
+            )?;
+            if receive
+                .first()
+                .is_some_and(|key| key.fingerprint == device_fingerprint)
+            {
+                return Ok((cosigner_fingerprint, cosigner_xpub, receive));
+            }
+        }
+        bail!("could not find deterministic Ledger multisig cosigner");
+    }
+
+    #[derive(Clone)]
+    struct DerivedKey {
+        inner: bitcoin::secp256k1::PublicKey,
+        fingerprint: Fingerprint,
+        derivation_path: DerivationPath,
+    }
+
+    fn sorted_multisig_keys<C: bitcoin::secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        device_xpub: Xpub,
+        device_fingerprint: Fingerprint,
+        cosigner_xpub: Xpub,
+        cosigner_fingerprint: Fingerprint,
+        suffix: &DerivationPath,
+    ) -> Result<Vec<DerivedKey>> {
+        let device = device_xpub.derive_pub(secp, suffix)?;
+        let cosigner = cosigner_xpub.derive_pub(secp, suffix)?;
+        let account_path = DerivationPath::from_str("m/48'/1'/0'/2'")?;
+        let mut keys = vec![
+            DerivedKey {
+                inner: device.public_key,
+                fingerprint: device_fingerprint,
+                derivation_path: join_derivation_path(&account_path, suffix),
+            },
+            DerivedKey {
+                inner: cosigner.public_key,
+                fingerprint: cosigner_fingerprint,
+                derivation_path: join_derivation_path(&account_path, suffix),
+            },
+        ];
+        keys.sort_by_key(|key| key.inner.serialize());
+        Ok(keys)
+    }
+
+    fn join_derivation_path(base: &DerivationPath, suffix: &DerivationPath) -> DerivationPath {
+        let mut children = base.as_ref().to_vec();
+        children.extend_from_slice(suffix.as_ref());
+        DerivationPath::from(children)
+    }
+
+    fn multisig_script(threshold: i64, keys: &[DerivedKey]) -> ScriptBuf {
+        let mut builder = Builder::new().push_int(threshold);
+        for key in keys {
+            builder = builder.push_slice(key.inner.serialize());
+        }
+        builder
+            .push_int(keys.len() as i64)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script()
+    }
+
+    fn spending_psbt(input_script: ScriptBuf, change_script: ScriptBuf) -> Psbt {
+        Psbt::from_unsigned_tx(Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: previous_tx(input_script).compute_txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(49_000),
+                script_pubkey: change_script,
+            }],
+        })
+        .expect("unsigned tx should become PSBT")
+    }
+
+    fn previous_tx(script_pubkey: ScriptBuf) -> Transaction {
+        Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey,
+            }],
+        }
+    }
+
+    fn reference_fingerprint(device_type: &str) -> Result<Fingerprint> {
+        let output = HwiBinary::reference()?.run(args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "enumerate",
+        ]))?;
+        assert_success("reference", &output)?;
+        let device = assert_enumerate_contains_device("reference", &output.json, device_type)?;
+        let fingerprint = assert_string_field("reference", device, "fingerprint")?;
+        Fingerprint::from_str(fingerprint).context("reference fingerprint was invalid")
+    }
+
+    fn reference_xpub(device_type: &str, path: &str) -> Result<Xpub> {
+        let output = HwiBinary::reference()?.run(args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "getxpub",
+            path,
+        ]))?;
+        assert_success("reference", &output)?;
+        let xpub = assert_string_json_field("reference", &output.json, "xpub")?;
+        Xpub::from_str(xpub).context("reference xpub was invalid")
+    }
+
+    fn signtx_args(device_type: &str, psbt: &str) -> Vec<String> {
+        args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "signtx",
+            psbt,
+        ])
+    }
+
+    fn signmessage_arg_cases(device_type: &str) -> Result<Vec<(&'static str, &'static str)>> {
+        let path = match device_type {
+            "ledger" => "m/44'/1'/0'/0",
+            "jade" | "coldcard" => "m/44'/1'/0'",
+            _ => bail!("unsupported signmessage device type {device_type:?}"),
+        };
+        Ok(vec![("hello", path), ("hello world", path)])
+    }
+
+    fn signmessage_args(device_type: &str, message: &str, path: &str) -> Vec<String> {
+        args([
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            device_type,
+            "signmessage",
+            message,
+            path,
+        ])
+    }
+
+    fn prepare_signmessage_run(args: &[String]) -> Result<()> {
+        let Some(device_type) = arg_value(args, "--device-type") else {
+            return Ok(());
+        };
+        match device_type {
+            "ledger" => set_ledger_signmessage_automation(),
+            "coldcard" => {
+                spawn_coldcard_approval();
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn prepare_signtx_run(args: &[String], case: &SigntxCase) -> Result<()> {
+        let Some(device_type) = arg_value(args, "--device-type") else {
+            return Ok(());
+        };
+        match device_type {
+            "ledger" => set_ledger_automation(case.ledger_registers_wallet),
+            "coldcard" => {
+                spawn_coldcard_approval();
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn arg_value<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+        args.windows(2)
+            .find(|pair| pair[0] == name)
+            .map(|pair| pair[1].as_str())
+    }
+
+    fn set_ledger_automation(registers_wallet: bool) -> Result<()> {
+        let automation = if registers_wallet {
+            serde_json::from_str(include_str!("../../ledger/automations/hwi_speculos.json"))?
+        } else {
+            serde_json::from_str(include_str!("../../ledger/automations/sign_psbt.json"))?
+        };
+        post_speculos_automation(&automation)
+    }
+
+    fn set_ledger_signmessage_automation() -> Result<()> {
+        let automation =
+            serde_json::from_str(include_str!("../../ledger/automations/sign_message.json"))?;
+        post_speculos_automation(&automation)
+    }
+
+    fn post_speculos_automation(automation: &Value) -> Result<()> {
+        let body = serde_json::to_vec(automation)?;
+        let mut stream = std::net::TcpStream::connect("127.0.0.1:5000")
+            .context("failed to connect to Speculos automation API")?;
+        write!(
+            stream,
+            "POST /automation HTTP/1.1\r\nHost: 127.0.0.1:5000\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )?;
+        stream.write_all(&body)?;
+        stream.flush()?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response)?;
+        if !response.starts_with("HTTP/1.1 200") && !response.starts_with("HTTP/1.0 200") {
+            bail!("Speculos automation API returned unexpected response: {response}");
+        }
+        Ok(())
+    }
+
+    fn spawn_coldcard_approval() {
+        std::thread::spawn(|| {
+            std::thread::sleep(Duration::from_secs(1));
+            let _ = send_coldcard_approval();
+        });
+    }
+
+    fn send_coldcard_approval() -> Result<()> {
+        let client_socket = format!("/tmp/bhwi-hwi-parity-ckcc-{}.sock", std::process::id());
+        let _ = std::fs::remove_file(&client_socket);
+        let socket = UnixDatagram::bind(&client_socket)?;
+        socket.set_read_timeout(Some(Duration::from_secs(2)))?;
+        socket.connect("/tmp/ckcc-simulator.sock")?;
+        coldcard_hid_exchange(&socket, b"XKEYy")?;
+        let _ = std::fs::remove_file(client_socket);
+        Ok(())
+    }
+
+    fn coldcard_hid_exchange(socket: &UnixDatagram, request: &[u8]) -> Result<Vec<u8>> {
+        let mut packet = [0_u8; 64];
+        packet[0] =
+            0x80 | u8::try_from(request.len()).context("Coldcard test request too large")?;
+        packet[1..1 + request.len()].copy_from_slice(request);
+        socket.send(&packet)?;
+
+        let mut response = Vec::new();
+        let mut first = true;
+        loop {
+            let mut packet = [0_u8; 64];
+            socket.recv(&mut packet)?;
+            let flag = packet[0];
+            let len = usize::from(flag & 0x3f);
+            let is_fram = first && &packet[1..5] == b"fram";
+            response.extend_from_slice(&packet[1..1 + len]);
+            first = false;
+            if flag & 0x80 != 0 || is_fram {
+                break;
+            }
+        }
+        Ok(response)
     }
 
     fn enumerate_args_from_env() -> Result<(Vec<String>, Option<String>)> {

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -373,6 +373,43 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_unsupported_device_actions_match_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for case in unsupported_device_action_cases(&device_type) {
+            if device_type == "coldcard" && case.command == "backup" {
+                let candidate =
+                    assert_candidate_error_json(case.args.clone()).with_context(|| {
+                        format!(
+                            "candidate Coldcard backup deviation failed for args: {:?}",
+                            case.args
+                        )
+                    })?;
+                assert_eq!(candidate["code"], -9);
+                assert_eq!(
+                    candidate["error"],
+                    "The Coldcard does not support creating a backup via software"
+                );
+            } else {
+                assert_error_json_parity(case.args.clone()).with_context(|| {
+                    format!(
+                        "unsupported device action parity failed for args: {:?}",
+                        case.args
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -505,6 +542,12 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    fn assert_candidate_error_json(args: Vec<String>) -> Result<Value> {
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_error_shape("candidate", &candidate.json)?;
+        Ok(candidate.json)
     }
 
     fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
@@ -1847,6 +1890,11 @@ mod tests {
         expect: ExpectedResult,
     }
 
+    struct UnsupportedDeviceActionCase {
+        command: &'static str,
+        args: Vec<String>,
+    }
+
     fn getkeypool_arg_cases(device_type: &str) -> Vec<CommandCase> {
         let mut cases = vec![
             CommandCase {
@@ -1934,6 +1982,129 @@ mod tests {
         });
 
         cases
+    }
+
+    fn unsupported_device_action_cases(device_type: &str) -> Vec<UnsupportedDeviceActionCase> {
+        vec![
+            UnsupportedDeviceActionCase {
+                command: "setup",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "setup",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "setup",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "--interactive",
+                    "setup",
+                    "--label",
+                    "HWI Test",
+                    "--backup_passphrase",
+                    "backup passphrase",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "wipe",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "wipe",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "restore",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "restore",
+                    "--word_count",
+                    "12",
+                    "--label",
+                    "HWI Test",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "restore",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "--interactive",
+                    "restore",
+                    "-w",
+                    "18",
+                    "-l",
+                    "HWI Test",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "backup",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                    "--label",
+                    "HWI Test",
+                    "--backup_passphrase",
+                    "backup passphrase",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "promptpin",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "promptpin",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "sendpin",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "sendpin",
+                    "1234",
+                ]),
+            },
+            UnsupportedDeviceActionCase {
+                command: "togglepassphrase",
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "togglepassphrase",
+                ]),
+            },
+        ]
     }
 
     fn enumerate_python_hwi_arg_cases(

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -402,6 +402,31 @@ mod tests {
     }
 
     #[test]
+    fn candidate_backup_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for case in backup_arg_cases(&device_type) {
+            match case.expect {
+                ExpectedResult::Success => assert_json_parity(case.args.clone())
+                    .with_context(|| format!("backup parity failed for args: {:?}", case.args))?,
+                ExpectedResult::Error => {
+                    assert_error_json_parity(case.args.clone()).with_context(|| {
+                        format!("backup error parity failed for args: {:?}", case.args)
+                    })?
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn candidate_unsupported_device_actions_match_reference() -> Result<()> {
         if env::var("HWI_BIN").is_err() {
             return Ok(());
@@ -2270,6 +2295,67 @@ mod tests {
                     device_type,
                     "togglepassphrase",
                 ]),
+            },
+        ]
+    }
+
+    fn backup_arg_cases(device_type: &str) -> Vec<CommandCase> {
+        if device_type != "bitbox02" {
+            return Vec::new();
+        }
+
+        vec![
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                    "--label",
+                    "HWI Test",
+                ]),
+                expect: ExpectedResult::Error,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                    "--backup_passphrase",
+                    "backup passphrase",
+                ]),
+                expect: ExpectedResult::Error,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                    "--label",
+                    "HWI Test",
+                    "--backup_passphrase",
+                    "backup passphrase",
+                ]),
+                expect: ExpectedResult::Error,
             },
         ]
     }

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -198,6 +198,24 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_getxpub_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for args in getxpub_arg_cases(&device_type) {
+            assert_getxpub_parity(args.clone())
+                .with_context(|| format!("getxpub parity failed for args: {args:?}"))?;
+        }
+
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -222,6 +240,27 @@ mod tests {
         if reference.json != candidate.json {
             bail!(
                 "HWI JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_getxpub_parity(args: Vec<String>) -> Result<()> {
+        let expert = args.iter().any(|arg| arg == "--expert");
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_getxpub_shape("reference", &reference.json, expert)?;
+
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_getxpub_shape("candidate", &candidate.json, expert)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI getxpub JSON mismatch\nreference:\n{}\ncandidate:\n{}",
                 serde_json::to_string_pretty(&reference.json)?,
                 serde_json::to_string_pretty(&candidate.json)?
             );
@@ -255,6 +294,144 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    fn assert_getxpub_shape(label: &str, json: &Value, expert: bool) -> Result<()> {
+        let Some(object) = json.as_object() else {
+            bail!(
+                "{label} hwi getxpub output was not an object:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+
+        assert_string_json_field(label, json, "xpub")?;
+
+        let expected: &[&str] = if expert {
+            &[
+                "xpub",
+                "testnet",
+                "private",
+                "depth",
+                "parent_fingerprint",
+                "child_num",
+                "chaincode",
+                "pubkey",
+            ]
+        } else {
+            &["xpub"]
+        };
+        assert_exact_keys(label, "getxpub", json, expected)?;
+
+        if !expert {
+            return Ok(());
+        }
+
+        if json.get("testnet").and_then(Value::as_bool).is_none() {
+            bail!(
+                "{label} hwi getxpub expert field \"testnet\" was not a bool:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        if json.get("private").and_then(Value::as_bool) != Some(false) {
+            bail!(
+                "{label} hwi getxpub expert field \"private\" was not false:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        assert_u64_json_field(label, json, "depth")?;
+        assert_u64_json_field(label, json, "child_num")?;
+        assert_lower_hex_string_field(label, json, "parent_fingerprint", 8)?;
+        assert_lower_hex_string_field(label, json, "chaincode", 64)?;
+        let pubkey = assert_lower_hex_string_field(label, json, "pubkey", 66)?;
+        if !pubkey.starts_with("02") && !pubkey.starts_with("03") {
+            bail!(
+                "{label} hwi getxpub expert field \"pubkey\" was not compressed SEC hex:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+
+        for stale in ["version", "child_index", "chain_code"] {
+            if object.contains_key(stale) {
+                bail!(
+                    "{label} hwi getxpub used stale expert field name {stale:?}:\n{}",
+                    serde_json::to_string_pretty(json)?
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn assert_exact_keys(
+        label: &str,
+        command: &str,
+        json: &Value,
+        expected: &[&str],
+    ) -> Result<()> {
+        let object = json
+            .as_object()
+            .with_context(|| format!("{label} hwi {command} output was not an object"))?;
+        let mut actual = object.keys().map(String::as_str).collect::<Vec<_>>();
+        actual.sort_unstable();
+        let mut expected = expected.to_vec();
+        expected.sort_unstable();
+        if actual != expected {
+            bail!(
+                "{label} hwi {command} keys did not match\nexpected: {:?}\nactual: {:?}\njson:\n{}",
+                expected,
+                actual,
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_string_json_field<'a>(label: &str, json: &'a Value, field: &str) -> Result<&'a str> {
+        let Some(value) = json.get(field).and_then(Value::as_str) else {
+            bail!(
+                "{label} hwi field {field:?} was not a string:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+
+        if value.is_empty() {
+            bail!(
+                "{label} hwi field {field:?} was empty:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+
+        Ok(value)
+    }
+
+    fn assert_u64_json_field(label: &str, json: &Value, field: &str) -> Result<u64> {
+        let Some(value) = json.get(field).and_then(Value::as_u64) else {
+            bail!(
+                "{label} hwi field {field:?} was not an unsigned integer:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+        Ok(value)
+    }
+
+    fn assert_lower_hex_string_field<'a>(
+        label: &str,
+        json: &'a Value,
+        field: &str,
+        expected_len: usize,
+    ) -> Result<&'a str> {
+        let value = assert_string_json_field(label, json, field)?;
+        let valid = value.len() == expected_len
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        if !valid {
+            bail!(
+                "{label} hwi field {field:?} was not {expected_len} lowercase hex chars:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(value)
     }
 
     fn assert_enumerate_array(label: &str, json: &Value) -> Result<()> {
@@ -420,6 +597,30 @@ mod tests {
             Err(env::VarError::NotPresent) => Ok(None),
             Err(err) => Err(err).context("failed to read HWI_PARITY_DEVICE_TYPE"),
         }
+    }
+
+    fn getxpub_arg_cases(device_type: &str) -> Vec<Vec<String>> {
+        vec![
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getxpub",
+                "m/44h/1h/0h",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--expert",
+                "--device-type",
+                device_type,
+                "getxpub",
+                "m/44h/1h/0h/0/3",
+            ]),
+        ]
     }
 
     fn enumerate_python_hwi_arg_cases(

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -216,6 +216,24 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn candidate_getmasterxpub_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for args in getmasterxpub_arg_cases(&device_type) {
+            assert_getmasterxpub_parity(args.clone())
+                .with_context(|| format!("getmasterxpub parity failed for args: {args:?}"))?;
+        }
+
+        Ok(())
+    }
+
     fn assert_enumerate_parity(
         args: Vec<String>,
         expected_device_type: Option<&str>,
@@ -240,6 +258,26 @@ mod tests {
         if reference.json != candidate.json {
             bail!(
                 "HWI JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_getmasterxpub_parity(args: Vec<String>) -> Result<()> {
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_xpub_only_shape("reference", "getmasterxpub", &reference.json)?;
+
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_xpub_only_shape("candidate", "getmasterxpub", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI getmasterxpub JSON mismatch\nreference:\n{}\ncandidate:\n{}",
                 serde_json::to_string_pretty(&reference.json)?,
                 serde_json::to_string_pretty(&candidate.json)?
             );
@@ -304,8 +342,6 @@ mod tests {
             );
         };
 
-        assert_string_json_field(label, json, "xpub")?;
-
         let expected: &[&str] = if expert {
             &[
                 "xpub",
@@ -321,6 +357,7 @@ mod tests {
             &["xpub"]
         };
         assert_exact_keys(label, "getxpub", json, expected)?;
+        assert_string_json_field(label, json, "xpub")?;
 
         if !expert {
             return Ok(());
@@ -359,6 +396,18 @@ mod tests {
             }
         }
 
+        Ok(())
+    }
+
+    fn assert_xpub_only_shape(label: &str, command: &str, json: &Value) -> Result<()> {
+        if !json.is_object() {
+            bail!(
+                "{label} hwi {command} output was not an object:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+        assert_exact_keys(label, command, json, &["xpub"])?;
+        assert_string_json_field(label, json, "xpub")?;
         Ok(())
     }
 
@@ -597,6 +646,78 @@ mod tests {
             Err(env::VarError::NotPresent) => Ok(None),
             Err(err) => Err(err).context("failed to read HWI_PARITY_DEVICE_TYPE"),
         }
+    }
+
+    fn getmasterxpub_arg_cases(device_type: &str) -> Vec<Vec<String>> {
+        vec![
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--expert",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+                "--account",
+                "1",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+                "--addr-type",
+                "legacy",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+                "--addr-type",
+                "sh_wit",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+                "--addr-type",
+                "wit",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getmasterxpub",
+                "--addr-type",
+                "tap",
+            ]),
+        ]
     }
 
     fn getxpub_arg_cases(device_type: &str) -> Vec<Vec<String>> {

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -272,6 +272,33 @@ mod tests {
     }
 
     #[test]
+    fn candidate_getkeypool_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for case in getkeypool_arg_cases(&device_type) {
+            match case.expect {
+                ExpectedResult::Success => assert_getkeypool_parity(case.args.clone())
+                    .with_context(|| {
+                        format!("getkeypool parity failed for args: {:?}", case.args)
+                    })?,
+                ExpectedResult::Error => {
+                    assert_error_json_parity(case.args.clone()).with_context(|| {
+                        format!("getkeypool error parity failed for args: {:?}", case.args)
+                    })?
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn candidate_signtx_matches_reference() -> Result<()> {
         if env::var("HWI_BIN").is_err() {
             return Ok(());
@@ -409,6 +436,47 @@ mod tests {
         Ok(())
     }
 
+    fn assert_getkeypool_parity(args: Vec<String>) -> Result<()> {
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_getkeypool_shape("reference", &reference.json)?;
+
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_getkeypool_shape("candidate", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI getkeypool JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
+    fn assert_error_json_parity(args: Vec<String>) -> Result<()> {
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        let candidate = HwiBinary::candidate()?.run(args)?;
+
+        // Python HWI 3.2.0 sometimes exits 0 for JSON error responses; keep
+        // command parity focused on the HWI JSON contract until the dedicated
+        // error-model work standardizes process status.
+        assert_error_shape("reference", &reference.json)?;
+        assert_error_shape("candidate", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI error JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
     fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
         prepare_signmessage_run(&args)?;
         let reference = HwiBinary::reference()?.run(args.clone())?;
@@ -533,6 +601,78 @@ mod tests {
         Ok(())
     }
 
+    fn assert_getkeypool_shape(label: &str, json: &Value) -> Result<()> {
+        let Some(entries) = json.as_array() else {
+            bail!(
+                "{label} hwi getkeypool output was not an array:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+        if entries.is_empty() {
+            bail!(
+                "{label} hwi getkeypool output was empty:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+
+        for entry in entries {
+            assert_exact_keys(
+                label,
+                "getkeypool entry",
+                entry,
+                &[
+                    "desc",
+                    "range",
+                    "timestamp",
+                    "internal",
+                    "keypool",
+                    "active",
+                    "watchonly",
+                ],
+            )?;
+            let descriptor = assert_string_json_field(label, entry, "desc")?;
+            if !descriptor.contains('#') || !descriptor.contains("/*") {
+                bail!(
+                    "{label} hwi getkeypool descriptor was not ranged with checksum: {descriptor}"
+                );
+            }
+            if descriptor.contains('\'') {
+                bail!(
+                    "{label} hwi getkeypool descriptor used apostrophe hardening instead of h: {descriptor}"
+                );
+            }
+            assert_range_field(label, entry)?;
+            if entry.get("timestamp").and_then(Value::as_str) != Some("now") {
+                bail!(
+                    "{label} hwi getkeypool timestamp was not \"now\":\n{}",
+                    serde_json::to_string_pretty(entry)?
+                );
+            }
+            for field in ["internal", "keypool", "active", "watchonly"] {
+                if entry.get(field).and_then(Value::as_bool).is_none() {
+                    bail!(
+                        "{label} hwi getkeypool field {field:?} was not a bool:\n{}",
+                        serde_json::to_string_pretty(entry)?
+                    );
+                }
+            }
+            if entry.get("active") != entry.get("keypool") {
+                bail!(
+                    "{label} hwi getkeypool active did not match keypool:\n{}",
+                    serde_json::to_string_pretty(entry)?
+                );
+            }
+            if entry.get("watchonly").and_then(Value::as_bool) != Some(true) {
+                bail!(
+                    "{label} hwi getkeypool watchonly was not true:\n{}",
+                    serde_json::to_string_pretty(entry)?
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     fn assert_signtx_shape(label: &str, json: &Value) -> Result<()> {
         assert_exact_keys(label, "signtx", json, &["psbt", "signed"])?;
         assert_string_json_field(label, json, "psbt")?;
@@ -644,6 +784,34 @@ mod tests {
         };
         assert_exact_keys(label, command, json, &["xpub"])?;
         assert_string_json_field(label, json, "xpub")?;
+        Ok(())
+    }
+
+    fn assert_error_shape(label: &str, json: &Value) -> Result<()> {
+        assert_exact_keys(label, "error", json, &["error", "code"])?;
+        assert_string_json_field(label, json, "error")?;
+        if json.get("code").and_then(Value::as_i64).is_none() {
+            bail!(
+                "{label} hwi error field \"code\" was not an integer:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
+        Ok(())
+    }
+
+    fn assert_range_field(label: &str, json: &Value) -> Result<()> {
+        let Some(range) = json.get("range").and_then(Value::as_array) else {
+            bail!(
+                "{label} hwi field \"range\" was not an array:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        };
+        if range.len() != 2 || range.iter().any(|value| value.as_u64().is_none()) {
+            bail!(
+                "{label} hwi field \"range\" was not two unsigned integers:\n{}",
+                serde_json::to_string_pretty(json)?
+            );
+        }
         Ok(())
     }
 
@@ -1427,6 +1595,105 @@ mod tests {
                 "1",
             ]),
         ]
+    }
+
+    enum ExpectedResult {
+        Success,
+        Error,
+    }
+
+    struct CommandCase {
+        args: Vec<String>,
+        expect: ExpectedResult,
+    }
+
+    fn getkeypool_arg_cases(device_type: &str) -> Vec<CommandCase> {
+        let mut cases = vec![
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getkeypool",
+                    "0",
+                    "2",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getkeypool",
+                    "--internal",
+                    "--nokeypool",
+                    "--addr-type",
+                    "sh_wit",
+                    "--account",
+                    "1",
+                    "5",
+                    "7",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getkeypool",
+                    "--keypool",
+                    "--path",
+                    "m/84h/1h/0h/0/*",
+                    "0",
+                    "1",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getkeypool",
+                    "--all",
+                    "0",
+                    "1",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+        ];
+
+        cases.push(CommandCase {
+            args: args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getkeypool",
+                "--addr-type",
+                "tap",
+                "0",
+                "1",
+            ]),
+            expect: if device_type == "ledger" {
+                ExpectedResult::Success
+            } else {
+                ExpectedResult::Error
+            },
+        });
+
+        cases
     }
 
     fn enumerate_python_hwi_arg_cases(

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -254,6 +254,24 @@ mod tests {
     }
 
     #[test]
+    fn candidate_getdescriptors_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let Some(device_type) = expected_device_type_from_env()? else {
+            return Ok(());
+        };
+
+        for args in getdescriptors_arg_cases(&device_type) {
+            assert_getdescriptors_parity(args.clone())
+                .with_context(|| format!("getdescriptors parity failed for args: {args:?}"))?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn candidate_signtx_matches_reference() -> Result<()> {
         if env::var("HWI_BIN").is_err() {
             return Ok(());
@@ -371,6 +389,26 @@ mod tests {
         Ok(())
     }
 
+    fn assert_getdescriptors_parity(args: Vec<String>) -> Result<()> {
+        let reference = HwiBinary::reference()?.run(args.clone())?;
+        assert_success("reference", &reference)?;
+        assert_getdescriptors_shape("reference", &reference.json)?;
+
+        let candidate = HwiBinary::candidate()?.run(args)?;
+        assert_success("candidate", &candidate)?;
+        assert_getdescriptors_shape("candidate", &candidate.json)?;
+
+        if reference.json != candidate.json {
+            bail!(
+                "HWI getdescriptors JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        Ok(())
+    }
+
     fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
         prepare_signmessage_run(&args)?;
         let reference = HwiBinary::reference()?.run(args.clone())?;
@@ -454,6 +492,43 @@ mod tests {
                 decoded.len(),
                 serde_json::to_string_pretty(json)?
             );
+        }
+        Ok(())
+    }
+
+    fn assert_getdescriptors_shape(label: &str, json: &Value) -> Result<()> {
+        assert_exact_keys(label, "getdescriptors", json, &["receive", "internal"])?;
+        for field in ["receive", "internal"] {
+            let Some(descriptors) = json.get(field).and_then(Value::as_array) else {
+                bail!(
+                    "{label} hwi getdescriptors field {field:?} was not an array:\n{}",
+                    serde_json::to_string_pretty(json)?
+                );
+            };
+            if descriptors.is_empty() {
+                bail!(
+                    "{label} hwi getdescriptors field {field:?} was empty:\n{}",
+                    serde_json::to_string_pretty(json)?
+                );
+            }
+            for descriptor in descriptors {
+                let Some(descriptor) = descriptor.as_str() else {
+                    bail!(
+                        "{label} hwi getdescriptors field {field:?} contained a non-string:\n{}",
+                        serde_json::to_string_pretty(json)?
+                    );
+                };
+                if !descriptor.contains('#') || !descriptor.contains("/*") {
+                    bail!(
+                        "{label} hwi getdescriptors descriptor was not ranged with checksum: {descriptor}"
+                    );
+                }
+                if descriptor.contains('\'') {
+                    bail!(
+                        "{label} hwi getdescriptors descriptor used apostrophe hardening instead of h: {descriptor}"
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -1327,6 +1402,29 @@ mod tests {
                 device_type,
                 "getxpub",
                 "m/44h/1h/0h/0/3",
+            ]),
+        ]
+    }
+
+    fn getdescriptors_arg_cases(device_type: &str) -> Vec<Vec<String>> {
+        vec![
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getdescriptors",
+            ]),
+            args([
+                "--emulators",
+                "--chain",
+                "test",
+                "--device-type",
+                device_type,
+                "getdescriptors",
+                "--account",
+                "1",
             ]),
         ]
     }

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -261,9 +261,21 @@ mod tests {
             return Ok(());
         };
 
-        for args in getmasterxpub_arg_cases(&device_type) {
-            assert_getmasterxpub_parity(args.clone())
-                .with_context(|| format!("getmasterxpub parity failed for args: {args:?}"))?;
+        for case in getmasterxpub_arg_cases(&device_type) {
+            match case.expect {
+                ExpectedResult::Success => assert_getmasterxpub_parity(case.args.clone())
+                    .with_context(|| {
+                        format!("getmasterxpub parity failed for args: {:?}", case.args)
+                    })?,
+                ExpectedResult::Error => {
+                    assert_error_json_parity(case.args.clone()).with_context(|| {
+                        format!(
+                            "getmasterxpub error parity failed for args: {:?}",
+                            case.args
+                        )
+                    })?
+                }
+            }
         }
 
         Ok(())
@@ -640,6 +652,7 @@ mod tests {
     }
 
     fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
+        let device_type = arg_value(&args, "--device-type").map(str::to_owned);
         prepare_signmessage_run(&args)?;
         let reference = HwiBinary::reference()?.run(args.clone())?;
         assert_success("reference", &reference)?;
@@ -649,6 +662,10 @@ mod tests {
         let candidate = HwiBinary::candidate()?.run(args)?;
         assert_success("candidate", &candidate)?;
         assert_signmessage_shape("candidate", &candidate.json)?;
+
+        if device_type.as_deref() == Some("bitbox02") {
+            return Ok(());
+        }
 
         if reference.json != candidate.json {
             bail!(
@@ -734,10 +751,7 @@ mod tests {
 
     fn assert_signmessage_shape(label: &str, json: &Value) -> Result<()> {
         assert_exact_keys(label, "signmessage", json, &["signature"])?;
-        let signature = assert_string_json_field(label, json, "signature")?;
-        let decoded = BASE64_STANDARD
-            .decode(signature)
-            .with_context(|| format!("{label} hwi signmessage signature was not base64"))?;
+        let decoded = signmessage_payload(label, json)?;
         if decoded.len() != 65 {
             bail!(
                 "{label} hwi signmessage signature was {} bytes, expected 65:\n{}",
@@ -746,6 +760,13 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    fn signmessage_payload(label: &str, json: &Value) -> Result<Vec<u8>> {
+        let signature = assert_string_json_field(label, json, "signature")?;
+        BASE64_STANDARD
+            .decode(signature)
+            .with_context(|| format!("{label} hwi signmessage signature was not base64"))
     }
 
     fn assert_displayaddress_shape(label: &str, json: &Value) -> Result<()> {
@@ -1536,6 +1557,7 @@ mod tests {
 
     fn signmessage_arg_cases(device_type: &str) -> Result<Vec<(&'static str, &'static str)>> {
         let path = match device_type {
+            "bitbox02" => "m/49'/1'/0'/0/10",
             "ledger" => "m/44'/1'/0'/0",
             "jade" | "coldcard" => "m/44'/1'/0'",
             _ => bail!("unsupported signmessage device type {device_type:?}"),
@@ -1547,18 +1569,12 @@ mod tests {
         let fingerprint = reference_fingerprint(device_type)?;
         let wit_xpub = reference_xpub(device_type, "m/84'/1'/0'")?;
         let sh_wit_xpub = reference_xpub(device_type, "m/49'/1'/0'")?;
-        let legacy_xpub = reference_xpub(device_type, "m/44'/1'/0'")?;
         let fingerprint = fingerprint.to_string();
         let wit_xpub_string = wit_xpub.to_string();
         let wit_pubkey = lower_hex(&wit_xpub.public_key.serialize());
         let sh_wit_xpub = sh_wit_xpub.to_string();
-        let legacy_xpub = legacy_xpub.to_string();
 
         let mut cases = vec![
-            CommandCase {
-                args: displayaddress_path_args(device_type, "legacy", "m/44h/1h/0h/0/0"),
-                expect: ExpectedResult::Success,
-            },
             CommandCase {
                 args: displayaddress_path_args(device_type, "sh_wit", "m/49h/1h/0h/0/0"),
                 expect: ExpectedResult::Success,
@@ -1588,18 +1604,29 @@ mod tests {
                 ),
                 expect: ExpectedResult::Success,
             },
-            CommandCase {
+        ];
+
+        if device_type != "bitbox02" {
+            let legacy_xpub = reference_xpub(device_type, "m/44'/1'/0'")?.to_string();
+            cases.insert(
+                0,
+                CommandCase {
+                    args: displayaddress_path_args(device_type, "legacy", "m/44h/1h/0h/0/0"),
+                    expect: ExpectedResult::Success,
+                },
+            );
+            cases.push(CommandCase {
                 args: displayaddress_desc_args(
                     device_type,
                     &format!("pkh([{fingerprint}/44h/1h/0h]{legacy_xpub}/0/0)"),
                 ),
                 expect: ExpectedResult::Success,
-            },
-        ];
+            });
+        }
 
         cases.push(CommandCase {
             args: displayaddress_path_args(device_type, "tap", "m/86h/1h/0h/0/0"),
-            expect: if device_type == "ledger" {
+            expect: if device_type == "bitbox02" || device_type == "ledger" {
                 ExpectedResult::Success
             } else {
                 ExpectedResult::Error
@@ -1850,79 +1877,126 @@ mod tests {
         }
     }
 
-    fn getmasterxpub_arg_cases(device_type: &str) -> Vec<Vec<String>> {
-        vec![
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--expert",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-                "--account",
-                "1",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-                "--addr-type",
-                "legacy",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-                "--addr-type",
-                "sh_wit",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-                "--addr-type",
-                "wit",
-            ]),
-            args([
-                "--emulators",
-                "--chain",
-                "test",
-                "--device-type",
-                device_type,
-                "getmasterxpub",
-                "--addr-type",
-                "tap",
-            ]),
-        ]
+    fn getmasterxpub_arg_cases(device_type: &str) -> Vec<CommandCase> {
+        let cases = vec![
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--expert",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                    "--account",
+                    "1",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                    "--addr-type",
+                    "legacy",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                    "--addr-type",
+                    "sh_wit",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                    "--addr-type",
+                    "wit",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+            CommandCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getmasterxpub",
+                    "--addr-type",
+                    "tap",
+                ]),
+                expect: ExpectedResult::Success,
+            },
+        ];
+
+        cases
     }
 
     fn getxpub_arg_cases(device_type: &str) -> Vec<Vec<String>> {
+        if device_type == "bitbox02" {
+            return vec![
+                args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "getxpub",
+                    "m/84h/1h/0h",
+                ]),
+                args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--expert",
+                    "--device-type",
+                    device_type,
+                    "getxpub",
+                    "m/49h/1h/0h/0/3",
+                ]),
+            ];
+        }
+
         vec![
             args([
                 "--emulators",
@@ -2074,6 +2148,10 @@ mod tests {
     }
 
     fn unsupported_device_action_cases(device_type: &str) -> Vec<UnsupportedDeviceActionCase> {
+        if device_type == "bitbox02" {
+            return Vec::new();
+        }
+
         vec![
             UnsupportedDeviceActionCase {
                 command: "setup",
@@ -2355,7 +2433,7 @@ mod tests {
     fn normalize_device_type(device_type: &str) -> Result<String> {
         let device_type = device_type.to_ascii_lowercase();
         match device_type.as_str() {
-            "coldcard" | "jade" | "ledger" => Ok(device_type),
+            "bitbox02" | "coldcard" | "jade" | "ledger" => Ok(device_type),
             _ => bail!("unsupported HWI_PARITY_DEVICE_TYPE {device_type:?}"),
         }
     }

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -53,6 +53,19 @@ impl HwiBinary {
         parse_output(self.label, output)
     }
 
+    pub fn run_with_envs<I, S>(&self, args: I, envs: &[(&str, &str)]) -> Result<HwiOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = Command::new(&self.path)
+            .args(args)
+            .envs(envs.iter().copied())
+            .output()
+            .with_context(|| format!("failed to spawn {} hwi at {}", self.label, self.path))?;
+        parse_output(self.label, output)
+    }
+
     pub fn run_with_stdin<I, S>(&self, args: I, stdin: &str) -> Result<HwiOutput>
     where
         I: IntoIterator<Item = S>,
@@ -147,8 +160,11 @@ fn assert_success(label: &str, output: &HwiOutput) -> Result<()> {
 mod tests {
     use super::*;
     use std::{
+        fs,
         io::{Read, Write},
+        os::unix::fs::PermissionsExt,
         os::unix::net::UnixDatagram,
+        path::{Path, PathBuf},
         str::FromStr,
         time::Duration,
     };
@@ -408,6 +424,79 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn candidate_installudevrules_matches_reference_or_avoids_getlogin_failure() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let temp = temp_path("installudevrules")?;
+        let fake_bin = temp.join("bin");
+        let reference_rules = temp.join("reference-rules.d");
+        let candidate_rules = temp.join("candidate-rules.d");
+        fs::create_dir_all(&fake_bin)?;
+        fs::create_dir_all(&reference_rules)?;
+        fs::create_dir_all(&candidate_rules)?;
+        write_fake_command(&fake_bin.join("udevadm"), 0)?;
+        write_fake_command(&fake_bin.join("groupadd"), 0)?;
+        write_fake_command(&fake_bin.join("usermod"), 0)?;
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let test_path = format!("{}:{original_path}", fake_bin.display());
+        let envs = [("PATH", test_path.as_str()), ("USER", "bhwi-test")];
+
+        let reference = HwiBinary::reference()?.run_with_envs(
+            args([
+                "installudevrules",
+                "--location",
+                reference_rules
+                    .to_str()
+                    .context("reference rules path is not utf8")?,
+            ]),
+            &envs,
+        )?;
+        let reference_getlogin_failure = is_upstream_getlogin_failure(&reference.json);
+        if !reference_getlogin_failure {
+            assert_success("reference", &reference)?;
+        }
+
+        let candidate = HwiBinary::candidate()?.run_with_envs(
+            args([
+                "installudevrules",
+                "--location",
+                candidate_rules
+                    .to_str()
+                    .context("candidate rules path is not utf8")?,
+            ]),
+            &envs,
+        )?;
+        assert_success("candidate", &candidate)?;
+
+        if !reference_getlogin_failure && reference.json != candidate.json {
+            bail!(
+                "HWI installudevrules JSON mismatch\nreference:\n{}\ncandidate:\n{}",
+                serde_json::to_string_pretty(&reference.json)?,
+                serde_json::to_string_pretty(&candidate.json)?
+            );
+        }
+
+        assert_udev_rule_dirs_match(&reference_rules, &candidate_rules)?;
+        fs::remove_dir_all(temp).ok();
+        Ok(())
+    }
+
+    fn is_upstream_getlogin_failure(json: &Value) -> bool {
+        json.get("code").and_then(Value::as_i64) == Some(-13)
+            && json
+                .get("error")
+                .and_then(Value::as_str)
+                .is_some_and(|error| {
+                    error.starts_with("installudevrules failed: [Errno ")
+                        && (error.contains("Inappropriate ioctl for device")
+                            || error.contains("No such device or address"))
+                })
     }
 
     fn assert_enumerate_parity(
@@ -2204,6 +2293,63 @@ mod tests {
 
     fn args<const N: usize>(items: [&str; N]) -> Vec<String> {
         items.into_iter().map(str::to_owned).collect()
+    }
+
+    fn temp_path(name: &str) -> Result<PathBuf> {
+        let mut path = env::temp_dir();
+        path.push(format!("bhwi-hwi-parity-{name}-{}", std::process::id()));
+        if path.exists() {
+            fs::remove_dir_all(&path)
+                .with_context(|| format!("failed to clean {}", path.display()))?;
+        }
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create {}", path.display()))?;
+        Ok(path)
+    }
+
+    fn write_fake_command(path: &Path, exit_code: i32) -> Result<()> {
+        fs::write(path, format!("#!/bin/sh\nexit {exit_code}\n"))
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed to chmod {}", path.display()))?;
+        Ok(())
+    }
+
+    fn assert_udev_rule_dirs_match(reference: &Path, candidate: &Path) -> Result<()> {
+        let mut reference_files = rule_files(reference)?;
+        let mut candidate_files = rule_files(candidate)?;
+        reference_files.sort();
+        candidate_files.sort();
+
+        if reference_files != candidate_files {
+            bail!(
+                "udev rule file list mismatch\nreference: {:?}\ncandidate: {:?}",
+                reference_files,
+                candidate_files
+            );
+        }
+
+        for file_name in reference_files {
+            let reference_contents = fs::read(reference.join(&file_name))
+                .with_context(|| format!("failed to read reference {file_name}"))?;
+            let candidate_contents = fs::read(candidate.join(&file_name))
+                .with_context(|| format!("failed to read candidate {file_name}"))?;
+            if reference_contents != candidate_contents {
+                bail!("udev rule file contents mismatch for {file_name}");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn rule_files(path: &Path) -> Result<Vec<String>> {
+        fs::read_dir(path)
+            .with_context(|| format!("failed to read {}", path.display()))?
+            .map(|entry| {
+                let entry = entry?;
+                Ok(entry.file_name().to_string_lossy().into_owned())
+            })
+            .collect()
     }
 
     fn normalize_device_type(device_type: &str) -> Result<String> {

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     ffi::OsStr,
     io::Write,
+    path::Path,
     process::{Command, Output, Stdio},
 };
 
@@ -63,6 +64,26 @@ impl HwiBinary {
             .envs(envs.iter().copied())
             .output()
             .with_context(|| format!("failed to spawn {} hwi at {}", self.label, self.path))?;
+        parse_output(self.label, output)
+    }
+
+    pub fn run_in_dir<I, S>(&self, args: I, cwd: &Path) -> Result<HwiOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = Command::new(&self.path)
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .with_context(|| {
+                format!(
+                    "failed to spawn {} hwi at {} in {}",
+                    self.label,
+                    self.path,
+                    cwd.display()
+                )
+            })?;
         parse_output(self.label, output)
     }
 
@@ -413,7 +434,7 @@ mod tests {
 
         for case in backup_arg_cases(&device_type) {
             match case.expect {
-                ExpectedResult::Success => assert_json_parity(case.args.clone())
+                ExpectedResult::Success => assert_backup_parity(&device_type, case.args.clone())
                     .with_context(|| format!("backup parity failed for args: {:?}", case.args))?,
                 ExpectedResult::Error => {
                     assert_error_json_parity(case.args.clone()).with_context(|| {
@@ -421,6 +442,64 @@ mod tests {
                     })?
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn assert_backup_parity(device_type: &str, args: Vec<String>) -> Result<()> {
+        if device_type != "coldcard" {
+            assert_json_parity(args)?;
+            return Ok(());
+        }
+
+        let temp = temp_path("coldcard-backup")?;
+        let reference_dir = temp.join("reference");
+        let candidate_dir = temp.join("candidate");
+        fs::create_dir_all(&reference_dir)?;
+        fs::create_dir_all(&candidate_dir)?;
+
+        let reference_approval = spawn_coldcard_backup_approval();
+        let reference = HwiBinary::reference()?.run_in_dir(args.clone(), &reference_dir)?;
+        let _ = reference_approval.join();
+        let candidate_approval = spawn_coldcard_backup_approval();
+        let candidate = HwiBinary::candidate()?.run_in_dir(args, &candidate_dir)?;
+        let _ = candidate_approval.join();
+
+        assert_success("reference", &reference)?;
+        assert_success("candidate", &candidate)?;
+        assert_eq!(reference.json, serde_json::json!({ "success": true }));
+        assert_eq!(candidate.json, reference.json);
+        assert_backup_artifact("reference", &reference_dir)?;
+        assert_backup_artifact("candidate", &candidate_dir)?;
+
+        Ok(())
+    }
+
+    fn assert_backup_artifact(label: &str, dir: &Path) -> Result<()> {
+        let files = fs::read_dir(dir)?
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|entry| {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                name.starts_with("backup-") && name.ends_with(".7z")
+            })
+            .collect::<Vec<_>>();
+        if files.len() != 1 {
+            bail!(
+                "{label} backup wrote {} matching artifacts in {}",
+                files.len(),
+                dir.display()
+            );
+        }
+
+        let bytes = fs::read(files[0].path())?;
+        if !bytes.starts_with(b"7z\xbc\xaf'\x1c") {
+            bail!("{label} backup artifact does not look like a 7z file");
+        }
+        if bytes.len() <= 1024 {
+            bail!("{label} backup artifact is unexpectedly small");
         }
 
         Ok(())
@@ -437,27 +516,12 @@ mod tests {
         };
 
         for case in unsupported_device_action_cases(&device_type) {
-            if device_type == "coldcard" && case.command == "backup" {
-                let candidate =
-                    assert_candidate_error_json(case.args.clone()).with_context(|| {
-                        format!(
-                            "candidate Coldcard backup deviation failed for args: {:?}",
-                            case.args
-                        )
-                    })?;
-                assert_eq!(candidate["code"], -9);
-                assert_eq!(
-                    candidate["error"],
-                    "The Coldcard does not support creating a backup via software"
-                );
-            } else {
-                assert_error_json_parity(case.args.clone()).with_context(|| {
-                    format!(
-                        "unsupported device action parity failed for args: {:?}",
-                        case.args
-                    )
-                })?;
-            }
+            assert_error_json_parity(case.args.clone()).with_context(|| {
+                format!(
+                    "unsupported device action parity failed for args: {:?}",
+                    case.args
+                )
+            })?;
         }
 
         Ok(())
@@ -668,12 +732,6 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    fn assert_candidate_error_json(args: Vec<String>) -> Result<Value> {
-        let candidate = HwiBinary::candidate()?.run(args)?;
-        assert_error_shape("candidate", &candidate.json)?;
-        Ok(candidate.json)
     }
 
     fn assert_signmessage_parity(args: Vec<String>) -> Result<()> {
@@ -1844,6 +1902,13 @@ mod tests {
         });
     }
 
+    fn spawn_coldcard_backup_approval() -> std::thread::JoinHandle<()> {
+        std::thread::spawn(|| {
+            std::thread::sleep(Duration::from_secs(1));
+            let _ = send_coldcard_backup_approval();
+        })
+    }
+
     fn send_coldcard_approval() -> Result<()> {
         let client_socket = format!("/tmp/bhwi-hwi-parity-ckcc-{}.sock", std::process::id());
         let _ = std::fs::remove_file(&client_socket);
@@ -1851,6 +1916,24 @@ mod tests {
         socket.set_read_timeout(Some(Duration::from_secs(2)))?;
         socket.connect("/tmp/ckcc-simulator.sock")?;
         coldcard_hid_exchange(&socket, b"XKEYy")?;
+        let _ = std::fs::remove_file(client_socket);
+        Ok(())
+    }
+
+    fn send_coldcard_backup_approval() -> Result<()> {
+        let client_socket = format!(
+            "/tmp/bhwi-hwi-parity-ckcc-backup-{}.sock",
+            std::process::id()
+        );
+        let _ = std::fs::remove_file(&client_socket);
+        let socket = UnixDatagram::bind(&client_socket)?;
+        socket.set_read_timeout(Some(Duration::from_secs(2)))?;
+        socket.connect("/tmp/ckcc-simulator.sock")?;
+        coldcard_hid_exchange(&socket, b"XKEYy")?;
+        for _ in 0..20 {
+            std::thread::sleep(Duration::from_millis(250));
+            coldcard_hid_exchange(&socket, b"XKEY1")?;
+        }
         let _ = std::fs::remove_file(client_socket);
         Ok(())
     }
@@ -2079,7 +2162,6 @@ mod tests {
     }
 
     struct UnsupportedDeviceActionCase {
-        command: &'static str,
         args: Vec<String>,
     }
 
@@ -2177,9 +2259,8 @@ mod tests {
             return Vec::new();
         }
 
-        vec![
+        let mut cases = vec![
             UnsupportedDeviceActionCase {
-                command: "setup",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2190,7 +2271,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "setup",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2206,7 +2286,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "wipe",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2217,7 +2296,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "restore",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2232,7 +2310,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "restore",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2248,22 +2325,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "backup",
-                args: args([
-                    "--emulators",
-                    "--chain",
-                    "test",
-                    "--device-type",
-                    device_type,
-                    "backup",
-                    "--label",
-                    "HWI Test",
-                    "--backup_passphrase",
-                    "backup passphrase",
-                ]),
-            },
-            UnsupportedDeviceActionCase {
-                command: "promptpin",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2274,7 +2335,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "sendpin",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2286,7 +2346,6 @@ mod tests {
                 ]),
             },
             UnsupportedDeviceActionCase {
-                command: "togglepassphrase",
                 args: args([
                     "--emulators",
                     "--chain",
@@ -2296,68 +2355,118 @@ mod tests {
                     "togglepassphrase",
                 ]),
             },
-        ]
+        ];
+
+        if device_type != "coldcard" {
+            cases.push(UnsupportedDeviceActionCase {
+                args: args([
+                    "--emulators",
+                    "--chain",
+                    "test",
+                    "--device-type",
+                    device_type,
+                    "backup",
+                    "--label",
+                    "HWI Test",
+                    "--backup_passphrase",
+                    "backup passphrase",
+                ]),
+            });
+        }
+
+        cases
     }
 
     fn backup_arg_cases(device_type: &str) -> Vec<CommandCase> {
-        if device_type != "bitbox02" {
-            return Vec::new();
+        if device_type == "coldcard" {
+            return vec![
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                    ]),
+                    expect: ExpectedResult::Success,
+                },
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                        "--label",
+                        "HWI Test",
+                        "--backup_passphrase",
+                        "backup passphrase",
+                    ]),
+                    expect: ExpectedResult::Success,
+                },
+            ];
         }
 
-        vec![
-            CommandCase {
-                args: args([
-                    "--emulators",
-                    "--chain",
-                    "test",
-                    "--device-type",
-                    device_type,
-                    "backup",
-                ]),
-                expect: ExpectedResult::Success,
-            },
-            CommandCase {
-                args: args([
-                    "--emulators",
-                    "--chain",
-                    "test",
-                    "--device-type",
-                    device_type,
-                    "backup",
-                    "--label",
-                    "HWI Test",
-                ]),
-                expect: ExpectedResult::Error,
-            },
-            CommandCase {
-                args: args([
-                    "--emulators",
-                    "--chain",
-                    "test",
-                    "--device-type",
-                    device_type,
-                    "backup",
-                    "--backup_passphrase",
-                    "backup passphrase",
-                ]),
-                expect: ExpectedResult::Error,
-            },
-            CommandCase {
-                args: args([
-                    "--emulators",
-                    "--chain",
-                    "test",
-                    "--device-type",
-                    device_type,
-                    "backup",
-                    "--label",
-                    "HWI Test",
-                    "--backup_passphrase",
-                    "backup passphrase",
-                ]),
-                expect: ExpectedResult::Error,
-            },
-        ]
+        if device_type == "bitbox02" {
+            return vec![
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                    ]),
+                    expect: ExpectedResult::Success,
+                },
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                        "--label",
+                        "HWI Test",
+                    ]),
+                    expect: ExpectedResult::Error,
+                },
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                        "--backup_passphrase",
+                        "backup passphrase",
+                    ]),
+                    expect: ExpectedResult::Error,
+                },
+                CommandCase {
+                    args: args([
+                        "--emulators",
+                        "--chain",
+                        "test",
+                        "--device-type",
+                        device_type,
+                        "backup",
+                        "--label",
+                        "HWI Test",
+                        "--backup_passphrase",
+                        "backup passphrase",
+                    ]),
+                    expect: ExpectedResult::Error,
+                },
+            ];
+        }
+
+        Vec::new()
     }
 
     fn enumerate_python_hwi_arg_cases(

--- a/e2e/ledger/automations/hwi_speculos.json
+++ b/e2e/ledger/automations/hwi_speculos.json
@@ -1,0 +1,102 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "text": "Confirm",
+      "x": 43,
+      "y": 37,
+      "actions": [
+        ["button", 1, true],
+        ["button", 2, true],
+        ["button", 1, false],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "text": "Confirm account ",
+      "actions": [
+        ["button", 1, true],
+        ["button", 2, true],
+        ["button", 1, false],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "^. of . Multisig$",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "^(Address|Review|Amount|Fee|Confirm|The derivation|Derivation path|Reject if|The change path|Change path|Register wallet|Policy map|Key|Our key|Their key|Path|Public key|Spend from|Wallet name|Wallet policy|Descriptor template|Verify Bitcoin|To|Output|Warning).*",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "^(Message)$",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "^(Accept|Approve|Continue|Sign message|Sign transaction|Register account).*",
+      "actions": [
+        ["button", 1, true],
+        ["button", 2, true],
+        ["button", 1, false],
+        ["button", 2, false]
+      ]
+    },
+    {
+      "regexp": "^Message hash.*",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false],
+        ["setbool", "seen_msg_hash", true]
+      ]
+    },
+    {
+      "regexp": "^Message content.*",
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false],
+        ["setbool", "seen_msg_hash", true]
+      ]
+    },
+    {
+      "text": "message",
+      "conditions": [
+        ["seen_msg_hash", false]
+      ],
+      "actions": [
+        ["button", 2, true],
+        ["button", 2, false],
+        ["setbool", "seen_msg_hash", true]
+      ]
+    },
+    {
+      "text": "message",
+      "conditions": [
+        ["seen_msg_hash", true]
+      ],
+      "actions": [
+        ["button", 1, true],
+        ["button", 2, true],
+        ["button", 1, false],
+        ["button", 2, false],
+        ["setbool", "seen_msg_hash", false]
+      ]
+    },
+    {
+      "regexp": "^(Cancel|Reject).*",
+      "actions": [
+        ["button", 1, true],
+        ["button", 1, false]
+      ]
+    }
+  ]
+}

--- a/e2e/ledger/automations/register_wallet_accept.json
+++ b/e2e/ledger/automations/register_wallet_accept.json
@@ -2,7 +2,7 @@
   "version": 1,
   "rules": [
     {
-      "regexp": "Review account|Account name|Wallet policy|Wallet|co-signer|Our|Their|Dummy|key|public|Policy",
+      "regexp": "Review account|Account name|Wallet policy|Wallet|co-signer|Our|Their|Dummy|Key|key|public|Policy",
       "actions": [
         ["button", 2, true],
         ["button", 2, false]

--- a/e2e/ledger/src/lib.rs
+++ b/e2e/ledger/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
     async fn can_get_version() {
         let (mut dev, _) = init().await;
         let info = dev.get_info().await.unwrap();
-        assert_eq!(info.version.to_string(), "2.4.6");
+        assert_eq!(info.version.to_string(), "2.4.1");
         assert_eq!(info.firmware, Some("Bitcoin Test".to_string()));
         assert_eq!(info.networks.first().unwrap().to_string(), "testnet");
     }

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,16 @@
     "app-bitcoin-new": {
       "flake": false,
       "locked": {
-        "lastModified": 1779205252,
-        "narHash": "sha256-LNvZm7ZpKO+ruHQPTcCkjoMT4dm8Tt45lI5VrN5ZQ0Y=",
+        "lastModified": 1751527834,
+        "narHash": "sha256-+u5sPi2qLfGiWwm3+aBIjn4CPFIMdS9jkHP/yLDrvjg=",
         "owner": "LedgerHQ",
         "repo": "app-bitcoin-new",
-        "rev": "3ac253258f8cec4922255a0296eeb6119f72f572",
+        "rev": "e674f4223eb7cf3dd8defbc323b90c7c90de3908",
         "type": "github"
       },
       "original": {
         "owner": "LedgerHQ",
+        "ref": "2.4.1",
         "repo": "app-bitcoin-new",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -473,7 +473,7 @@
         hwiReferenceBhwiMain = pkgs.writeText "hwi-reference-bhwi.py" ''
           from hwilib import commands
 
-          commands.all_devs = ["ledger", "coldcard", "jade"]
+          commands.all_devs = ["ledger", "coldcard", "jade", "bitbox02"]
 
           from hwilib._cli import main
 
@@ -512,6 +512,7 @@
         hwiParityColdcard = mkHwiParityRunner "bhwi-hwi-parity-coldcard" "coldcard" (coldcardInputs ++ inputs) coldcardE2eEnv;
         hwiParityLedger = mkHwiParityRunner "bhwi-hwi-parity-ledger" "ledger" (ledgerInputs ++ inputs) commonE2eEnv;
         hwiParityJade = mkHwiParityRunner "bhwi-hwi-parity-jade" "jade" (jadeInputs ++ inputs) commonE2eEnv;
+        hwiParityBitbox = mkHwiParityRunner "bhwi-hwi-parity-bitbox" "bitbox02" inputs commonE2eEnv;
         linuxPackages = pkgs.lib.optionalAttrs emulatorSystem (
           {
             inherit speculos;
@@ -536,6 +537,7 @@
           }
           // pkgs.lib.optionalAttrs (!isDarwin) {
             hwi-upstream-suite = mkApp hwiUpstreamSuite;
+            hwi-parity-bitbox = mkApp hwiParityBitbox;
             hwi-parity-coldcard = mkApp hwiParityColdcard;
             hwi-parity-ledger = mkApp hwiParityLedger;
             hwi-parity-jade = mkApp hwiParityJade;

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     app-bitcoin-new = {
-      url = "github:LedgerHQ/app-bitcoin-new";
+      url = "github:LedgerHQ/app-bitcoin-new/2.4.1";
       flake = false;
     };
     coldcard-firmware = {
@@ -492,23 +492,147 @@
           runtimeInputs =
             inputs
             ++ ledgerInputs
+            ++ coldcardInputs
+            ++ jadeQemuInputs
             ++ [
               hwiPython
               pkgs.bitcoin
             ];
           text = ''
+            ${commonE2eEnv}
+            unset C_INCLUDE_PATH
+            unset CPLUS_INCLUDE_PATH
+            unset LIBRARY_PATH
+            unset OBJC_INCLUDE_PATH
+            unset OBJCPLUS_INCLUDE_PATH
+
+            export HWI_PYTHON="${hwiPython}/bin/python"
             export HWI_UPSTREAM_SRC="${python-hwi}"
             export HWI_BITCOIND="''${HWI_BITCOIND:-${pkgs.bitcoin}/bin/bitcoind}"
+            export HWI_BITBOX02_SIMULATOR="''${HWI_BITBOX02_SIMULATOR:-${bitboxSimulator}/bin/bitbox02-simulator}"
             export HWI_LEDGER_SPECULOS_BIN="''${HWI_LEDGER_SPECULOS_BIN:-${speculos}/bin/speculos}"
             export LEDGER_BUILD_APP_SCRIPT="''${LEDGER_BUILD_APP_SCRIPT:-${./nix/scripts/build-ledger-app.sh}}"
             export APP_BITCOIN_NEW_SRC="${app-bitcoin-new}"
             export APP_BITCOIN_NEW_REV="${app-bitcoin-new.rev or "locked"}"
             export APP_BITCOIN_NEW_URL="https://github.com/LedgerHQ/app-bitcoin-new.git"
+            export HWI_COLDCARD_PREPARE_SCRIPT="${coldcardRunner}/bin/bhwi-start-coldcard"
+            export COLDCARD_FIRMWARE_SRC="${coldcard-firmware}"
+            export COLDCARD_FIRMWARE_REV="${coldcard-firmware.rev or "locked"}"
+            export COLDCARD_FIRMWARE_URL="https://github.com/Coldcard/firmware.git"
+            export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
+              coldcardPkgs.SDL2
+              coldcardPkgs.gcc13.cc.lib
+              coldcardPkgs.glibc
+              coldcardPkgs.libffi
+              coldcardPkgs.openssl.out
+              coldcardPkgs.pcsclite
+              coldcardPkgs.systemd
+            ]}"
+            export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
+            export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+            export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
+            export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
+            export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
+            export HWI_JADE_PREPARE_SCRIPT="${./nix/scripts/start-jade.sh}"
+            export JADE_FIRMWARE_SRC="${jade-firmware}"
+            export JADE_FIRMWARE_REV="${jade-firmware.rev or "locked"}"
+            export JADE_FIRMWARE_URL="https://github.com/Blockstream/Jade.git"
+            export IDF_PATH="${jadeEspIdf}"
+            export IDF_TOOLS_PATH="$IDF_PATH/tools"
+            export IDF_PYTHON_CHECK_CONSTRAINTS=no
+            IDF_PYTHON_ENV_PATH="$(readlink "$IDF_PATH/python-env")"
+            export IDF_PYTHON_ENV_PATH
+            export PATH="$IDF_TOOLS_PATH:$IDF_PATH/components/espcoredump:$IDF_PATH/components/partition_table:$IDF_PATH/components/app_update:$PATH"
+            if [ -e "$IDF_PATH/.tool-env" ]; then
+              # shellcheck disable=SC1091
+              . "$IDF_PATH/.tool-env"
+            fi
+            if [ -e "$IDF_PATH/etc/gitconfig" ]; then
+              export GIT_CONFIG_SYSTEM="$IDF_PATH/etc/gitconfig"
+            fi
             export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
+            export HWI_BIN="''${HWI_BIN:-$PWD/target/debug/hwi}"
 
+            cargo build -p bhwi-cli --bin hwi
             exec ${pkgs.bash}/bin/bash ${./nix/scripts/run-hwi-upstream-suite.sh} "$@"
           '';
         };
+        mkHwiUpstreamDevice = name: device: runtimeInputs: env:
+          pkgs.writeShellApplication {
+            inherit name runtimeInputs;
+            text =
+              commonE2eEnv
+              + env
+              + ''
+
+                export HWI_PYTHON="${hwiPython}/bin/python"
+                export HWI_UPSTREAM_SRC="${python-hwi}"
+                export HWI_BITCOIND="''${HWI_BITCOIND:-${pkgs.bitcoin}/bin/bitcoind}"
+                export PYTHONPATH="${python-hwi}:''${PYTHONPATH:-}"
+                export HWI_BIN="''${HWI_BIN:-$PWD/target/debug/hwi}"
+
+                cargo build -p bhwi-cli --bin hwi
+                exec ${pkgs.bash}/bin/bash ${./nix/scripts/run-hwi-upstream-suite.sh} ${device} "$@"
+              '';
+          };
+        hwiUpstreamBitbox =
+          mkHwiUpstreamDevice "hwi-upstream-bitbox" "bitbox02" (inputs ++ [hwiPython pkgs.bitcoin]) ''
+            export HWI_BITBOX02_SIMULATOR="${bitboxSimulator}/bin/bitbox02-simulator"
+          '';
+        hwiUpstreamColdcard =
+          mkHwiUpstreamDevice "hwi-upstream-coldcard" "coldcard" (inputs ++ coldcardInputs ++ [hwiPython pkgs.bitcoin]) ''
+            unset C_INCLUDE_PATH
+            unset CPLUS_INCLUDE_PATH
+            unset LIBRARY_PATH
+            unset OBJC_INCLUDE_PATH
+            unset OBJCPLUS_INCLUDE_PATH
+            export HWI_COLDCARD_PREPARE_SCRIPT="${coldcardRunner}/bin/bhwi-start-coldcard"
+            export COLDCARD_FIRMWARE_SRC="${coldcard-firmware}"
+            export COLDCARD_FIRMWARE_REV="${coldcard-firmware.rev or "locked"}"
+            export COLDCARD_FIRMWARE_URL="https://github.com/Coldcard/firmware.git"
+            export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
+              coldcardPkgs.SDL2
+              coldcardPkgs.gcc13.cc.lib
+              coldcardPkgs.glibc
+              coldcardPkgs.libffi
+              coldcardPkgs.openssl.out
+              coldcardPkgs.pcsclite
+              coldcardPkgs.systemd
+            ]}"
+            export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
+            export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+            export PYSDL2_DLL_PATH="${coldcardPkgs.SDL2}/lib"
+            export CFLAGS="-I${coldcardPkgs.pcsclite.dev}/include/PCSC ''${CFLAGS:-}"
+            export LDFLAGS="-L${coldcardPkgs.pcsclite}/lib ''${LDFLAGS:-}"
+          '';
+        hwiUpstreamLedger =
+          mkHwiUpstreamDevice "hwi-upstream-ledger" "ledger" (inputs ++ ledgerInputs ++ [hwiPython pkgs.bitcoin]) ''
+            export HWI_LEDGER_SPECULOS_BIN="${speculos}/bin/speculos"
+            export LEDGER_BUILD_APP_SCRIPT="${./nix/scripts/build-ledger-app.sh}"
+            export APP_BITCOIN_NEW_SRC="${app-bitcoin-new}"
+            export APP_BITCOIN_NEW_REV="${app-bitcoin-new.rev or "locked"}"
+            export APP_BITCOIN_NEW_URL="https://github.com/LedgerHQ/app-bitcoin-new.git"
+          '';
+        hwiUpstreamJade =
+          mkHwiUpstreamDevice "hwi-upstream-jade" "jade" (inputs ++ jadeQemuInputs ++ [hwiPython pkgs.bitcoin]) ''
+            export HWI_JADE_PREPARE_SCRIPT="${./nix/scripts/start-jade.sh}"
+            export JADE_FIRMWARE_SRC="${jade-firmware}"
+            export JADE_FIRMWARE_REV="${jade-firmware.rev or "locked"}"
+            export JADE_FIRMWARE_URL="https://github.com/Blockstream/Jade.git"
+            export IDF_PATH="${jadeEspIdf}"
+            export IDF_TOOLS_PATH="$IDF_PATH/tools"
+            export IDF_PYTHON_CHECK_CONSTRAINTS=no
+            IDF_PYTHON_ENV_PATH="$(readlink "$IDF_PATH/python-env")"
+            export IDF_PYTHON_ENV_PATH
+            export PATH="$IDF_TOOLS_PATH:$IDF_PATH/components/espcoredump:$IDF_PATH/components/partition_table:$IDF_PATH/components/app_update:$PATH"
+            if [ -e "$IDF_PATH/.tool-env" ]; then
+              # shellcheck disable=SC1091
+              . "$IDF_PATH/.tool-env"
+            fi
+            if [ -e "$IDF_PATH/etc/gitconfig" ]; then
+              export GIT_CONFIG_SYSTEM="$IDF_PATH/etc/gitconfig"
+            fi
+          '';
         hwiParityColdcard = mkHwiParityRunner "bhwi-hwi-parity-coldcard" "coldcard" (coldcardInputs ++ inputs) coldcardE2eEnv;
         hwiParityLedger = mkHwiParityRunner "bhwi-hwi-parity-ledger" "ledger" (ledgerInputs ++ inputs) commonE2eEnv;
         hwiParityJade = mkHwiParityRunner "bhwi-hwi-parity-jade" "jade" (jadeInputs ++ inputs) commonE2eEnv;
@@ -537,6 +661,10 @@
           }
           // pkgs.lib.optionalAttrs (!isDarwin) {
             hwi-upstream-suite = mkApp hwiUpstreamSuite;
+            hwi-upstream-bitbox = mkApp hwiUpstreamBitbox;
+            hwi-upstream-coldcard = mkApp hwiUpstreamColdcard;
+            hwi-upstream-ledger = mkApp hwiUpstreamLedger;
+            hwi-upstream-jade = mkApp hwiUpstreamJade;
             hwi-parity-bitbox = mkApp hwiParityBitbox;
             hwi-parity-coldcard = mkApp hwiParityColdcard;
             hwi-parity-ledger = mkApp hwiParityLedger;
@@ -570,6 +698,8 @@
             test -f ${./nix/scripts/start-jade-pinserver.sh}
             test -f ${./nix/scripts/init-jade.sh}
             test -f ${./nix/scripts/emit-gh-error-log.sh}
+            test -f ${./nix/scripts/run-hwi-upstream-suite.sh}
+            test -f ${./nix/scripts/stop-emulator.sh}
             touch $out
           '';
         };
@@ -593,6 +723,10 @@
           }
           // pkgs.lib.optionalAttrs (!isDarwin) {
             hwi-upstream-suite = hwiUpstreamSuite;
+            hwi-upstream-bitbox = hwiUpstreamBitbox;
+            hwi-upstream-coldcard = hwiUpstreamColdcard;
+            hwi-upstream-ledger = hwiUpstreamLedger;
+            hwi-upstream-jade = hwiUpstreamJade;
           }
           // linuxPackages;
 

--- a/nix/scripts/run-hwi-upstream-suite.sh
+++ b/nix/scripts/run-hwi-upstream-suite.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-usage: run-hwi-upstream-suite.sh <ledger|coldcard|jade> [extra run_tests.py args...]
+usage: run-hwi-upstream-suite.sh <bitbox02|coldcard|ledger|jade> [extra run_tests.py args...]
 
 Required:
   HWI_BIN                     Path to the BHWI hwi binary under test.
@@ -11,8 +11,9 @@ Required:
 Optional device inputs:
   HWI_LEDGER_APP_ELF          Prebuilt Ledger Bitcoin app ELF.
   HWI_LEDGER_SPECULOS_BIN     Speculos executable. Defaults to SPECULOS_BIN or speculos.
-  HWI_COLDCARD_SIMULATOR      Path to Coldcard simulator.py.
-  HWI_JADE_SIMULATOR_DIR      Directory containing HWI-compatible Jade simulator files.
+  HWI_COLDCARD_SIMULATOR      Prepared Coldcard simulator.py (otherwise uses its prepare script).
+  HWI_JADE_SIMULATOR_DIR      Prepared HWI-compatible Jade directory.
+  HWI_BITBOX02_SIMULATOR      BitBox02 simulator binary.
   HWI_BITCOIND                Path to bitcoind. Defaults to bitcoind on PATH.
 
 The runner executes Bitcoin Core HWI's upstream test suite in --interface=cli
@@ -59,8 +60,17 @@ export PYTHONPATH="$work/HWI${PYTHONPATH:+:$PYTHONPATH}"
 
 bitcoind="${HWI_BITCOIND:-bitcoind}"
 common_args=(--device-only --interface=cli --bitcoind "$bitcoind")
+python="${HWI_PYTHON:?HWI_PYTHON must point to the pinned HWI Python interpreter}"
+cd "$work/HWI/test"
 
 case "$device" in
+  bitbox02)
+    simulator="${HWI_BITBOX02_SIMULATOR:?HWI_BITBOX02_SIMULATOR must point to the BitBox02 simulator}"
+    bitbox_dir="$work/bitbox02-compat"
+    mkdir -p "$bitbox_dir"
+    ln -s "$simulator" "$bitbox_dir/bitbox02-simulator"
+    "$python" run_tests.py "${common_args[@]}" --bitbox02 --bitbox02-path "$bitbox_dir/bitbox02-simulator" "$@"
+    ;;
   ledger)
     ledger_dir="$work/ledger-compat"
     mkdir -p "$ledger_dir/apps"
@@ -68,36 +78,63 @@ case "$device" in
     if [[ -z "$app_elf" ]]; then
       app_elf="$(bash "${LEDGER_BUILD_APP_SCRIPT:?LEDGER_BUILD_APP_SCRIPT must be set or HWI_LEDGER_APP_ELF provided}")"
     fi
-    ln -s "$app_elf" "$ledger_dir/apps/btc-test.elf"
+    cp "$app_elf" "$ledger_dir/apps/btc-test.elf"
+    cp "$work/HWI/test/data/speculos-automation.json" "$ledger_dir/apps/speculos-automation.json"
     cat > "$ledger_dir/speculos.py" <<'PY'
 import os
+import signal
+import subprocess
 import sys
 
 args = sys.argv[1:]
 if not args:
     raise SystemExit("missing Speculos arguments")
-app = args[-1]
+app = os.path.abspath(args[-1])
 speculos_args = args[:-1]
+for index, arg in enumerate(speculos_args):
+    if arg.startswith("file:"):
+        speculos_args[index] = "file:/app/speculos-automation.json"
 speculos = os.environ.get("HWI_LEDGER_SPECULOS_BIN") or os.environ.get("SPECULOS_BIN") or "speculos"
-os.execvp(speculos, [speculos, app] + speculos_args)
+process = subprocess.Popen([speculos, app] + speculos_args, start_new_session=True)
+
+def stop_speculos(_signum, _frame):
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGINT)
+
+signal.signal(signal.SIGTERM, stop_speculos)
+signal.signal(signal.SIGINT, stop_speculos)
+raise SystemExit(process.wait())
 PY
-    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --ledger --ledger-path "$ledger_dir/speculos.py" "$@"
+    "$python" run_tests.py "${common_args[@]}" --ledger --ledger-path "$ledger_dir/speculos.py" "$@"
     ;;
   coldcard)
     simulator="${HWI_COLDCARD_SIMULATOR:-}"
     if [[ -z "$simulator" ]]; then
-      echo "HWI_COLDCARD_SIMULATOR must point to Coldcard simulator.py" >&2
-      exit 2
+      simulator="$(bash \
+        "${HWI_COLDCARD_PREPARE_SCRIPT:?HWI_COLDCARD_PREPARE_SCRIPT must be set}" \
+        --prepare-hwi \
+        "$work/HWI/test/data/coldcard-multisig.patch" |
+        tail -n 1)"
     fi
-    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --coldcard --coldcard-path "$simulator" "$@"
+    coldcard_python="$(dirname "$simulator")/../ENV/bin/python3"
+    mkdir -p "$work/coldcard-bin"
+    export HWI_COLDCARD_PYTHON="$coldcard_python"
+    cat > "$work/coldcard-bin/python3" <<'SH'
+#!/usr/bin/env bash
+export LD_LIBRARY_PATH="${COLDCARD_RUNTIME_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$HWI_COLDCARD_PYTHON" "$@"
+SH
+    chmod +x "$work/coldcard-bin/python3"
+    PATH="$work/coldcard-bin:$PATH" \
+      "$python" run_tests.py "${common_args[@]}" --coldcard --coldcard-path "$simulator" "$@"
     ;;
   jade)
     simulator_dir="${HWI_JADE_SIMULATOR_DIR:-}"
     if [[ -z "$simulator_dir" ]]; then
-      echo "HWI_JADE_SIMULATOR_DIR must point to an HWI-compatible Jade simulator directory" >&2
-      exit 2
+      simulator_dir="$work/jade-compat"
+      bash "${HWI_JADE_PREPARE_SCRIPT:?HWI_JADE_PREPARE_SCRIPT must be set}" --prepare-hwi "$simulator_dir"
     fi
-    python3 "$work/HWI/test/run_tests.py" "${common_args[@]}" --jade --jade-path "$simulator_dir" "$@"
+    "$python" run_tests.py "${common_args[@]}" --jade --jade-path "$simulator_dir" "$@"
     ;;
   *)
     echo "unsupported upstream HWI suite device: $device" >&2

--- a/nix/scripts/start-coldcard.sh
+++ b/nix/scripts/start-coldcard.sh
@@ -5,10 +5,26 @@ cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/coldcard"
 src="${COLDCARD_FIRMWARE_SRC:?COLDCARD_FIRMWARE_SRC must point to Coldcard firmware source}"
 rev="${COLDCARD_FIRMWARE_REV:-$(basename "$src")}"
 src_key="${rev//[^A-Za-z0-9_.-]/_}"
-work="$cache_root/firmware-$src_key"
+prepare_hwi_patch=""
+if [[ "${1:-}" == "--prepare-hwi" ]]; then
+  prepare_hwi_patch="${2:?--prepare-hwi requires the upstream compatibility patch}"
+  shift 2
+fi
+if [[ $# -ne 0 ]]; then
+  echo "usage: start-coldcard.sh [--prepare-hwi PATCH]" >&2
+  exit 2
+fi
+
+work_suffix=""
+build_variant="unpatched-mk5-v1"
+if [[ -n "$prepare_hwi_patch" ]]; then
+  work_suffix="-hwi"
+  build_variant="hwi-v2-$(sha256sum "$prepare_hwi_patch" | cut -d' ' -f1)"
+fi
+work="$cache_root/firmware-$src_key$work_suffix"
 marker="$work/.bhwi-built"
 build_key_file="$work/.bhwi-build-key"
-build_key="rev=$rev simulator=unpatched-mk5-v1"
+build_key="rev=$rev simulator=$build_variant"
 socket="${COLDCARD_SOCKET:-/tmp/ckcc-simulator.sock}"
 
 dump_build_logs() {
@@ -26,7 +42,7 @@ dump_build_logs() {
 }
 trap dump_build_logs ERR
 
-if [[ -S "$socket" ]]; then
+if [[ -z "$prepare_hwi_patch" && -S "$socket" ]]; then
   echo "Coldcard socket already exists: $socket" >&2
   echo "Stop the existing simulator or remove the stale socket before starting a new one." >&2
   exit 1
@@ -52,6 +68,9 @@ if [[ ! -f "$marker" || ! -f "$build_key_file" || "$(cat "$build_key_file")" != 
   chmod -R u+w "$work"
 
   cd "$work"
+  if [[ -n "$prepare_hwi_patch" ]]; then
+    git apply "$prepare_hwi_patch"
+  fi
   # Upstream ships OS-specific micropython patches (clang vs gcc warning flags).
   if [[ "$(uname)" == "Darwin" && -f macos-mpy.patch ]]; then
     (cd external/micropython && git apply ../../macos-mpy.patch)
@@ -78,6 +97,11 @@ if [[ ! -f "$marker" || ! -f "$build_key_file" || "$(cat "$build_key_file")" != 
   make -C unix PWD="$work/unix" PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}" CFLAGS_EXTRA="$mpy_cflags_extra"
   printf '%s\n' "$build_key" > "$build_key_file"
   touch "$marker"
+fi
+
+if [[ -n "$prepare_hwi_patch" ]]; then
+  printf '%s\n' "$work/unix/simulator.py"
+  exit 0
 fi
 
 cd "$work/unix"

--- a/nix/scripts/start-jade.sh
+++ b/nix/scripts/start-jade.sh
@@ -8,6 +8,15 @@ src_key="${rev//[^A-Za-z0-9_.-]/_}"
 work="$cache_root/source-$src_key"
 flash="$cache_root/flash-image-$src_key.bin"
 marker="$cache_root/.flash-built-$src_key"
+prepare_hwi_dir=""
+if [[ "${1:-}" == "--prepare-hwi" ]]; then
+  prepare_hwi_dir="${2:?--prepare-hwi requires an output directory}"
+  shift 2
+fi
+if [[ $# -ne 0 ]]; then
+  echo "usage: start-jade.sh [--prepare-hwi OUTPUT_DIR]" >&2
+  exit 2
+fi
 
 mkdir -p "$cache_root"
 
@@ -48,6 +57,23 @@ if [[ ! -f "$flash" || ! -f "$marker" ]]; then
   touch "$marker"
 elif [[ ! -d "$work" ]]; then
   prepare_source
+fi
+
+if [[ -n "$prepare_hwi_dir" ]]; then
+  mkdir -p "$prepare_hwi_dir"
+  cp "$flash" "$prepare_hwi_dir/flash_image.bin"
+  cp "$work/main/qemu/qemu_efuse.bin" "$prepare_hwi_dir/qemu_efuse.bin"
+  ln -s "$(command -v qemu-system-xtensa)" "$prepare_hwi_dir/qemu-system-xtensa"
+  qemu_dir="$(dirname "$(command -v qemu-system-xtensa)")"
+  if [[ -d "$qemu_dir/../share/qemu" ]]; then
+    ln -s "$qemu_dir/../share/qemu" "$prepare_hwi_dir/pc-bios"
+  elif [[ -d "${QEMU_PC_BIOS_DIR:-}" ]]; then
+    ln -s "$QEMU_PC_BIOS_DIR" "$prepare_hwi_dir/pc-bios"
+  else
+    echo "unable to locate QEMU pc-bios directory" >&2
+    exit 1
+  fi
+  exit 0
 fi
 
 exec qemu-system-xtensa \

--- a/nix/scripts/stop-emulator.sh
+++ b/nix/scripts/stop-emulator.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: stop-emulator.sh PID_FILE [tcp HOST PORT|socket PATH] [TIMEOUT_SECONDS]" >&2
+  exit 2
+fi
+
+pid_file="$1"
+shift
+endpoint_type="${1:-}"
+timeout_seconds=30
+
+case "$endpoint_type" in
+  tcp)
+    host="${2:?tcp endpoint requires HOST}"
+    port="${3:?tcp endpoint requires PORT}"
+    timeout_seconds="${4:-30}"
+    ;;
+  socket)
+    socket="${2:?socket endpoint requires PATH}"
+    timeout_seconds="${3:-30}"
+    ;;
+  "")
+    ;;
+  *)
+    echo "unknown endpoint type: $endpoint_type" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -f "$pid_file" ]]; then
+  pid="$(cat "$pid_file")"
+  kill_target="$pid"
+  process_group="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  if [[ "$process_group" == "$pid" ]]; then
+    kill_target="-$pid"
+  fi
+  if kill -0 -- "$kill_target" 2>/dev/null; then
+    kill -- "$kill_target" 2>/dev/null || true
+    deadline=$((SECONDS + timeout_seconds))
+    while kill -0 -- "$kill_target" 2>/dev/null && ((SECONDS < deadline)); do
+      sleep 1
+    done
+    if kill -0 -- "$kill_target" 2>/dev/null; then
+      kill -KILL -- "$kill_target" 2>/dev/null || true
+    fi
+  fi
+fi
+
+deadline=$((SECONDS + timeout_seconds))
+case "$endpoint_type" in
+  tcp)
+    while (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null; do
+      if ((SECONDS >= deadline)); then
+        echo "TCP endpoint still open after stopping emulator: $host:$port" >&2
+        exit 1
+      fi
+      sleep 1
+    done
+    ;;
+  socket)
+    while [[ -S "$socket" ]]; do
+      if ((SECONDS >= deadline)); then
+        rm -f "$socket"
+        break
+      fi
+      sleep 1
+    done
+    ;;
+esac

--- a/nix/speculos.nix
+++ b/nix/speculos.nix
@@ -41,14 +41,44 @@ writeShellApplication {
     fi
 
     if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-      exec docker run --rm "''${net_args[@]}" -v "$elf_dir:/app:ro" "$image" \
-        speculos "/app/$elf_name" "$@"
+      container_runtime="docker"
+      elf_mount="$elf_dir:/app:ro"
     elif command -v podman >/dev/null 2>&1; then
-      exec podman run --rm "''${net_args[@]}" -v "$elf_dir:/app:ro,Z" "$image" \
-        speculos "/app/$elf_name" "$@"
+      container_runtime="podman"
+      elf_mount="$elf_dir:/app:ro,Z"
     else
       echo "Neither docker nor podman is available for Speculos" >&2
       exit 1
     fi
+
+    container_state_dir="$(mktemp -d)"
+    container_cidfile="$container_state_dir/container.cid"
+
+    # Invoked indirectly by the EXIT trap below.
+    # shellcheck disable=SC2329
+    cleanup_container() {
+      if [ -s "$container_cidfile" ]; then
+        "$container_runtime" rm --force "$(cat "$container_cidfile")" >/dev/null 2>&1 || true
+      fi
+      rm -f "$container_cidfile"
+      rmdir "$container_state_dir" 2>/dev/null || true
+    }
+
+    # Stopping the container client alone can leave the container and its host
+    # network listeners running. Keep this wrapper alive to own that lifecycle.
+    trap cleanup_container EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    "$container_runtime" run --rm --cidfile "$container_cidfile" "''${net_args[@]}" \
+      -v "$elf_mount" "$image" speculos "/app/$elf_name" "$@" &
+    container_client_pid=$!
+
+    set +e
+    wait "$container_client_pid"
+    status=$?
+    set -e
+    exit "$status"
   '';
 }


### PR DESCRIPTION
## Summary

- complete the Python HWI-compatible CLI surface for discovery, xpubs, descriptors, keypools, signing, address display, backups, and unsupported management actions
- align BitBox02, Coldcard, Ledger, and Jade behavior with the pinned upstream HWI 3.2.0 suite, including multisig display/registration flows and Ledger non-standard xpub fallback
- add per-device `hwi-upstream-*` Nix apps and make the unmodified upstream HWI suite the final emulator CI gate
- pin the Ledger Bitcoin app version used by upstream HWI and add deterministic emulator teardown helpers
- document the parity contract, gate commands, lifecycle, and remaining device-management gaps

## API and CLI impact

- adds the `hwi` compatibility binary and HWI-compatible command/output handling
- models wallet registration as complete, optionally with an HMAC, or pending user confirmation
- adds device protocol support needed by the upstream suites without moving transport or runtime concerns into the core interpreters

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
- `cargo test --verbose --no-default-features`
- `cargo test --verbose --color always -- --nocapture`
- `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
- `nix run .#hwi-upstream-bitbox`: 15 tests, OK, 1 upstream-authored skip
- `nix run .#hwi-upstream-coldcard`: 28 tests, OK, 10 upstream-authored skips
- `nix run .#hwi-upstream-ledger`: 22 tests, OK, 6 upstream-authored skips
- `nix run .#hwi-upstream-jade`: 28 tests, OK, 1 upstream-authored skip

The suite itself is not patched or locally skipped; all reported skips come from upstream HWI device capability/temporary-disable annotations.