### PR TITLE
fix(bhwi-cli): skip macOS dial-in serial node when enumerating jade

### DIFF
--- a/bhwi-cli/src/jade.rs
+++ b/bhwi-cli/src/jade.rs
@@ -122,6 +122,13 @@ impl JadeDevice {
     }
 }
 
+// serialport-rs lists each macOS serial port under both its callout
+// (`/dev/cu.*`) and dial-in (`/dev/tty.*`) node & skip the dial-in so the same
+// Jade is not opened twice.
+fn is_macos_dialin(port_name: &str) -> bool {
+    port_name.starts_with("/dev/tty.")
+}
+
 #[async_trait(?Send)]
 impl DeviceEnumerator for JadeDevice {
     async fn enumerate(selector: &DeviceSelector) -> Result<Vec<Device>> {
@@ -130,6 +137,7 @@ impl DeviceEnumerator for JadeDevice {
                 match info.port_type {
                     SerialPortType::UsbPort(usb)
                         if selector.matches(DeviceType::Jade, &info.port_name)
+                            && !is_macos_dialin(&info.port_name)
                             && Self::valid_usb(&usb) =>
                     {
                         Self::serial_device(selector.network, &info.port_name, usb).await


### PR DESCRIPTION
On macOS a plugged in Jade was not detected. The serial library lists each port twice, as a cu node and a tty node that both point at the same Jade, so bhwi opened it twice and the second open failed with a busy error that aborted the scan. This skips the tty node and keeps the cu one. Tested on a real Jade.