### PR TITLE
feat(nix): build and run the device emulators on macOS / arm64 for nix e2e

### DIFF
--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -3,8 +3,33 @@
 BHWI uses Nix flake outputs to run emulator-backed e2e tests for the currently
 supported devices: Coldcard, Ledger, and Jade.
 
-The emulator outputs are Linux-only and intended for GitHub Actions first, with
-the same commands available locally.
+The emulator outputs build on `x86_64-linux` and `aarch64-darwin` (Apple
+Silicon), and are intended for GitHub Actions first, with the same commands
+available locally.
+
+## Platforms
+
+The `nix run` and `nix develop` commands below are identical on every platform.
+
+On macOS the device simulators have no prebuilt binaries, so they build from
+source on first run under `$XDG_CACHE_HOME/bhwi`:
+
+- Coldcard and Jade build natively.
+- BitBox02 builds from source with `make simulator`. Linux keeps the prebuilt
+  release binary.
+- Ledger runs the `arm64` variant of the multi-arch app-builder container
+  natively and publishes ports, because Docker Desktop and OrbStack on macOS do
+  not support `--network host`.
+
+Linux-only outputs:
+
+- `bitbox02-simulator` (the prebuilt release binary).
+- The HWI parity and upstream suites (`hwi-parity-*`, `hwi-upstream-*`), which
+  need the linux-amd64 prebuilt simulator and a toolchain that does not build on
+  darwin.
+
+The macOS emulator run is not part of PR CI and is intended for a separate
+on-demand workflow.
 
 ## CI
 
@@ -158,8 +183,9 @@ upstream suite, and `HWI_LEDGER_APP_ELF` to use a prebuilt Ledger app.
 
 BitBox02:
 
-- Downloads a pinned `BitBoxSwiss/bitbox02-firmware` multi-edition simulator
-  release binary (autopatched to run on NixOS).
+- On Linux, downloads a pinned `BitBoxSwiss/bitbox02-firmware` multi-edition
+  simulator release binary (autopatched to run on NixOS). On macOS, builds that
+  same pinned firmware from source with `make simulator`.
 - Starts the simulator on TCP `localhost:15423`.
 - The simulator auto-confirms Noise pairing and restores a fixed mnemonic when
   the package e2e seeds it.
@@ -167,7 +193,8 @@ BitBox02:
 Coldcard:
 
 - Uses pinned `Coldcard/firmware`.
-- Builds the Unix simulator in `$XDG_CACHE_HOME/bhwi/coldcard`.
+- Builds the Unix simulator in `$XDG_CACHE_HOME/bhwi/coldcard`. On macOS applies
+  the upstream `macos-mpy.patch` and links against `DYLD_LIBRARY_PATH`.
 - Starts `simulator.py --headless`.
 - Exposes `/tmp/ckcc-simulator.sock`.
 
@@ -177,7 +204,8 @@ Ledger:
 - Builds the Nano X Bitcoin app ELF through Ledger's app-builder container and
   caches it under `$XDG_CACHE_HOME/bhwi/ledger`.
 - Starts Speculos through Ledger's app-builder container on APDU
-  `localhost:9999` and API `localhost:5000`.
+  `localhost:9999` and API `localhost:5000`. On macOS the container runs as its
+  native `arm64` variant with published ports instead of `--network host`.
 - `LEDGER_APP_ELF=/path/to/app.elf` can override the cached build.
 
 Jade:
@@ -195,6 +223,7 @@ Jade:
 
 - Emulator tests must run serially. Pass `-- --test-threads=1`; this is not set
   in `.cargo/config.toml`.
-- Emulator outputs are restricted to `x86_64-linux`.
+- Emulator outputs build on `x86_64-linux` and `aarch64-darwin`. See Platforms
+  for the macOS specifics and the Linux-only outputs.
 - The first CI run for a changed emulator source may be slow. Follow-up runs
   should hit Magic Nix Cache and the `$XDG_CACHE_HOME/bhwi` artifact cache.

--- a/flake.nix
+++ b/flake.nix
@@ -427,11 +427,41 @@
             install -m755 $src $out/bin/bitbox02-simulator
           '';
         };
+        bitboxBuildInputs = [
+          pkgs.cmake
+          pkgs.protobuf
+          pkgs.python3Packages.mypy-protobuf
+          pkgs.clang
+          pkgs.hidapi
+          pkgs.libusb1
+          pkgs.libiconv
+          pkgs.rust-cbindgen
+          pkgs.rust-bindgen
+          pkgs.rustup
+          pkgs.go
+          pkgs.gnused
+          pkgs.gnumake
+          pkgs.git
+          pkgs.pkg-config
+          pkgs.coreutils
+        ];
         bitboxRunner =
-          mkRunner "bhwi-start-bitbox" [pkgs.coreutils] ''
-            export BITBOX_SIMULATOR_BIN="${bitboxSimulator}/bin/bitbox02-simulator"
-          ''
-          ./nix/scripts/start-bitbox.sh;
+          if isDarwin
+          then
+            mkRunner "bhwi-start-bitbox" bitboxBuildInputs ''
+              export BITBOX_BUILD_SCRIPT="${./nix/scripts/build-bitbox-sim.sh}"
+              export BITBOX_FIRMWARE_URL="https://github.com/BitBoxSwiss/bitbox02-firmware.git"
+              export BITBOX_FIRMWARE_REV="firmware/v${bitboxSimulatorVersion}"
+              export PKG_CONFIG_PATH="${pkgs.hidapi}/lib/pkgconfig:${pkgs.libusb1.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
+              export LIBRARY_PATH="${pkgs.libiconv}/lib:''${LIBRARY_PATH:-}"
+              export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
+            ''
+            ./nix/scripts/start-bitbox.sh
+          else
+            mkRunner "bhwi-start-bitbox" [pkgs.coreutils] ''
+              export BITBOX_SIMULATOR_BIN="${bitboxSimulator}/bin/bitbox02-simulator"
+            ''
+            ./nix/scripts/start-bitbox.sh;
         hwiReference = pkgs.writeShellApplication {
           name = "hwi-reference";
           runtimeInputs = [hwiPython];

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,21 @@
           ];
         };
         coldcardPkgs = import nixpkgs-coldcard {inherit system;};
-        emulatorSystem = system == "x86_64-linux";
+        emulatorSystem = system == "x86_64-linux" || system == "aarch64-linux" || system == "aarch64-darwin";
+        isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+        coldcardRuntimeLibraryPath = coldcardPkgs.lib.makeLibraryPath (
+          [
+            coldcardPkgs.SDL2
+            coldcardPkgs.libffi
+            coldcardPkgs.openssl.out
+            coldcardPkgs.pcsclite
+          ]
+          ++ coldcardPkgs.lib.optionals (!isDarwin) [
+            coldcardPkgs.gcc13.cc.lib
+            coldcardPkgs.glibc
+            coldcardPkgs.systemd
+          ]
+        );
         espPkgs = import nixpkgs-esp-dev.inputs.nixpkgs {
           inherit system;
           overlays = [nixpkgs-esp-dev.overlays.default];
@@ -176,47 +190,52 @@
           pkgs.corepack_20
           pkgs.nodejs_20
         ];
-        emulatorInputs = [
-          pkgs.bash
-          pkgs.cacert
-          pkgs.coreutils
-          pkgs.curl
-          pkgs.git
-          pkgs.gnumake
-          pkgs.gnused
-          pkgs.netcat-openbsd
-          pkgs.openssl
-          pkgs.pkg-config
-          pkgs.procps
-          pkgs.python3
-          pkgs.which
-        ];
-        coldcardEmulatorInputs = [
-          coldcardPkgs.bash
-          coldcardPkgs.cacert
-          coldcardPkgs.coreutils
-          coldcardPkgs.curl
-          coldcardPkgs.gawk
-          coldcardPkgs.git
-          coldcardPkgs.gnumake
-          coldcardPkgs.gnugrep
-          coldcardPkgs.gnused
-          coldcardPkgs.netcat-openbsd
-          coldcardPkgs.openssl
-          coldcardPkgs.pkg-config
-          coldcardPkgs.procps
-          coldcardPkgs.python312
-          coldcardPkgs.which
-        ];
+        emulatorInputs =
+          [
+            pkgs.bash
+            pkgs.cacert
+            pkgs.coreutils
+            pkgs.curl
+            pkgs.git
+            pkgs.gnumake
+            pkgs.gnused
+            pkgs.openssl
+            pkgs.pkg-config
+            pkgs.python3
+            pkgs.which
+          ]
+          ++ (
+            if isDarwin
+            then [pkgs.netcat-gnu]
+            else [pkgs.netcat-openbsd pkgs.procps]
+          );
+        coldcardEmulatorInputs =
+          [
+            coldcardPkgs.bash
+            coldcardPkgs.cacert
+            coldcardPkgs.coreutils
+            coldcardPkgs.curl
+            coldcardPkgs.gawk
+            coldcardPkgs.git
+            coldcardPkgs.gnumake
+            coldcardPkgs.gnugrep
+            coldcardPkgs.gnused
+            coldcardPkgs.openssl
+            coldcardPkgs.pkg-config
+            coldcardPkgs.python312
+            coldcardPkgs.which
+          ]
+          ++ (
+            if isDarwin
+            then [coldcardPkgs.netcat-gnu]
+            else [coldcardPkgs.netcat-openbsd coldcardPkgs.procps]
+          );
         coldcardInputs =
           coldcardEmulatorInputs
           ++ [
             coldcardPkgs.autoconf
             coldcardPkgs.automake
-            coldcardPkgs.binutils
-            coldcardPkgs.gcc13
             coldcardPkgs.gcc-arm-embedded
-            coldcardPkgs.glibc.bin
             coldcardPkgs.libffi
             coldcardPkgs.libtool
             coldcardPkgs.m4

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           ];
         };
         coldcardPkgs = import nixpkgs-coldcard {inherit system;};
-        emulatorSystem = system == "x86_64-linux" || system == "aarch64-linux" || system == "aarch64-darwin";
+        emulatorSystem = system == "x86_64-linux" || system == "aarch64-darwin";
         isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
         coldcardRuntimeLibraryPath = coldcardPkgs.lib.makeLibraryPath (
           [

--- a/flake.nix
+++ b/flake.nix
@@ -512,26 +512,35 @@
         hwiParityColdcard = mkHwiParityRunner "bhwi-hwi-parity-coldcard" "coldcard" (coldcardInputs ++ inputs) coldcardE2eEnv;
         hwiParityLedger = mkHwiParityRunner "bhwi-hwi-parity-ledger" "ledger" (ledgerInputs ++ inputs) commonE2eEnv;
         hwiParityJade = mkHwiParityRunner "bhwi-hwi-parity-jade" "jade" (jadeInputs ++ inputs) commonE2eEnv;
-        linuxPackages = pkgs.lib.optionalAttrs emulatorSystem {
-          inherit speculos bitboxSimulator;
-          bitbox02-simulator = bitboxSimulator;
-          coldcard-simulator = coldcardRunner;
-          ledger-app = ledgerAppBuilder;
-          jade-qemu = jadeRunner;
-        };
-        linuxApps = pkgs.lib.optionalAttrs emulatorSystem {
-          bitbox = mkApp bitboxRunner;
-          coldcard = mkApp coldcardRunner;
-          ledger = mkApp ledgerRunner;
-          ledger-build-app = mkApp ledgerAppBuilder;
-          hwi-upstream-suite = mkApp hwiUpstreamSuite;
-          hwi-parity-coldcard = mkApp hwiParityColdcard;
-          hwi-parity-ledger = mkApp hwiParityLedger;
-          hwi-parity-jade = mkApp hwiParityJade;
-          jade = mkApp jadeRunner;
-          jade-init = mkApp jadeInitRunner;
-          jade-pinserver = mkApp jadePinserverRunner;
-        };
+        linuxPackages = pkgs.lib.optionalAttrs emulatorSystem (
+          {
+            inherit speculos;
+            coldcard-simulator = coldcardRunner;
+            ledger-app = ledgerAppBuilder;
+            jade-qemu = jadeRunner;
+          }
+          // pkgs.lib.optionalAttrs (!isDarwin) {
+            inherit bitboxSimulator;
+            bitbox02-simulator = bitboxSimulator;
+          }
+        );
+        linuxApps = pkgs.lib.optionalAttrs emulatorSystem (
+          {
+            bitbox = mkApp bitboxRunner;
+            coldcard = mkApp coldcardRunner;
+            ledger = mkApp ledgerRunner;
+            ledger-build-app = mkApp ledgerAppBuilder;
+            jade = mkApp jadeRunner;
+            jade-init = mkApp jadeInitRunner;
+            jade-pinserver = mkApp jadePinserverRunner;
+          }
+          // pkgs.lib.optionalAttrs (!isDarwin) {
+            hwi-upstream-suite = mkApp hwiUpstreamSuite;
+            hwi-parity-coldcard = mkApp hwiParityColdcard;
+            hwi-parity-ledger = mkApp hwiParityLedger;
+            hwi-parity-jade = mkApp hwiParityJade;
+          }
+        );
         linuxShells = pkgs.lib.optionalAttrs emulatorSystem {
           bitbox = pkgs.mkShell {
             packages = inputs;
@@ -567,7 +576,6 @@
           {
             hwi-reference = hwiReference;
             hwi-reference-bhwi = hwiReferenceBhwi;
-            hwi-upstream-suite = hwiUpstreamSuite;
             default = pkgs.rustPlatform.buildRustPackage {
               name = "bhwi";
               src = ./.;
@@ -580,6 +588,9 @@
             };
             website = mkWebsite {};
             website-ghpages = mkWebsite {base = "/bhwi/";};
+          }
+          // pkgs.lib.optionalAttrs (!isDarwin) {
+            hwi-upstream-suite = hwiUpstreamSuite;
           }
           // linuxPackages;
 

--- a/flake.nix
+++ b/flake.nix
@@ -243,9 +243,18 @@
             coldcardPkgs.python312Packages.virtualenv
             coldcardPkgs.SDL2
             coldcardPkgs.swig
-            coldcardPkgs.systemd
-            coldcardPkgs.xterm
-          ];
+          ]
+          ++ (
+            if isDarwin
+            then [coldcardPkgs.clang]
+            else [
+              coldcardPkgs.binutils
+              coldcardPkgs.gcc13
+              coldcardPkgs.glibc.bin
+              coldcardPkgs.systemd
+              coldcardPkgs.xterm
+            ]
+          );
         speculos = pkgs.callPackage ./nix/speculos.nix {};
         ledgerInputs =
           emulatorInputs
@@ -290,15 +299,7 @@
         '';
         coldcardE2eEnv = ''
           export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-          export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
-            coldcardPkgs.SDL2
-            coldcardPkgs.gcc13.cc.lib
-            coldcardPkgs.glibc
-            coldcardPkgs.libffi
-            coldcardPkgs.openssl.out
-            coldcardPkgs.pcsclite
-            coldcardPkgs.systemd
-          ]}"
+          export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardRuntimeLibraryPath}"
           export LD_LIBRARY_PATH=${pkgs.openssl}/lib:''${LD_LIBRARY_PATH:-}
           export ACLOCAL_PATH="${coldcardPkgs.libtool}/share/aclocal:''${ACLOCAL_PATH:-}"
           export PKG_CONFIG_PATH="${coldcardPkgs.libffi.dev}/lib/pkgconfig:''${PKG_CONFIG_PATH:-}"
@@ -342,15 +343,7 @@
             unset LIBRARY_PATH
             unset OBJC_INCLUDE_PATH
             unset OBJCPLUS_INCLUDE_PATH
-            export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardPkgs.lib.makeLibraryPath [
-              coldcardPkgs.SDL2
-              coldcardPkgs.gcc13.cc.lib
-              coldcardPkgs.glibc
-              coldcardPkgs.libffi
-              coldcardPkgs.openssl.out
-              coldcardPkgs.pcsclite
-              coldcardPkgs.systemd
-            ]}"
+            export COLDCARD_RUNTIME_LIBRARY_PATH="${coldcardRuntimeLibraryPath}"
             export COLDCARD_FIRMWARE_SRC="${coldcard-firmware}"
             export COLDCARD_FIRMWARE_REV="${coldcard-firmware.rev or "locked"}"
             export COLDCARD_FIRMWARE_URL="https://github.com/Coldcard/firmware.git"

--- a/nix/scripts/build-bitbox-sim.sh
+++ b/nix/scripts/build-bitbox-sim.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/bhwi/bitbox"
+rev="${BITBOX_FIRMWARE_REV:?BITBOX_FIRMWARE_REV must be set (e.g. firmware/v9.26.4)}"
+url="${BITBOX_FIRMWARE_URL:-https://github.com/BitBoxSwiss/bitbox02-firmware.git}"
+src_key="${rev//[^A-Za-z0-9_.-]/_}"
+work="$cache_root/firmware-$src_key"
+marker="$work/.bhwi-built"
+build_key_file="$work/.bhwi-build-key"
+build_key="rev=$rev url=$url simulator=v1"
+sim="$work/build-build-noasan/bin/simulator"
+
+mkdir -p "$cache_root"
+
+if [[ ! -f "$marker" || ! -x "$sim" || ! -f "$build_key_file" || "$(cat "$build_key_file")" != "$build_key" ]]; then
+  echo "Building BitBox02 simulator in $work" >&2
+  rm -rf "$work"
+  # Full clone: generate_version_headers.py resolves the version via git describe over the bootloader/* and firmware/* tags.
+  git clone --recursive "$url" "$work" >&2
+  git -C "$work" checkout "$rev" >&2
+  git -C "$work" submodule update --init --recursive >&2
+  chmod -R u+w "$work"
+
+  # -Zbuild-std needs rust-src and the embedded targets on the firmware's pinned toolchain.
+  toolchain="$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' "$work/src/rust/rust-toolchain.toml")"
+  rustup toolchain install "$toolchain" --profile minimal -c rust-src \
+    -t thumbv7em-none-eabi -t thumbv8m.main-none-eabihf >&2
+
+  make -C "$work" simulator >&2
+  test -x "$sim"
+  printf '%s\n' "$build_key" > "$build_key_file"
+  touch "$marker"
+fi
+
+printf '%s\n' "$sim"

--- a/nix/scripts/start-bitbox.sh
+++ b/nix/scripts/start-bitbox.sh
@@ -6,6 +6,11 @@
 # release binary); when running outside nix, point it at a simulator binary yourself.
 set -euo pipefail
 
+# No prebuilt release binary on darwin/arm64: build the simulator from source.
+if [[ -z "${BITBOX_SIMULATOR_BIN:-}" && -n "${BITBOX_BUILD_SCRIPT:-}" ]]; then
+  BITBOX_SIMULATOR_BIN="$(bash "$BITBOX_BUILD_SCRIPT")"
+fi
+
 : "${BITBOX_SIMULATOR_BIN:?BITBOX_SIMULATOR_BIN must point to a BitBox02 simulator binary}"
 
 # Run in a scratch directory so any simulator state does not litter the working tree.

--- a/nix/scripts/start-coldcard.sh
+++ b/nix/scripts/start-coldcard.sh
@@ -52,7 +52,10 @@ if [[ ! -f "$marker" || ! -f "$build_key_file" || "$(cat "$build_key_file")" != 
   chmod -R u+w "$work"
 
   cd "$work"
-  if [[ -f ubuntu24_mpy.patch ]]; then
+  # Upstream ships OS-specific micropython patches (clang vs gcc warning flags).
+  if [[ "$(uname)" == "Darwin" && -f macos-mpy.patch ]]; then
+    (cd external/micropython && git apply ../../macos-mpy.patch)
+  elif [[ -f ubuntu24_mpy.patch ]]; then
     (cd external/micropython && git apply ../../ubuntu24_mpy.patch)
   fi
   mpy_cflags_extra="${MPY_CFLAGS_EXTRA:--Wno-error}"
@@ -79,6 +82,10 @@ fi
 
 cd "$work/unix"
 if [[ -n "${COLDCARD_RUNTIME_LIBRARY_PATH:-}" ]]; then
-  export LD_LIBRARY_PATH="$COLDCARD_RUNTIME_LIBRARY_PATH"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    export DYLD_LIBRARY_PATH="$COLDCARD_RUNTIME_LIBRARY_PATH"
+  else
+    export LD_LIBRARY_PATH="$COLDCARD_RUNTIME_LIBRARY_PATH"
+  fi
 fi
 exec ../ENV/bin/python3 simulator.py --headless

--- a/nix/speculos.nix
+++ b/nix/speculos.nix
@@ -32,11 +32,19 @@ writeShellApplication {
     elf_dir="$(cd "$(dirname "$elf")" && pwd)"
     elf_name="$(basename "$elf")"
 
+    apdu_port="''${LEDGER_APDU_PORT:-9999}"
+    api_port="''${LEDGER_API_PORT:-5000}"
+    if [ "$(uname)" = "Darwin" ]; then
+      net_args=(-p "$apdu_port:$apdu_port" -p "$api_port:$api_port")
+    else
+      net_args=(--network host)
+    fi
+
     if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-      exec docker run --rm --network host -v "$elf_dir:/app:ro" "$image" \
+      exec docker run --rm "''${net_args[@]}" -v "$elf_dir:/app:ro" "$image" \
         speculos "/app/$elf_name" "$@"
     elif command -v podman >/dev/null 2>&1; then
-      exec podman run --rm --network host -v "$elf_dir:/app:ro,Z" "$image" \
+      exec podman run --rm "''${net_args[@]}" -v "$elf_dir:/app:ro,Z" "$image" \
         speculos "/app/$elf_name" "$@"
     else
       echo "Neither docker nor podman is available for Speculos" >&2


### PR DESCRIPTION
Enable the four device emulators to build and run natively on aarch64-darwin (Apple Silicon), so the emulator e2e can run on a macOS runner. Addresses #61.

- Coldcard and Jade build from source natively. Coldcard applies upstream's macos-mpy.patch, drops Linux-only deps, and uses DYLD_LIBRARY_PATH.
- BitBox02 has no darwin simulator release, so it builds the sim from source with make simulator (macOS support landed in BitBoxSwiss/bitbox02-firmware#1435) behind a cached build-key. 
- Ledger runs the arm64 variant of the multi-arch ledger-app-dev-tools image natively with no --platform or Rosetta, and publishes ports because Docker Desktop and OrbStack on macOS have no --network host.

Darwin exposes the device emulators and their bhwi-e2e-* suites. The HWI parity and upstream acceptance suites stay Linux-only.