### PR TITLE
feat(bitbox): add stateful management commands

### DIFF
--- a/.github/workflows/emulators.yml
+++ b/.github/workflows/emulators.yml
@@ -36,7 +36,7 @@ jobs:
   bitbox-e2e:
     needs: nix-flake
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
@@ -80,8 +80,48 @@ jobs:
             cat bitbox-hwi-parity.log || true
             exit 1
           }
-      - name: Stop BitBox simulator before upstream gate
+      - name: Stop shared BitBox simulator before management lifecycle
         run: bash nix/scripts/stop-emulator.sh bitbox.pid tcp localhost 15423 60
+      - name: Start fresh BitBox02 simulator for setup lifecycle
+        run: |
+          nix run .#bitbox > bitbox-setup.log 2>&1 &
+          echo $! > bitbox.pid
+          bash nix/scripts/wait-for-port.sh localhost 15423 600 "$(cat bitbox.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "BitBox setup lifecycle startup log" bitbox-setup.log
+            cat bitbox-setup.log || true
+            exit 1
+          }
+      - name: Run BitBox setup, toggle-passphrase, and wipe lifecycle
+        run: |
+          set -o pipefail
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#bitbox -c cargo test -p bhwi-e2e-cli bitbox::bitbox_setup_management_lifecycle -- --ignored --exact --test-threads=1 2>&1 | tee bitbox-management-setup.log || {
+            bash nix/scripts/emit-gh-error-log.sh "BitBox setup lifecycle log" bitbox-management-setup.log
+            cat bitbox-management-setup.log || true
+            exit 1
+          }
+      - name: Restart BitBox02 simulator after reset
+        run: |
+          bash nix/scripts/stop-emulator.sh bitbox.pid tcp localhost 15423 5
+          # The pinned simulator does not set SO_REUSEADDR; let the reset connection leave
+          # TIME_WAIT before binding its fixed port again.
+          sleep 65
+          nix run .#bitbox > bitbox-restore.log 2>&1 &
+          echo $! > bitbox.pid
+          bash nix/scripts/wait-for-port.sh localhost 15423 600 "$(cat bitbox.pid)" || {
+            bash nix/scripts/emit-gh-error-log.sh "BitBox restore lifecycle startup log" bitbox-restore.log
+            cat bitbox-restore.log || true
+            exit 1
+          }
+      - name: Run BitBox restore lifecycle
+        run: |
+          set -o pipefail
+          BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#bitbox -c cargo test -p bhwi-e2e-cli bitbox::bitbox_restore_management_lifecycle -- --ignored --exact --test-threads=1 2>&1 | tee bitbox-management-restore.log || {
+            bash nix/scripts/emit-gh-error-log.sh "BitBox restore lifecycle log" bitbox-management-restore.log
+            cat bitbox-management-restore.log || true
+            exit 1
+          }
+      - name: Stop BitBox simulator before upstream gate
+        run: bash nix/scripts/stop-emulator.sh bitbox.pid tcp localhost 15423 5
       - name: Run upstream HWI BitBox02 suite
         run: timeout 45m nix run .#hwi-upstream-bitbox
       - name: Stop BitBox simulator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,10 +301,10 @@ dependencies = [
  "bhwi",
  "bhwi-async",
  "bitcoin",
+ "chrono",
  "clap",
  "futures",
  "hex",
- "libc",
  "miniscript",
  "rand_core 0.6.4",
  "reqwest",
@@ -564,6 +573,17 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1288,6 +1308,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1715,15 @@ dependencies = [
  "sha2",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -12,6 +12,7 @@ pub use bhwi::common::DeviceBackup;
 pub use bhwi::common::DeviceContext;
 pub use bhwi::common::DisplayAddress;
 pub use bhwi::common::Info;
+pub use bhwi::common::RestoreOptions;
 pub use bhwi::common::SetupOptions;
 pub use bhwi::common::WalletRegistration;
 use bhwi::miniscript::descriptor::WalletPolicy;
@@ -58,6 +59,11 @@ pub trait HWI {
         context: Option<DeviceContext>,
     ) -> Result<bool, Self::Error>;
     async fn wipe_device(&mut self) -> Result<bool, Self::Error>;
+    async fn restore_device(
+        &mut self,
+        options: RestoreOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, Self::Error>;
     async fn unlock(&mut self, network: Network) -> Result<(), Self::Error>;
     async fn get_info(&mut self) -> Result<Info, Self::Error>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, Self::Error>;
@@ -100,6 +106,11 @@ pub trait HWIDevice {
         context: Option<DeviceContext>,
     ) -> Result<bool, HWIDeviceError>;
     async fn wipe_device(&mut self) -> Result<bool, HWIDeviceError>;
+    async fn restore_device(
+        &mut self,
+        options: RestoreOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, HWIDeviceError>;
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError>;
     async fn get_info(&mut self) -> Result<Info, HWIDeviceError>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, HWIDeviceError>;
@@ -185,6 +196,20 @@ where
     async fn wipe_device(&mut self) -> Result<bool, Self::Error> {
         if let common::Response::DeviceAction(success) =
             run_command_allowing_final_disconnect(self, common::Command::Wipe).await?
+        {
+            Ok(success)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
+
+    async fn restore_device(
+        &mut self,
+        options: RestoreOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, Self::Error> {
+        if let common::Response::DeviceAction(success) =
+            run_command(self, common::Command::Restore(options, context)).await?
         {
             Ok(success)
         } else {
@@ -333,6 +358,16 @@ where
 
     async fn wipe_device(&mut self) -> Result<bool, HWIDeviceError> {
         HWI::wipe_device(self).await.map_err(HWIDeviceError::new)
+    }
+
+    async fn restore_device(
+        &mut self,
+        options: RestoreOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, HWIDeviceError> {
+        HWI::restore_device(self, options, context)
+            .await
+            .map_err(HWIDeviceError::new)
     }
 
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError> {

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -64,6 +64,7 @@ pub trait HWI {
         options: RestoreOptions,
         context: Option<DeviceContext>,
     ) -> Result<bool, Self::Error>;
+    async fn toggle_passphrase(&mut self) -> Result<bool, Self::Error>;
     async fn unlock(&mut self, network: Network) -> Result<(), Self::Error>;
     async fn get_info(&mut self) -> Result<Info, Self::Error>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, Self::Error>;
@@ -111,6 +112,7 @@ pub trait HWIDevice {
         options: RestoreOptions,
         context: Option<DeviceContext>,
     ) -> Result<bool, HWIDeviceError>;
+    async fn toggle_passphrase(&mut self) -> Result<bool, HWIDeviceError>;
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError>;
     async fn get_info(&mut self) -> Result<Info, HWIDeviceError>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, HWIDeviceError>;
@@ -210,6 +212,16 @@ where
     ) -> Result<bool, Self::Error> {
         if let common::Response::DeviceAction(success) =
             run_command(self, common::Command::Restore(options, context)).await?
+        {
+            Ok(success)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
+
+    async fn toggle_passphrase(&mut self) -> Result<bool, Self::Error> {
+        if let common::Response::DeviceAction(success) =
+            run_command(self, common::Command::TogglePassphrase).await?
         {
             Ok(success)
         } else {
@@ -366,6 +378,12 @@ where
         context: Option<DeviceContext>,
     ) -> Result<bool, HWIDeviceError> {
         HWI::restore_device(self, options, context)
+            .await
+            .map_err(HWIDeviceError::new)
+    }
+
+    async fn toggle_passphrase(&mut self) -> Result<bool, HWIDeviceError> {
+        HWI::toggle_passphrase(self)
             .await
             .map_err(HWIDeviceError::new)
     }

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -12,6 +12,7 @@ pub use bhwi::common::DeviceBackup;
 pub use bhwi::common::DeviceContext;
 pub use bhwi::common::DisplayAddress;
 pub use bhwi::common::Info;
+pub use bhwi::common::SetupOptions;
 pub use bhwi::common::WalletRegistration;
 use bhwi::miniscript::descriptor::WalletPolicy;
 use bhwi::{
@@ -43,6 +44,11 @@ pub trait HttpClient {
 pub trait HWI {
     type Error: Debug;
     async fn backup_device(&mut self) -> Result<DeviceBackup, Self::Error>;
+    async fn setup_device(
+        &mut self,
+        options: SetupOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, Self::Error>;
     async fn unlock(&mut self, network: Network) -> Result<(), Self::Error>;
     async fn get_info(&mut self) -> Result<Info, Self::Error>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, Self::Error>;
@@ -79,6 +85,11 @@ pub trait HWI {
 #[async_trait(?Send)]
 pub trait HWIDevice {
     async fn backup_device(&mut self) -> Result<DeviceBackup, HWIDeviceError>;
+    async fn setup_device(
+        &mut self,
+        options: SetupOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, HWIDeviceError>;
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError>;
     async fn get_info(&mut self) -> Result<Info, HWIDeviceError>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, HWIDeviceError>;
@@ -142,6 +153,20 @@ where
         if let common::Response::Backup(backup) = run_command(self, common::Command::Backup).await?
         {
             Ok(backup)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
+
+    async fn setup_device(
+        &mut self,
+        options: SetupOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, Self::Error> {
+        if let common::Response::DeviceAction(success) =
+            run_command(self, common::Command::Setup(options, context)).await?
+        {
+            Ok(success)
         } else {
             Err(common::Error::NoErrorOrResult.into())
         }
@@ -274,6 +299,16 @@ where
 {
     async fn backup_device(&mut self) -> Result<DeviceBackup, HWIDeviceError> {
         HWI::backup_device(self).await.map_err(HWIDeviceError::new)
+    }
+
+    async fn setup_device(
+        &mut self,
+        options: SetupOptions,
+        context: Option<DeviceContext>,
+    ) -> Result<bool, HWIDeviceError> {
+        HWI::setup_device(self, options, context)
+            .await
+            .map_err(HWIDeviceError::new)
     }
 
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError> {

--- a/bhwi-async/src/lib.rs
+++ b/bhwi-async/src/lib.rs
@@ -32,6 +32,14 @@ pub use ledger::Ledger;
 pub trait Transport {
     type Error: Debug;
     async fn exchange(&mut self, command: &[u8], encrypted: bool) -> Result<Vec<u8>, Self::Error>;
+
+    /// Whether an exchange failed while reading after the request was successfully written.
+    ///
+    /// Stateful commands that reboot a device can use this to distinguish an expected
+    /// post-write disconnect from a failure to deliver the command.
+    fn is_post_write_disconnect(&self, _error: &Self::Error) -> bool {
+        false
+    }
 }
 
 #[async_trait(?Send)]
@@ -49,6 +57,7 @@ pub trait HWI {
         options: SetupOptions,
         context: Option<DeviceContext>,
     ) -> Result<bool, Self::Error>;
+    async fn wipe_device(&mut self) -> Result<bool, Self::Error>;
     async fn unlock(&mut self, network: Network) -> Result<(), Self::Error>;
     async fn get_info(&mut self) -> Result<Info, Self::Error>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, Self::Error>;
@@ -90,6 +99,7 @@ pub trait HWIDevice {
         options: SetupOptions,
         context: Option<DeviceContext>,
     ) -> Result<bool, HWIDeviceError>;
+    async fn wipe_device(&mut self) -> Result<bool, HWIDeviceError>;
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError>;
     async fn get_info(&mut self) -> Result<Info, HWIDeviceError>;
     async fn get_master_fingerprint(&mut self) -> Result<Fingerprint, HWIDeviceError>;
@@ -165,6 +175,16 @@ where
     ) -> Result<bool, Self::Error> {
         if let common::Response::DeviceAction(success) =
             run_command(self, common::Command::Setup(options, context)).await?
+        {
+            Ok(success)
+        } else {
+            Err(common::Error::NoErrorOrResult.into())
+        }
+    }
+
+    async fn wipe_device(&mut self) -> Result<bool, Self::Error> {
+        if let common::Response::DeviceAction(success) =
+            run_command_allowing_final_disconnect(self, common::Command::Wipe).await?
         {
             Ok(success)
         } else {
@@ -311,6 +331,10 @@ where
             .map_err(HWIDeviceError::new)
     }
 
+    async fn wipe_device(&mut self) -> Result<bool, HWIDeviceError> {
+        HWI::wipe_device(self).await.map_err(HWIDeviceError::new)
+    }
+
     async fn unlock(&mut self, network: Network) -> Result<(), HWIDeviceError> {
         HWI::unlock(self, network)
             .await
@@ -413,6 +437,47 @@ where
         >,
     C: Into<common::Command>,
 {
+    run_command_inner(device, command, false).await
+}
+
+async fn run_command_allowing_final_disconnect<D, C, E, F>(
+    device: &mut D,
+    command: C,
+) -> Result<common::Response, Error<E, F>>
+where
+    E: Debug,
+    F: Debug,
+    D: CommonInterface<
+            common::Command,
+            common::Transmit,
+            common::Response,
+            common::Error,
+            TransportError = E,
+            HttpClientError = F,
+        >,
+    C: Into<common::Command>,
+{
+    run_command_inner(device, command, true).await
+}
+
+async fn run_command_inner<D, C, E, F>(
+    device: &mut D,
+    command: C,
+    allow_final_disconnect: bool,
+) -> Result<common::Response, Error<E, F>>
+where
+    E: Debug,
+    F: Debug,
+    D: CommonInterface<
+            common::Command,
+            common::Transmit,
+            common::Response,
+            common::Error,
+            TransportError = E,
+            HttpClientError = F,
+        >,
+    C: Into<common::Command>,
+{
     let (transport, http_client, mut intpr) = device.components();
     let transmit = intpr.start(command.into())?;
     let exchange = transport
@@ -430,10 +495,15 @@ where
                 transmit = intpr.exchange(res)?;
             }
             common::Recipient::Device => {
-                let exchange = transport
-                    .exchange(&t.payload, t.encrypted)
-                    .await
-                    .map_err(Error::Transport)?;
+                let exchange = match transport.exchange(&t.payload, t.encrypted).await {
+                    Ok(exchange) => exchange,
+                    Err(error)
+                        if allow_final_disconnect && transport.is_post_write_disconnect(&error) =>
+                    {
+                        return Ok(common::Response::DeviceAction(true));
+                    }
+                    Err(error) => return Err(Error::Transport(error)),
+                };
                 transmit = intpr.exchange(exchange)?;
             }
         }

--- a/bhwi-async/src/transport/bitbox/hid.rs
+++ b/bhwi-async/src/transport/bitbox/hid.rs
@@ -33,8 +33,10 @@ pub enum BitBoxHIDError {
     Busy,
     #[error("U2F framing error")]
     U2f,
-    #[error("HID IO error: {0}")]
-    Hid(#[from] std::io::Error),
+    #[error("HID write error: {0}")]
+    Write(std::io::Error),
+    #[error("HID read error: {0}")]
+    Read(std::io::Error),
 }
 
 pub struct BitBoxTransportHID<C> {
@@ -63,7 +65,7 @@ impl<C: Channel> BitBoxTransportHID<C> {
                 .channel
                 .send(chunk)
                 .await
-                .map_err(BitBoxHIDError::Hid)?;
+                .map_err(BitBoxHIDError::Write)?;
             if sent < chunk.len() {
                 return Err(BitBoxHIDError::Comm("short write"));
             }
@@ -77,9 +79,12 @@ impl<C: Channel> BitBoxTransportHID<C> {
             .channel
             .receive(&mut buf)
             .await
-            .map_err(BitBoxHIDError::Hid)?;
+            .map_err(BitBoxHIDError::Read)?;
         if read != HID_PACKET_LEN {
-            return Err(BitBoxHIDError::Comm("short read"));
+            return Err(BitBoxHIDError::Read(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "short read",
+            )));
         }
         loop {
             match self.u2f.decode(&buf).map_err(|_| BitBoxHIDError::U2f)? {
@@ -90,9 +95,12 @@ impl<C: Channel> BitBoxTransportHID<C> {
                         .channel
                         .receive(&mut more)
                         .await
-                        .map_err(BitBoxHIDError::Hid)?;
+                        .map_err(BitBoxHIDError::Read)?;
                     if read != HID_PACKET_LEN {
-                        return Err(BitBoxHIDError::Comm("short read"));
+                        return Err(BitBoxHIDError::Read(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "short read",
+                        )));
                     }
                     buf.extend_from_slice(&more);
                 }
@@ -128,5 +136,43 @@ impl<C: Channel> Transport for BitBoxTransportHID<C> {
                 _ => return Err(BitBoxHIDError::Comm("unexpected HWW response")),
             }
         }
+    }
+
+    fn is_post_write_disconnect(&self, error: &Self::Error) -> bool {
+        matches!(error, BitBoxHIDError::Read(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct UnusedChannel;
+
+    #[async_trait(?Send)]
+    impl Channel for UnusedChannel {
+        async fn send(&self, _data: &[u8]) -> Result<usize, std::io::Error> {
+            unreachable!()
+        }
+
+        async fn receive(&mut self, _data: &mut [u8]) -> Result<usize, std::io::Error> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn only_read_errors_are_post_write_disconnects() {
+        let transport = BitBoxTransportHID::new(UnusedChannel);
+        assert!(
+            transport.is_post_write_disconnect(&BitBoxHIDError::Read(std::io::Error::from(
+                std::io::ErrorKind::TimedOut
+            )))
+        );
+        assert!(
+            !transport.is_post_write_disconnect(&BitBoxHIDError::Write(std::io::Error::from(
+                std::io::ErrorKind::BrokenPipe
+            )))
+        );
+        assert!(!transport.is_post_write_disconnect(&BitBoxHIDError::Nack));
     }
 }

--- a/bhwi-cli/Cargo.toml
+++ b/bhwi-cli/Cargo.toml
@@ -30,7 +30,7 @@ rand_core.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "io-util", "sync"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "io-util", "sync", "time"] }
 
 async-hid = "0.5.0"
 clap = { version = "4.4.7", features = ["derive"] }

--- a/bhwi-cli/Cargo.toml
+++ b/bhwi-cli/Cargo.toml
@@ -22,9 +22,9 @@ async-trait.workspace = true
 bitcoin = { workspace = true, features = ["base64", "serde"] }
 bhwi-async = { workspace = true, features = ["bitbox", "emulators"] }
 bhwi.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures.workspace = true
 hex = { workspace = true, features = ["serde"] }
-libc = "0.2"
 miniscript = { workspace = true, features = ["serde"] }
 rand_core.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -165,6 +165,8 @@ enum DeviceCommands {
         #[arg(long, short, default_value = "")]
         label: String,
     },
+    /// Toggle mnemonic-passphrase use on the selected BitBox02
+    TogglePassphrase,
     /// Install udev rules for hardware wallet device access
     InstallUdevRules {
         /// Device rule targets to install
@@ -416,6 +418,21 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Device(DeviceCommands::TogglePassphrase) => {
+            if let Some(mut device) = dev_man.get_device_with_fingerprint().await? {
+                if device.device_type() != DeviceType::BitBox02 {
+                    anyhow::bail!(
+                        "device toggle-passphrase is currently supported only for BitBox02"
+                    );
+                }
+                if !device.device().toggle_passphrase().await? {
+                    anyhow::bail!("BitBox02 passphrase setting was not changed");
+                }
+                if let Some(OutputFormat::Json) = format {
+                    println!("{}", serde_json::json!({ "success": true }));
+                }
+            }
+        }
         Commands::Device(DeviceCommands::InstallUdevRules {
             targets,
             all,
@@ -652,6 +669,16 @@ mod tests {
         assert!(matches!(
             args.command,
             Commands::Device(DeviceCommands::Restore { label }) if label == "Recovered"
+        ));
+    }
+
+    #[test]
+    fn parses_device_toggle_passphrase() {
+        let args = Args::try_parse_from(["bhwi", "device", "toggle-passphrase"])
+            .expect("parse device toggle-passphrase");
+        assert!(matches!(
+            args.command,
+            Commands::Device(DeviceCommands::TogglePassphrase)
         ));
     }
 

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
-use bhwi_async::{DeviceBackup, DeviceContext, SetupOptions, WalletRegistration};
+use bhwi_async::{DeviceBackup, DeviceContext, RestoreOptions, SetupOptions, WalletRegistration};
 use bhwi_cli::{
     DeviceManager, DeviceType, OutputFormat,
     address::AddressTarget,
     config::DeviceSelector,
     get_descriptors::GetKeypoolOptions,
-    management::bitbox_setup_context,
+    management::{bitbox_restore_context, bitbox_setup_context},
     udev::{UdevRuleSelection, install_udev_rules},
 };
 
@@ -159,6 +159,12 @@ enum DeviceCommands {
     },
     /// Erase wallet material from the selected BitBox02
     Wipe,
+    /// Restore an unseeded BitBox02 using its on-device mnemonic flow
+    Restore {
+        /// User-visible device name
+        #[arg(long, short, default_value = "")]
+        label: String,
+    },
     /// Install udev rules for hardware wallet device access
     InstallUdevRules {
         /// Device rule targets to install
@@ -380,6 +386,30 @@ async fn main() -> Result<()> {
                 }
                 if !device.device().wipe_device().await? {
                     anyhow::bail!("BitBox02 wipe was not completed");
+                }
+                if let Some(OutputFormat::Json) = format {
+                    println!("{}", serde_json::json!({ "success": true }));
+                }
+            }
+        }
+        Commands::Device(DeviceCommands::Restore { label }) => {
+            if let Some(mut device) = dev_man.get_device_with_fingerprint().await? {
+                if device.device_type() != DeviceType::BitBox02 {
+                    anyhow::bail!("device restore is currently supported only for BitBox02");
+                }
+                let context = bitbox_restore_context()?;
+                if !device
+                    .device()
+                    .restore_device(
+                        RestoreOptions {
+                            label,
+                            word_count: 24,
+                        },
+                        Some(context),
+                    )
+                    .await?
+                {
+                    anyhow::bail!("BitBox02 restore was not completed");
                 }
                 if let Some(OutputFormat::Json) = format {
                     println!("{}", serde_json::json!({ "success": true }));
@@ -612,6 +642,16 @@ mod tests {
         assert!(matches!(
             args.command,
             Commands::Device(DeviceCommands::Wipe)
+        ));
+    }
+
+    #[test]
+    fn parses_device_restore() {
+        let args = Args::try_parse_from(["bhwi", "device", "restore", "--label", "Recovered"])
+            .expect("parse device restore");
+        assert!(matches!(
+            args.command,
+            Commands::Device(DeviceCommands::Restore { label }) if label == "Recovered"
         ));
     }
 

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use bhwi::ledger::{LedgerWalletPolicy, Version};
-use bhwi_async::{DeviceBackup, DeviceContext, WalletRegistration};
+use bhwi_async::{DeviceBackup, DeviceContext, SetupOptions, WalletRegistration};
 use bhwi_cli::{
-    DeviceManager, OutputFormat,
+    DeviceManager, DeviceType, OutputFormat,
     address::AddressTarget,
     config::DeviceSelector,
     get_descriptors::GetKeypoolOptions,
+    management::bitbox_setup_context,
     udev::{UdevRuleSelection, install_udev_rules},
 };
 
@@ -149,6 +150,12 @@ enum DeviceCommands {
         /// Output file for devices that export encrypted backup bytes
         #[arg(long, short)]
         output: Option<PathBuf>,
+    },
+    /// Initialize an unseeded BitBox02
+    Setup {
+        /// User-visible device name
+        #[arg(long, short, default_value = "")]
+        label: String,
     },
     /// Install udev rules for hardware wallet device access
     InstallUdevRules {
@@ -337,6 +344,30 @@ async fn main() -> Result<()> {
                             println!("{}", serde_json::json!({ "success": true }));
                         }
                     }
+                }
+            }
+        }
+        Commands::Device(DeviceCommands::Setup { label }) => {
+            if let Some(mut device) = dev_man.get_device_with_fingerprint().await? {
+                if device.device_type() != DeviceType::BitBox02 {
+                    anyhow::bail!("device setup is currently supported only for BitBox02");
+                }
+                let context = bitbox_setup_context(device.is_emulated())?;
+                let success = device
+                    .device()
+                    .setup_device(
+                        SetupOptions {
+                            label,
+                            backup_passphrase: String::new(),
+                        },
+                        Some(context),
+                    )
+                    .await?;
+                if !success {
+                    anyhow::bail!("BitBox02 setup was not completed");
+                }
+                if let Some(OutputFormat::Json) = format {
+                    println!("{}", serde_json::json!({ "success": true }));
                 }
             }
         }
@@ -548,6 +579,16 @@ mod tests {
             }
             command => panic!("unexpected command: {command:?}"),
         }
+    }
+
+    #[test]
+    fn parses_device_setup() {
+        let args = Args::try_parse_from(["bhwi", "device", "setup", "--label", "BHWI"])
+            .expect("parse device setup");
+        assert!(matches!(
+            args.command,
+            Commands::Device(DeviceCommands::Setup { label }) if label == "BHWI"
+        ));
     }
 
     #[test]

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -157,6 +157,8 @@ enum DeviceCommands {
         #[arg(long, short, default_value = "")]
         label: String,
     },
+    /// Erase wallet material from the selected BitBox02
+    Wipe,
     /// Install udev rules for hardware wallet device access
     InstallUdevRules {
         /// Device rule targets to install
@@ -365,6 +367,19 @@ async fn main() -> Result<()> {
                     .await?;
                 if !success {
                     anyhow::bail!("BitBox02 setup was not completed");
+                }
+                if let Some(OutputFormat::Json) = format {
+                    println!("{}", serde_json::json!({ "success": true }));
+                }
+            }
+        }
+        Commands::Device(DeviceCommands::Wipe) => {
+            if let Some(mut device) = dev_man.get_device_with_fingerprint().await? {
+                if device.device_type() != DeviceType::BitBox02 {
+                    anyhow::bail!("device wipe is currently supported only for BitBox02");
+                }
+                if !device.device().wipe_device().await? {
+                    anyhow::bail!("BitBox02 wipe was not completed");
                 }
                 if let Some(OutputFormat::Json) = format {
                     println!("{}", serde_json::json!({ "success": true }));
@@ -588,6 +603,15 @@ mod tests {
         assert!(matches!(
             args.command,
             Commands::Device(DeviceCommands::Setup { label }) if label == "BHWI"
+        ));
+    }
+
+    #[test]
+    fn parses_device_wipe() {
+        let args = Args::try_parse_from(["bhwi", "device", "wipe"]).expect("parse device wipe");
+        assert!(matches!(
+            args.command,
+            Commands::Device(DeviceCommands::Wipe)
         ));
     }
 

--- a/bhwi-cli/src/bin/bhwi.rs
+++ b/bhwi-cli/src/bin/bhwi.rs
@@ -31,6 +31,12 @@ struct Args {
     /// default will be the first connected device with the master fingerprint matching.
     #[arg(long, alias = "fg", value_parser = clap::value_parser!(bitcoin::bip32::Fingerprint))]
     fingerprint: Option<Fingerprint>,
+    /// select a device implementation by type
+    #[arg(long, value_enum)]
+    device_type: Option<DeviceType>,
+    /// select a device by transport path
+    #[arg(long)]
+    device_path: Option<String>,
     /// default will be the Bitcoin mainnet network.
     #[arg(long, short, value_parser = clap::value_parser!(bitcoin::Network), default_value_t = bitcoin::Network::Bitcoin)]
     network: Network,
@@ -44,8 +50,9 @@ impl Args {
         DeviceSelector {
             network: self.network,
             fingerprint: self.fingerprint,
+            device_type: self.device_type,
+            device_path: self.device_path.clone(),
             include_emulators: true,
-            ..DeviceSelector::default()
         }
     }
 }
@@ -300,10 +307,14 @@ async fn main() -> Result<()> {
             for (i, device) in devices.iter_mut().enumerate() {
                 // XXX: Coldcard always needs unlocking
                 device.device().unlock(dev_man.selector.network).await?;
-                let fingerprint = device.fingerprint().await?;
                 let name = device.name().to_string();
                 let is_emulated = device.is_emulated();
                 let info = device.info().await?;
+                let fingerprint = if info.initialized == Some(false) {
+                    None
+                } else {
+                    Some(device.fingerprint().await?)
+                };
                 match format {
                     Some(OutputFormat::Pretty) => {
                         if i == 0 {
@@ -314,6 +325,9 @@ async fn main() -> Result<()> {
                         }
                         println!("{}", "-".repeat(80));
                         let network = info.networks_string();
+                        let fingerprint = fingerprint
+                            .map(|fingerprint| fingerprint.to_string())
+                            .unwrap_or_else(|| "-".to_owned());
                         println!(
                             "{name:<18} | {is_emulated:<8} | {fingerprint:<15} | {network:<12} | {:<8}",
                             info.version
@@ -321,7 +335,10 @@ async fn main() -> Result<()> {
                         println!("{}", "-".repeat(80));
                     }
                     Some(OutputFormat::Json) => {}
-                    None => println!("{fingerprint}"),
+                    None => match fingerprint {
+                        Some(fingerprint) => println!("{fingerprint}"),
+                        None => println!("{}", device.path()),
+                    },
                 }
             }
             if let Some(OutputFormat::Json) = format {
@@ -756,17 +773,20 @@ mod tests {
     }
 
     #[test]
-    fn native_cli_rejects_hwi_only_selector_flags() {
-        let error = Args::try_parse_from([
+    fn native_cli_accepts_device_type_and_path_selectors() {
+        let args = Args::try_parse_from([
             "bhwi",
+            "--device-type",
+            "bitbox02",
             "--device-path",
-            "tcp:localhost:9999",
+            "tcp:127.0.0.1:15423",
             "device",
             "list",
         ])
-        .expect_err("native CLI must not accept HWI compatibility flags");
+        .expect("native selectors parse");
 
-        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(args.device_type, Some(DeviceType::BitBox02));
+        assert_eq!(args.device_path.as_deref(), Some("tcp:127.0.0.1:15423"));
     }
 
     #[test]

--- a/bhwi-cli/src/bitbox.rs
+++ b/bhwi-cli/src/bitbox.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{io, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use anyhow::Result;
@@ -159,7 +159,11 @@ impl Channel for BitBoxTcpChannel {
 
     async fn receive(&mut self, data: &mut [u8]) -> Result<usize, std::io::Error> {
         let mut stream = self.stream.lock().await;
-        stream.read_exact(data).await?;
+        tokio::time::timeout(Duration::from_secs(10), stream.read_exact(data))
+            .await
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::TimedOut, "BitBox02 response timed out")
+            })??;
         Ok(data.len())
     }
 }

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -206,6 +206,7 @@ pub enum HwiCommand {
         label: String,
         backup_passphrase: String,
     },
+    Wipe,
     UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
     InstallUdevRules {
         location: PathBuf,
@@ -275,6 +276,7 @@ pub enum HwiErrorCode {
     DeviceFailure,
     DeviceConnectionError,
     NeedToBeRoot,
+    DeviceNotInitialized,
 }
 
 impl HwiErrorCode {
@@ -287,6 +289,7 @@ impl HwiErrorCode {
             HwiErrorCode::DeviceFailure => -13,
             HwiErrorCode::DeviceConnectionError => -3,
             HwiErrorCode::NeedToBeRoot => -16,
+            HwiErrorCode::DeviceNotInitialized => -18,
         }
     }
 }
@@ -454,6 +457,7 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             label,
             backup_passphrase,
         } => setup_device(request.selector, interactive, label, backup_passphrase).await,
+        HwiCommand::Wipe => wipe_device(request.selector).await,
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
@@ -700,6 +704,53 @@ async fn setup_device(
         )
         .await
     {
+        Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+async fn wipe_device(selector: DeviceSelector) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    if device.device_type() != DeviceType::BitBox02 {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            hwi_unavailable_action_message(device.device_type(), &HwiUnsupportedDeviceAction::Wipe),
+        ));
+    }
+    if device.info().await.ok().and_then(|info| info.initialized) == Some(false) {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceNotInitialized,
+            "The BitBox02 must be initialized first.",
+        ));
+    }
+
+    match device.device().wipe_device().await {
         Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
         Err(err) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::DeviceConnectionError,
@@ -2280,9 +2331,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
             label,
             backup_passphrase,
         },
-        HwiCliCommand::Wipe => {
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Wipe)
-        }
+        HwiCliCommand::Wipe => HwiCommand::Wipe,
         HwiCliCommand::Restore { word_count, label } => {
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Restore {
                 interactive: args.interactive,
@@ -2787,6 +2836,15 @@ mod tests {
                 backup_passphrase: "backup passphrase".to_owned(),
             }
         );
+    }
+
+    #[test]
+    fn parses_wipe_action() {
+        let request =
+            parse_args(["hwi", "--device-type", "bitbox02", "wipe"]).expect("wipe request");
+
+        assert_eq!(request.selector.device_type, Some(DeviceType::BitBox02));
+        assert_eq!(request.command, HwiCommand::Wipe);
     }
 
     #[test]

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -5,7 +5,6 @@ use std::{
     path::PathBuf,
     process::ExitCode,
     str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use bhwi::{
@@ -13,7 +12,7 @@ use bhwi::{
     common::{MultisigAddressType, MultisigDisplayAddress},
     ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
 };
-use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress};
+use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress, SetupOptions};
 use bitcoin::{
     Network, NetworkKind, PublicKey, ScriptBuf,
     base64::prelude::{BASE64_STANDARD, Engine as _},
@@ -25,6 +24,7 @@ use bitcoin::{
     psbt::Input,
     secp256k1::{PublicKey as SecpPublicKey, XOnlyPublicKey},
 };
+use chrono::{Datelike, Local, Timelike};
 use clap::{ArgAction, ArgGroup, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use miniscript::{
     Descriptor, DescriptorPublicKey,
@@ -36,6 +36,7 @@ use crate::{
     Device, DeviceManager, DeviceType,
     config::DeviceSelector,
     get_descriptors::GetDescriptorOptions,
+    management::bitbox_setup_context,
     udev::{UdevRuleSelection, install_udev_rules},
 };
 
@@ -197,6 +198,11 @@ pub enum HwiCommand {
         path: Option<String>,
     },
     Backup {
+        label: String,
+        backup_passphrase: String,
+    },
+    Setup {
+        interactive: bool,
         label: String,
         backup_passphrase: String,
     },
@@ -443,6 +449,11 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             label,
             backup_passphrase,
         } => backup_device(request.selector, label, backup_passphrase).await,
+        HwiCommand::Setup {
+            interactive,
+            label,
+            backup_passphrase,
+        } => setup_device(request.selector, interactive, label, backup_passphrase).await,
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
@@ -612,6 +623,91 @@ async fn unsupported_device_action(
     HwiResponse::Error(HwiError::new(HwiErrorCode::UnsupportedCommand, error))
 }
 
+async fn setup_device(
+    selector: DeviceSelector,
+    interactive: bool,
+    label: String,
+    backup_passphrase: String,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    if !interactive {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "setup requires interactive mode",
+        ));
+    }
+    if device.device_type() != DeviceType::BitBox02 {
+        let action = HwiUnsupportedDeviceAction::Setup {
+            interactive,
+            label,
+            backup_passphrase,
+        };
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            hwi_unavailable_action_message(device.device_type(), &action),
+        ));
+    }
+    if !backup_passphrase.is_empty() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "Passphrase not needed when setting up a BitBox02.",
+        ));
+    }
+    if device.info().await.ok().and_then(|info| info.initialized) == Some(true) {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "The BitBox02 must be wiped before setup.",
+        ));
+    }
+
+    let context = match bitbox_setup_context(device.is_emulated()) {
+        Ok(context) => context,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceFailure, err.to_string()));
+        }
+    };
+    match device
+        .device()
+        .setup_device(
+            SetupOptions {
+                label,
+                backup_passphrase,
+            },
+            Some(context),
+        )
+        .await
+    {
+        Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
 async fn backup_device(
     selector: DeviceSelector,
     label: String,
@@ -687,47 +783,22 @@ async fn backup_device(
 }
 
 fn write_hwi_backup_file(bytes: &[u8]) -> io::Result<()> {
-    fs::write(hwi_backup_filename()?, bytes)
+    fs::write(hwi_backup_filename(), bytes)
 }
 
-fn hwi_backup_filename() -> io::Result<String> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(io::Error::other)?;
-    let timestamp = now.as_secs().try_into().map_err(io::Error::other)?;
-    let tm = local_time(timestamp)?;
+fn hwi_backup_filename() -> String {
+    format_hwi_backup_filename(Local::now())
+}
 
-    Ok(format!(
+fn format_hwi_backup_filename<Tz: chrono::TimeZone>(time: chrono::DateTime<Tz>) -> String {
+    format!(
         "backup-{:04}{:02}{:02}-{:02}{:02}.7z",
-        tm.tm_year + 1900,
-        tm.tm_mon + 1,
-        tm.tm_mday,
-        tm.tm_hour,
-        tm.tm_min
-    ))
-}
-
-#[cfg(unix)]
-fn local_time(timestamp: libc::time_t) -> io::Result<libc::tm> {
-    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
-    // Python HWI uses `time.strftime`, i.e. the process local timezone.
-    unsafe {
-        if libc::localtime_r(&timestamp, tm.as_mut_ptr()).is_null() {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(tm.assume_init())
-    }
-}
-
-#[cfg(windows)]
-fn local_time(timestamp: libc::time_t) -> io::Result<libc::tm> {
-    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
-    // Windows uses the bounds-checked variant with destination first.
-    let code = unsafe { libc::localtime_s(tm.as_mut_ptr(), &timestamp) };
-    if code != 0 {
-        return Err(io::Error::from_raw_os_error(code));
-    }
-    Ok(unsafe { tm.assume_init() })
+        time.year(),
+        time.month(),
+        time.day(),
+        time.hour(),
+        time.minute()
+    )
 }
 
 async fn get_master_xpub(
@@ -2204,11 +2275,11 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Setup {
             label,
             backup_passphrase,
-        } => HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Setup {
+        } => HwiCommand::Setup {
             interactive: args.interactive,
             label,
             backup_passphrase,
-        }),
+        },
         HwiCliCommand::Wipe => {
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Wipe)
         }
@@ -2291,6 +2362,18 @@ mod tests {
         secp256k1::Secp256k1,
         transaction::Version as TxVersion,
     };
+    use chrono::{FixedOffset, TimeZone};
+
+    #[test]
+    fn backup_filename_matches_python_hwi_local_time_format() {
+        let time = FixedOffset::east_opt(3 * 60 * 60)
+            .unwrap()
+            .with_ymd_and_hms(2026, 7, 21, 9, 5, 0)
+            .single()
+            .unwrap();
+
+        assert_eq!(format_hwi_backup_filename(time), "backup-20260721-0905.7z");
+    }
 
     #[test]
     fn parses_enumerate_selector() {
@@ -2678,7 +2761,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_setup_unsupported_action() {
+    fn parses_setup_action() {
         let request = parse_args([
             "hwi",
             "--chain",
@@ -2692,17 +2775,17 @@ mod tests {
             "-b",
             "backup passphrase",
         ])
-        .expect("unsupported setup request");
+        .expect("setup request");
 
         assert_eq!(request.selector.network, Network::Testnet);
         assert_eq!(request.selector.device_type, Some(DeviceType::Ledger));
         assert_eq!(
             request.command,
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Setup {
+            HwiCommand::Setup {
                 interactive: true,
                 label: "HWI Ledger".to_owned(),
                 backup_passphrase: "backup passphrase".to_owned(),
-            })
+            }
         );
     }
 

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -12,7 +12,7 @@ use bhwi::{
     common::{MultisigAddressType, MultisigDisplayAddress},
     ledger::{LedgerWalletPolicy, Version, singlesig_wallet_policy},
 };
-use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress, SetupOptions};
+use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress, RestoreOptions, SetupOptions};
 use bitcoin::{
     Network, NetworkKind, PublicKey, ScriptBuf,
     base64::prelude::{BASE64_STANDARD, Engine as _},
@@ -36,7 +36,7 @@ use crate::{
     Device, DeviceManager, DeviceType,
     config::DeviceSelector,
     get_descriptors::GetDescriptorOptions,
-    management::bitbox_setup_context,
+    management::{bitbox_restore_context, bitbox_setup_context},
     udev::{UdevRuleSelection, install_udev_rules},
 };
 
@@ -207,6 +207,11 @@ pub enum HwiCommand {
         backup_passphrase: String,
     },
     Wipe,
+    Restore {
+        interactive: bool,
+        word_count: i32,
+        label: String,
+    },
     UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
     InstallUdevRules {
         location: PathBuf,
@@ -458,6 +463,11 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             backup_passphrase,
         } => setup_device(request.selector, interactive, label, backup_passphrase).await,
         HwiCommand::Wipe => wipe_device(request.selector).await,
+        HwiCommand::Restore {
+            interactive,
+            word_count,
+            label,
+        } => restore_device(request.selector, interactive, word_count, label).await,
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
@@ -751,6 +761,81 @@ async fn wipe_device(selector: DeviceSelector) -> HwiResponse {
     }
 
     match device.device().wipe_device().await {
+        Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+async fn restore_device(
+    selector: DeviceSelector,
+    interactive: bool,
+    word_count: i32,
+    label: String,
+) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    if !interactive {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "restore requires interactive mode",
+        ));
+    }
+    if device.device_type() != DeviceType::BitBox02 {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            hwi_unavailable_action_message(
+                device.device_type(),
+                &HwiUnsupportedDeviceAction::Restore {
+                    interactive,
+                    word_count,
+                    label,
+                },
+            ),
+        ));
+    }
+    if device.info().await.ok().and_then(|info| info.initialized) == Some(true) {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            "The BitBox02 must be wiped before setup.",
+        ));
+    }
+
+    let context = match bitbox_restore_context() {
+        Ok(context) => context,
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceFailure, err.to_string()));
+        }
+    };
+    match device
+        .device()
+        .restore_device(RestoreOptions { label, word_count }, Some(context))
+        .await
+    {
         Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
         Err(err) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::DeviceConnectionError,
@@ -2332,13 +2417,11 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
             backup_passphrase,
         },
         HwiCliCommand::Wipe => HwiCommand::Wipe,
-        HwiCliCommand::Restore { word_count, label } => {
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Restore {
-                interactive: args.interactive,
-                word_count,
-                label,
-            })
-        }
+        HwiCliCommand::Restore { word_count, label } => HwiCommand::Restore {
+            interactive: args.interactive,
+            word_count,
+            label,
+        },
         HwiCliCommand::Backup {
             label,
             backup_passphrase,
@@ -2848,7 +2931,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_restore_unsupported_action() {
+    fn parses_restore_action() {
         let request = parse_args([
             "hwi",
             "--device-type",
@@ -2860,15 +2943,15 @@ mod tests {
             "--label",
             "HWI Jade",
         ])
-        .expect("unsupported restore request");
+        .expect("restore request");
 
         assert_eq!(
             request.command,
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::Restore {
+            HwiCommand::Restore {
                 interactive: true,
                 word_count: 12,
                 label: "HWI Jade".to_owned(),
-            })
+            }
         );
     }
 

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -212,6 +212,7 @@ pub enum HwiCommand {
         word_count: i32,
         label: String,
     },
+    TogglePassphrase,
     UnsupportedDeviceAction(HwiUnsupportedDeviceAction),
     InstallUdevRules {
         location: PathBuf,
@@ -468,6 +469,7 @@ pub async fn process_request(request: HwiRequest) -> HwiResponse {
             word_count,
             label,
         } => restore_device(request.selector, interactive, word_count, label).await,
+        HwiCommand::TogglePassphrase => toggle_passphrase_device(request.selector).await,
         HwiCommand::UnsupportedDeviceAction(action) => {
             unsupported_device_action(request.selector, action).await
         }
@@ -836,6 +838,56 @@ async fn restore_device(
         .restore_device(RestoreOptions { label, word_count }, Some(context))
         .await
     {
+        Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
+        Err(err) => HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceConnectionError,
+            err.to_string(),
+        )),
+    }
+}
+
+async fn toggle_passphrase_device(selector: DeviceSelector) -> HwiResponse {
+    if selector.device_type.is_none() && selector.fingerprint.is_none() {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::NoDeviceType,
+            "You must specify a device type or fingerprint for all commands except enumerate",
+        ));
+    }
+
+    let manager = DeviceManager::new(selector);
+    let mut device = match manager.get_device_with_fingerprint().await {
+        Ok(Some(device)) => device,
+        Ok(None) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                "Could not find device with specified fingerprint or type",
+            ));
+        }
+        Err(err) => {
+            return HwiResponse::Error(HwiError::new(
+                HwiErrorCode::DeviceConnectionError,
+                err.to_string(),
+            ));
+        }
+    };
+
+    if device.device_type() != DeviceType::BitBox02 {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::UnsupportedCommand,
+            hwi_unavailable_action_message(
+                device.device_type(),
+                &HwiUnsupportedDeviceAction::TogglePassphrase,
+            ),
+        ));
+    }
+    if device.info().await.ok().and_then(|info| info.initialized) == Some(false) {
+        return HwiResponse::Error(HwiError::new(
+            HwiErrorCode::DeviceNotInitialized,
+            "The BitBox02 must be initialized first.",
+        ));
+    }
+
+    match device.device().toggle_passphrase().await {
         Ok(success) => HwiResponse::Success(HwiSuccessResponse { success }),
         Err(err) => HwiResponse::Error(HwiError::new(
             HwiErrorCode::DeviceConnectionError,
@@ -2435,9 +2487,7 @@ fn request_from_cli(args: HwiCli) -> HwiResult<HwiRequest> {
         HwiCliCommand::Sendpin { pin } => {
             HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::SendPin { pin })
         }
-        HwiCliCommand::Togglepassphrase => {
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
-        }
+        HwiCliCommand::Togglepassphrase => HwiCommand::TogglePassphrase,
         HwiCliCommand::Installudevrules { location } => HwiCommand::InstallUdevRules { location },
         HwiCliCommand::External(argv) => {
             let command = argv
@@ -2979,7 +3029,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_pin_and_passphrase_unsupported_actions() {
+    fn parses_pin_actions_and_toggle_passphrase() {
         let promptpin = parse_args(["hwi", "--device-type", "ledger", "promptpin"])
             .expect("unsupported promptpin request");
         assert_eq!(
@@ -2997,11 +3047,8 @@ mod tests {
         );
 
         let togglepassphrase = parse_args(["hwi", "--device-type", "ledger", "togglepassphrase"])
-            .expect("unsupported togglepassphrase request");
-        assert_eq!(
-            togglepassphrase.command,
-            HwiCommand::UnsupportedDeviceAction(HwiUnsupportedDeviceAction::TogglePassphrase)
-        );
+            .expect("togglepassphrase request");
+        assert_eq!(togglepassphrase.command, HwiCommand::TogglePassphrase);
     }
 
     #[test]

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -140,6 +140,7 @@ impl Device {
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum DeviceType {
+    #[value(name = "bitbox02", alias = "bit-box02")]
     BitBox02,
     Coldcard,
     Jade,

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod hid;
 pub mod hwi;
 pub mod jade;
 pub mod ledger;
+pub mod management;
 pub mod udev;
 
 #[derive(Serialize)]
@@ -44,6 +45,8 @@ pub struct Info {
     pub version: String,
     pub networks: Vec<Network>,
     pub firmware: Option<String>,
+    #[serde(skip)]
+    pub initialized: Option<bool>,
 }
 
 impl Info {
@@ -62,6 +65,7 @@ impl From<bhwi_async::Info> for Info {
             version: info.version,
             networks: info.networks,
             firmware: info.firmware,
+            initialized: info.initialized,
         }
     }
 }

--- a/bhwi-cli/src/management.rs
+++ b/bhwi-cli/src/management.rs
@@ -1,0 +1,63 @@
+use anyhow::{Context, Result};
+use bhwi::{
+    bitbox::{ManagementContext, SetupEntropy, SetupMode},
+    common::DeviceContext,
+};
+use chrono::Local;
+use rand_core::{OsRng, RngCore};
+
+pub fn bitbox_setup_context(is_emulated: bool) -> Result<DeviceContext> {
+    let (timestamp, timezone_offset) = timestamp_and_timezone_offset()?;
+    let mode = if is_emulated {
+        SetupMode::RestoreFromMnemonic
+    } else {
+        let mut entropy = [0; 32];
+        OsRng.fill_bytes(&mut entropy);
+        SetupMode::NewWallet {
+            entropy: SetupEntropy::new(entropy),
+        }
+    };
+    Ok(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+        mode,
+        timestamp,
+        timezone_offset,
+    }))
+}
+
+fn timestamp_and_timezone_offset() -> Result<(u32, i32)> {
+    let now = Local::now();
+    timestamp_and_timezone_offset_from(now.timestamp(), now.offset().local_minus_utc())
+}
+
+fn timestamp_and_timezone_offset_from(timestamp: i64, timezone_offset: i32) -> Result<(u32, i32)> {
+    let timestamp = u32::try_from(timestamp).context("current timestamp does not fit in u32")?;
+    Ok((timestamp, timezone_offset))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simulator_setup_uses_mnemonic_restore_without_entropy() {
+        let context = bitbox_setup_context(true).unwrap();
+        assert!(matches!(
+            context,
+            DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                mode: SetupMode::RestoreFromMnemonic,
+                ..
+            })
+        ));
+    }
+    #[test]
+    fn timestamp_and_timezone_offset_preserves_seconds_east_of_utc() {
+        assert_eq!(
+            timestamp_and_timezone_offset_from(1_750_000_000, 3 * 60 * 60).unwrap(),
+            (1_750_000_000, 3 * 60 * 60)
+        );
+        assert_eq!(
+            timestamp_and_timezone_offset_from(1_750_000_000, -7 * 60 * 60).unwrap(),
+            (1_750_000_000, -7 * 60 * 60)
+        );
+    }
+}

--- a/bhwi-cli/src/management.rs
+++ b/bhwi-cli/src/management.rs
@@ -24,6 +24,16 @@ pub fn bitbox_setup_context(is_emulated: bool) -> Result<DeviceContext> {
     }))
 }
 
+pub fn bitbox_restore_context() -> Result<DeviceContext> {
+    let (timestamp, timezone_offset) = timestamp_and_timezone_offset()?;
+    Ok(DeviceContext::BitBoxManagement(
+        ManagementContext::Restore {
+            timestamp,
+            timezone_offset,
+        },
+    ))
+}
+
 fn timestamp_and_timezone_offset() -> Result<(u32, i32)> {
     let now = Local::now();
     timestamp_and_timezone_offset_from(now.timestamp(), now.offset().local_minus_utc())
@@ -59,5 +69,14 @@ mod tests {
             timestamp_and_timezone_offset_from(1_750_000_000, -7 * 60 * 60).unwrap(),
             (1_750_000_000, -7 * 60 * 60)
         );
+    }
+
+    #[test]
+    fn restore_context_contains_host_time() {
+        assert!(matches!(
+            bitbox_restore_context().unwrap(),
+            DeviceContext::BitBoxManagement(ManagementContext::Restore { timestamp, .. })
+                if timestamp > 0
+        ));
     }
 }

--- a/bhwi/src/bitbox/api.rs
+++ b/bhwi/src/bitbox/api.rs
@@ -117,6 +117,13 @@ pub fn reset_request() -> pb::request::Request {
     pb::request::Request::Reset(pb::ResetRequest {})
 }
 
+/// Enable or disable use of a mnemonic passphrase on the device.
+pub fn set_mnemonic_passphrase_enabled_request(enabled: bool) -> pb::request::Request {
+    pb::request::Request::SetMnemonicPassphraseEnabled(pb::SetMnemonicPassphraseEnabledRequest {
+        enabled,
+    })
+}
+
 /// Build a nested `BtcRequest::IsScriptConfigRegistered`.
 pub fn is_script_config_registered_request(
     coin: pb::BtcCoin,
@@ -221,6 +228,16 @@ mod tests {
         assert!(matches!(
             reset_request(),
             pb::request::Request::Reset(pb::ResetRequest {})
+        ));
+    }
+
+    #[test]
+    fn toggle_passphrase_request_preserves_enabled_state() {
+        assert!(matches!(
+            set_mnemonic_passphrase_enabled_request(true),
+            pb::request::Request::SetMnemonicPassphraseEnabled(
+                pb::SetMnemonicPassphraseEnabledRequest { enabled: true }
+            )
         ));
     }
 }

--- a/bhwi/src/bitbox/api.rs
+++ b/bhwi/src/bitbox/api.rs
@@ -84,6 +84,34 @@ pub fn show_mnemonic_request() -> pb::request::Request {
     pb::request::Request::ShowMnemonic(pb::ShowMnemonicRequest {})
 }
 
+/// Set the user-visible device name.
+pub fn set_device_name_request(name: impl Into<String>) -> pb::request::Request {
+    pb::request::Request::DeviceName(pb::SetDeviceNameRequest { name: name.into() })
+}
+
+/// Initialize a new wallet using host-provided entropy.
+pub fn set_password_request(entropy: &[u8; 32]) -> pb::request::Request {
+    pb::request::Request::SetPassword(pb::SetPasswordRequest {
+        entropy: entropy.to_vec(),
+    })
+}
+
+/// Create the initial SD-card backup after a new wallet has been initialized.
+pub fn create_backup_request(timestamp: u32, timezone_offset: i32) -> pb::request::Request {
+    pb::request::Request::CreateBackup(pb::CreateBackupRequest {
+        timestamp,
+        timezone_offset,
+    })
+}
+
+/// Start the on-device mnemonic restore flow.
+pub fn restore_from_mnemonic_request(timestamp: u32, timezone_offset: i32) -> pb::request::Request {
+    pb::request::Request::RestoreFromMnemonic(pb::RestoreFromMnemonicRequest {
+        timestamp,
+        timezone_offset,
+    })
+}
+
 /// Build a nested `BtcRequest::IsScriptConfigRegistered`.
 pub fn is_script_config_registered_request(
     coin: pb::BtcCoin,
@@ -148,6 +176,38 @@ mod tests {
         assert!(matches!(
             show_mnemonic_request(),
             pb::request::Request::ShowMnemonic(pb::ShowMnemonicRequest {})
+        ));
+    }
+
+    #[test]
+    fn setup_requests_preserve_external_inputs() {
+        assert!(matches!(
+            set_device_name_request("HWI Test"),
+            pb::request::Request::DeviceName(pb::SetDeviceNameRequest { name })
+                if name == "HWI Test"
+        ));
+
+        let entropy = [42; 32];
+        assert!(matches!(
+            set_password_request(&entropy),
+            pb::request::Request::SetPassword(pb::SetPasswordRequest { entropy: encoded })
+                if encoded == entropy
+        ));
+
+        assert!(matches!(
+            create_backup_request(1_601_450_521, 3_600),
+            pb::request::Request::CreateBackup(pb::CreateBackupRequest {
+                timestamp: 1_601_450_521,
+                timezone_offset: 3_600,
+            })
+        ));
+
+        assert!(matches!(
+            restore_from_mnemonic_request(1_601_450_521, -3_600),
+            pb::request::Request::RestoreFromMnemonic(pb::RestoreFromMnemonicRequest {
+                timestamp: 1_601_450_521,
+                timezone_offset: -3_600,
+            })
         ));
     }
 }

--- a/bhwi/src/bitbox/api.rs
+++ b/bhwi/src/bitbox/api.rs
@@ -112,6 +112,11 @@ pub fn restore_from_mnemonic_request(timestamp: u32, timezone_offset: i32) -> pb
     })
 }
 
+/// Erase wallet material and return the device to its uninitialized state.
+pub fn reset_request() -> pb::request::Request {
+    pb::request::Request::Reset(pb::ResetRequest {})
+}
+
 /// Build a nested `BtcRequest::IsScriptConfigRegistered`.
 pub fn is_script_config_registered_request(
     coin: pb::BtcCoin,
@@ -208,6 +213,14 @@ mod tests {
                 timestamp: 1_601_450_521,
                 timezone_offset: -3_600,
             })
+        ));
+    }
+
+    #[test]
+    fn wipe_request_uses_reset() {
+        assert!(matches!(
+            reset_request(),
+            pb::request::Request::Reset(pb::ResetRequest {})
         ));
     }
 }

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -85,6 +85,12 @@ pub enum BitBoxCommand {
     },
     /// Erase wallet material from the device.
     Wipe,
+    /// Restore wallet material using the device's on-screen mnemonic flow.
+    Restore {
+        label: String,
+        timestamp: u32,
+        timezone_offset: i32,
+    },
     /// Restore the device from its currently-loaded mnemonic (simulator seeding).
     RestoreFromMnemonic {
         timestamp: u32,
@@ -146,12 +152,21 @@ enum State {
     SetupWaitRestore,
     WipeWaitInfo,
     WipeWaitReset,
+    RestoreWaitInfo(RestoreInit),
+    RestoreWaitName(RestoreInit),
+    RestoreWaitMnemonic,
     Finished(BitBoxResponse),
 }
 
 struct SetupInit {
     label: String,
     mode: SetupMode,
+    timestamp: u32,
+    timezone_offset: i32,
+}
+
+struct RestoreInit {
+    label: String,
     timestamp: u32,
     timezone_offset: i32,
 }
@@ -896,6 +911,22 @@ where
                 self.state = State::WipeWaitInfo;
                 Ok(encrypted_transmit(bytes).into())
             }
+            BitBoxCommand::Restore {
+                label,
+                timestamp,
+                timezone_offset,
+            } => {
+                if !self.noise.is_paired() {
+                    return Err(BitBoxError::Noise("not paired").into());
+                }
+                let bytes = self.build_encrypted(api::device_info_request())?;
+                self.state = State::RestoreWaitInfo(RestoreInit {
+                    label,
+                    timestamp,
+                    timezone_offset,
+                });
+                Ok(encrypted_transmit(bytes).into())
+            }
             BitBoxCommand::RestoreFromMnemonic {
                 timestamp,
                 timezone_offset,
@@ -1201,6 +1232,52 @@ where
                 self.state = State::Finished(BitBoxResponse::DeviceAction(success));
                 Ok(None)
             }
+            State::RestoreWaitInfo(restore) => {
+                let response = self.decode_encrypted_response(data)?;
+                let info = match response {
+                    pb::response::Response::DeviceInfo(info) => info,
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                };
+                if info.initialized {
+                    return Err(BitBoxError::InvalidInput(
+                        "The BitBox02 must be wiped before setup.",
+                    )
+                    .into());
+                }
+                if restore.label.is_empty() {
+                    let bytes = self.build_encrypted(api::restore_from_mnemonic_request(
+                        restore.timestamp,
+                        restore.timezone_offset,
+                    ))?;
+                    self.state = State::RestoreWaitMnemonic;
+                    Ok(Some(encrypted_transmit(bytes).into()))
+                } else {
+                    let bytes =
+                        self.build_encrypted(api::set_device_name_request(&restore.label))?;
+                    self.state = State::RestoreWaitName(restore);
+                    Ok(Some(encrypted_transmit(bytes).into()))
+                }
+            }
+            State::RestoreWaitName(restore) => {
+                match self.decode_encrypted_response(data)? {
+                    pb::response::Response::Success(_) => {}
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                }
+                let bytes = self.build_encrypted(api::restore_from_mnemonic_request(
+                    restore.timestamp,
+                    restore.timezone_offset,
+                ))?;
+                self.state = State::RestoreWaitMnemonic;
+                Ok(Some(encrypted_transmit(bytes).into()))
+            }
+            State::RestoreWaitMnemonic => {
+                match self.decode_encrypted_response(data)? {
+                    pb::response::Response::Success(_) => {}
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                }
+                self.state = State::Finished(BitBoxResponse::DeviceAction(true));
+                Ok(None)
+            }
         }
     }
 
@@ -1240,6 +1317,22 @@ impl TryFrom<Command> for BitBoxCommand {
                 })
             }
             Command::Wipe => Ok(BitBoxCommand::Wipe),
+            Command::Restore(options, context) => {
+                let Some(DeviceContext::BitBoxManagement(ManagementContext::Restore {
+                    timestamp,
+                    timezone_offset,
+                })) = context
+                else {
+                    return Err(BitBoxError::InvalidInput(
+                        "BitBox restore requires DeviceContext::BitBoxManagement",
+                    ));
+                };
+                Ok(BitBoxCommand::Restore {
+                    label: options.label,
+                    timestamp,
+                    timezone_offset,
+                })
+            }
             Command::Unlock { .. } => Ok(BitBoxCommand::UnlockAndPair),
             Command::GetVersion => Ok(BitBoxCommand::GetVersion),
             Command::GetMasterFingerprint => Ok(BitBoxCommand::GetMasterFingerprint),
@@ -1523,6 +1616,42 @@ mod tests {
         assert!(matches!(
             BitBoxCommand::try_from(Command::Wipe),
             Ok(BitBoxCommand::Wipe)
+        ));
+    }
+
+    #[test]
+    fn common_restore_maps_to_bitbox_restore_and_ignores_word_count() {
+        let command = BitBoxCommand::try_from(Command::Restore(
+            crate::common::RestoreOptions {
+                label: "Recovered".into(),
+                word_count: 12,
+            },
+            Some(DeviceContext::BitBoxManagement(
+                ManagementContext::Restore {
+                    timestamp: 1_601_450_521,
+                    timezone_offset: -3_600,
+                },
+            )),
+        ))
+        .unwrap();
+        assert!(matches!(
+            command,
+            BitBoxCommand::Restore {
+                label,
+                timestamp: 1_601_450_521,
+                timezone_offset: -3_600,
+            } if label == "Recovered"
+        ));
+    }
+
+    #[test]
+    fn common_restore_requires_context() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::Restore(
+                crate::common::RestoreOptions::default(),
+                None,
+            )),
+            Err(BitBoxError::InvalidInput(_))
         ));
     }
 

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -83,6 +83,8 @@ pub enum BitBoxCommand {
         timestamp: u32,
         timezone_offset: i32,
     },
+    /// Erase wallet material from the device.
+    Wipe,
     /// Restore the device from its currently-loaded mnemonic (simulator seeding).
     RestoreFromMnemonic {
         timestamp: u32,
@@ -142,6 +144,8 @@ enum State {
     },
     SetupWaitBackup,
     SetupWaitRestore,
+    WipeWaitInfo,
+    WipeWaitReset,
     Finished(BitBoxResponse),
 }
 
@@ -884,6 +888,14 @@ where
                 });
                 Ok(encrypted_transmit(bytes).into())
             }
+            BitBoxCommand::Wipe => {
+                if !self.noise.is_paired() {
+                    return Err(BitBoxError::Noise("not paired").into());
+                }
+                let bytes = self.build_encrypted(api::device_info_request())?;
+                self.state = State::WipeWaitInfo;
+                Ok(encrypted_transmit(bytes).into())
+            }
             BitBoxCommand::RestoreFromMnemonic {
                 timestamp,
                 timezone_offset,
@@ -1168,6 +1180,27 @@ where
                 self.state = State::Finished(BitBoxResponse::DeviceAction(true));
                 Ok(None)
             }
+            State::WipeWaitInfo => {
+                let response = self.decode_encrypted_response(data)?;
+                let info = match response {
+                    pb::response::Response::DeviceInfo(info) => info,
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                };
+                if !info.initialized {
+                    return Err(BitBoxError::InvalidInput(
+                        "The BitBox02 must be initialized first.",
+                    )
+                    .into());
+                }
+                let bytes = self.build_encrypted(api::reset_request())?;
+                self.state = State::WipeWaitReset;
+                Ok(Some(encrypted_transmit(bytes).into()))
+            }
+            State::WipeWaitReset => {
+                let success = self.decode_device_action_response(data)?;
+                self.state = State::Finished(BitBoxResponse::DeviceAction(success));
+                Ok(None)
+            }
         }
     }
 
@@ -1206,6 +1239,7 @@ impl TryFrom<Command> for BitBoxCommand {
                     timezone_offset,
                 })
             }
+            Command::Wipe => Ok(BitBoxCommand::Wipe),
             Command::Unlock { .. } => Ok(BitBoxCommand::UnlockAndPair),
             Command::GetVersion => Ok(BitBoxCommand::GetVersion),
             Command::GetMasterFingerprint => Ok(BitBoxCommand::GetMasterFingerprint),
@@ -1481,6 +1515,14 @@ mod tests {
         assert!(matches!(
             Response::from(BitBoxResponse::DeviceAction(false)),
             Response::DeviceAction(false)
+        ));
+    }
+
+    #[test]
+    fn common_wipe_maps_to_bitbox_wipe() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::Wipe),
+            Ok(BitBoxCommand::Wipe)
         ));
     }
 

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -12,13 +12,13 @@ use crate::common::{
 };
 
 use super::api;
-use super::error::BitBoxError;
+use super::error::{BitBoxDeviceError, BitBoxError};
 use super::noise::{HandshakeState, NoiseState};
 use super::proto as pb;
 use super::sign::{OurKey, Transaction, TxOutput, apply_signatures, is_schnorr};
 use super::{
-    OP_HER_COMEZ_TEH_HANDSHAEK, OP_I_CAN_HAS_HANDSHAEK, OP_I_CAN_HAS_PAIRIN_VERIFICASHUN,
-    OP_NOISE_MSG, OP_UNLOCK, RESPONSE_SUCCESS,
+    ManagementContext, OP_HER_COMEZ_TEH_HANDSHAEK, OP_I_CAN_HAS_HANDSHAEK,
+    OP_I_CAN_HAS_PAIRIN_VERIFICASHUN, OP_NOISE_MSG, OP_UNLOCK, RESPONSE_SUCCESS, SetupMode,
 };
 use super::{antiklepto, policy};
 
@@ -76,6 +76,13 @@ pub enum BitBoxCommand {
         index: u32,
         display: bool,
     },
+    /// Initialize an unseeded BitBox02.
+    Setup {
+        label: String,
+        mode: SetupMode,
+        timestamp: u32,
+        timezone_offset: i32,
+    },
     /// Restore the device from its currently-loaded mnemonic (simulator seeding).
     RestoreFromMnemonic {
         timestamp: u32,
@@ -88,6 +95,7 @@ pub enum BitBoxCommand {
 #[derive(Debug)]
 pub enum BitBoxResponse {
     TaskDone,
+    DeviceAction(bool),
     Info(Info),
     MasterFingerprint(Fingerprint),
     Xpub(Xpub),
@@ -125,7 +133,23 @@ enum State {
     },
     // Descriptor address: first fetch our fingerprint to resolve the account keypath.
     ShowAddrWaitFingerprint(ShowAddrInit),
+    // Stateful setup flow.
+    SetupWaitInfo(SetupInit),
+    SetupWaitName(SetupInit),
+    SetupWaitPassword {
+        timestamp: u32,
+        timezone_offset: i32,
+    },
+    SetupWaitBackup,
+    SetupWaitRestore,
     Finished(BitBoxResponse),
+}
+
+struct SetupInit {
+    label: String,
+    mode: SetupMode,
+    timestamp: u32,
+    timezone_offset: i32,
 }
 
 struct SignInit {
@@ -567,20 +591,69 @@ impl<C, T, R, E> BitBoxInterpreter<'_, C, T, R, E> {
         Ok(bytes)
     }
 
+    fn decode_encrypted_response(
+        &mut self,
+        data: Vec<u8>,
+    ) -> Result<pb::response::Response, BitBoxError> {
+        let body = expect_success(&data)?;
+        let decrypted = self.noise.decrypt(body)?;
+        api::decode_response(&decrypted)
+    }
+
+    fn decode_device_action_response(&mut self, data: Vec<u8>) -> Result<bool, BitBoxError> {
+        let body = expect_success(&data)?;
+        let decrypted = self.noise.decrypt(body)?;
+        let response = pb::Response::decode(decrypted.as_slice())?;
+        match response.response {
+            Some(pb::response::Response::Success(_)) => Ok(true),
+            Some(pb::response::Response::Error(pb::Error { code, .. })) => {
+                let error = BitBoxDeviceError::from_code(code);
+                if error == BitBoxDeviceError::Generic {
+                    Ok(false)
+                } else {
+                    Err(error.into())
+                }
+            }
+            _ => Err(BitBoxError::UnexpectedResponse),
+        }
+    }
+
+    fn start_setup_initialization(&mut self, setup: SetupInit) -> Result<Vec<u8>, BitBoxError> {
+        let SetupInit {
+            mode,
+            timestamp,
+            timezone_offset,
+            ..
+        } = setup;
+        let request = match mode {
+            SetupMode::NewWallet { entropy } => {
+                self.state = State::SetupWaitPassword {
+                    timestamp,
+                    timezone_offset,
+                };
+                api::set_password_request(entropy.as_bytes())
+            }
+            SetupMode::RestoreFromMnemonic => {
+                self.state = State::SetupWaitRestore;
+                api::restore_from_mnemonic_request(timestamp, timezone_offset)
+            }
+        };
+        self.build_encrypted(request)
+    }
+
     fn handle_encrypted_response(
         &mut self,
         ctx: EncryptedContext,
         data: Vec<u8>,
     ) -> Result<BitBoxResponse, BitBoxError> {
-        let body = expect_success(&data)?;
-        let decrypted = self.noise.decrypt(body)?;
-        let response = api::decode_response(&decrypted)?;
+        let response = self.decode_encrypted_response(data)?;
         use pb::response::Response as R;
         match (ctx, response) {
             (EncryptedContext::Version, R::DeviceInfo(info)) => Ok(BitBoxResponse::Info(Info {
                 version: info.version,
                 networks: vec![],
                 firmware: Some(info.name),
+                initialized: Some(info.initialized),
             })),
             (EncryptedContext::MasterFingerprint, R::Fingerprint(f)) => {
                 if f.fingerprint.len() != 4 {
@@ -790,6 +863,24 @@ where
                     change,
                     index,
                     display,
+                });
+                Ok(encrypted_transmit(bytes).into())
+            }
+            BitBoxCommand::Setup {
+                label,
+                mode,
+                timestamp,
+                timezone_offset,
+            } => {
+                if !self.noise.is_paired() {
+                    return Err(BitBoxError::Noise("not paired").into());
+                }
+                let bytes = self.build_encrypted(api::device_info_request())?;
+                self.state = State::SetupWaitInfo(SetupInit {
+                    label,
+                    mode,
+                    timestamp,
+                    timezone_offset,
                 });
                 Ok(encrypted_transmit(bytes).into())
             }
@@ -1022,6 +1113,61 @@ where
                 self.state = State::WaitEncryptedResponse(EncryptedContext::Address);
                 Ok(Some(encrypted_transmit(bytes).into()))
             }
+            State::SetupWaitInfo(setup) => {
+                let response = self.decode_encrypted_response(data)?;
+                let info = match response {
+                    pb::response::Response::DeviceInfo(info) => info,
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                };
+                if info.initialized {
+                    return Err(BitBoxError::InvalidInput(
+                        "The BitBox02 must be wiped before setup.",
+                    )
+                    .into());
+                }
+                if setup.label.is_empty() {
+                    let bytes = self.start_setup_initialization(setup)?;
+                    Ok(Some(encrypted_transmit(bytes).into()))
+                } else {
+                    let bytes = self.build_encrypted(api::set_device_name_request(&setup.label))?;
+                    self.state = State::SetupWaitName(setup);
+                    Ok(Some(encrypted_transmit(bytes).into()))
+                }
+            }
+            State::SetupWaitName(setup) => {
+                match self.decode_encrypted_response(data)? {
+                    pb::response::Response::Success(_) => {}
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                }
+                let bytes = self.start_setup_initialization(setup)?;
+                Ok(Some(encrypted_transmit(bytes).into()))
+            }
+            State::SetupWaitPassword {
+                timestamp,
+                timezone_offset,
+            } => {
+                if !self.decode_device_action_response(data)? {
+                    self.state = State::Finished(BitBoxResponse::DeviceAction(false));
+                    return Ok(None);
+                }
+                let bytes =
+                    self.build_encrypted(api::create_backup_request(timestamp, timezone_offset))?;
+                self.state = State::SetupWaitBackup;
+                Ok(Some(encrypted_transmit(bytes).into()))
+            }
+            State::SetupWaitBackup => {
+                let success = self.decode_device_action_response(data)?;
+                self.state = State::Finished(BitBoxResponse::DeviceAction(success));
+                Ok(None)
+            }
+            State::SetupWaitRestore => {
+                match self.decode_encrypted_response(data)? {
+                    pb::response::Response::Success(_) => {}
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                }
+                self.state = State::Finished(BitBoxResponse::DeviceAction(true));
+                Ok(None)
+            }
         }
     }
 
@@ -1037,6 +1183,29 @@ impl TryFrom<Command> for BitBoxCommand {
     type Error = BitBoxError;
     fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
+            Command::Setup(options, context) => {
+                if !options.backup_passphrase.is_empty() {
+                    return Err(BitBoxError::InvalidInput(
+                        "Passphrase not needed when setting up a BitBox02.",
+                    ));
+                }
+                let Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                    mode,
+                    timestamp,
+                    timezone_offset,
+                })) = context
+                else {
+                    return Err(BitBoxError::InvalidInput(
+                        "BitBox setup requires DeviceContext::BitBoxManagement",
+                    ));
+                };
+                Ok(BitBoxCommand::Setup {
+                    label: options.label,
+                    mode,
+                    timestamp,
+                    timezone_offset,
+                })
+            }
             Command::Unlock { .. } => Ok(BitBoxCommand::UnlockAndPair),
             Command::GetVersion => Ok(BitBoxCommand::GetVersion),
             Command::GetMasterFingerprint => Ok(BitBoxCommand::GetMasterFingerprint),
@@ -1126,6 +1295,7 @@ impl From<BitBoxResponse> for Response {
     fn from(res: BitBoxResponse) -> Response {
         match res {
             BitBoxResponse::TaskDone => Response::TaskDone,
+            BitBoxResponse::DeviceAction(success) => Response::DeviceAction(success),
             BitBoxResponse::Info(info) => Response::Info(info),
             BitBoxResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
             BitBoxResponse::Xpub(xpub) => Response::Xpub(xpub),
@@ -1257,6 +1427,61 @@ mod tests {
     fn common_backup_maps_to_bitbox_backup() {
         let command = BitBoxCommand::try_from(Command::Backup).unwrap();
         assert!(matches!(command, BitBoxCommand::Backup));
+    }
+
+    #[test]
+    fn common_setup_maps_to_bitbox_setup() {
+        let command = BitBoxCommand::try_from(Command::Setup(
+            crate::common::SetupOptions {
+                label: "BHWI".into(),
+                backup_passphrase: String::new(),
+            },
+            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                mode: SetupMode::NewWallet {
+                    entropy: super::super::SetupEntropy::new([42; 32]),
+                },
+                timestamp: 1_601_450_521,
+                timezone_offset: 3_600,
+            })),
+        ))
+        .unwrap();
+        assert!(matches!(
+            command,
+            BitBoxCommand::Setup {
+                label,
+                mode: SetupMode::NewWallet { .. },
+                timestamp: 1_601_450_521,
+                timezone_offset: 3_600,
+            } if label == "BHWI"
+        ));
+    }
+
+    #[test]
+    fn common_setup_requires_context_and_rejects_passphrase() {
+        let missing_context =
+            BitBoxCommand::try_from(Command::Setup(crate::common::SetupOptions::default(), None));
+        assert!(matches!(missing_context, Err(BitBoxError::InvalidInput(_))));
+
+        let passphrase = BitBoxCommand::try_from(Command::Setup(
+            crate::common::SetupOptions {
+                label: String::new(),
+                backup_passphrase: "secret".into(),
+            },
+            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                mode: SetupMode::RestoreFromMnemonic,
+                timestamp: 0,
+                timezone_offset: 0,
+            })),
+        ));
+        assert!(matches!(passphrase, Err(BitBoxError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn bitbox_setup_response_maps_to_device_action() {
+        assert!(matches!(
+            Response::from(BitBoxResponse::DeviceAction(false)),
+            Response::DeviceAction(false)
+        ));
     }
 
     #[test]

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -91,6 +91,8 @@ pub enum BitBoxCommand {
         timestamp: u32,
         timezone_offset: i32,
     },
+    /// Toggle the device's mnemonic-passphrase setting.
+    TogglePassphrase,
     /// Restore the device from its currently-loaded mnemonic (simulator seeding).
     RestoreFromMnemonic {
         timestamp: u32,
@@ -155,6 +157,8 @@ enum State {
     RestoreWaitInfo(RestoreInit),
     RestoreWaitName(RestoreInit),
     RestoreWaitMnemonic,
+    TogglePassphraseWaitInfo,
+    TogglePassphraseWaitSet,
     Finished(BitBoxResponse),
 }
 
@@ -927,6 +931,14 @@ where
                 });
                 Ok(encrypted_transmit(bytes).into())
             }
+            BitBoxCommand::TogglePassphrase => {
+                if !self.noise.is_paired() {
+                    return Err(BitBoxError::Noise("not paired").into());
+                }
+                let bytes = self.build_encrypted(api::device_info_request())?;
+                self.state = State::TogglePassphraseWaitInfo;
+                Ok(encrypted_transmit(bytes).into())
+            }
             BitBoxCommand::RestoreFromMnemonic {
                 timestamp,
                 timezone_offset,
@@ -1278,6 +1290,32 @@ where
                 self.state = State::Finished(BitBoxResponse::DeviceAction(true));
                 Ok(None)
             }
+            State::TogglePassphraseWaitInfo => {
+                let response = self.decode_encrypted_response(data)?;
+                let info = match response {
+                    pb::response::Response::DeviceInfo(info) => info,
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                };
+                if !info.initialized {
+                    return Err(BitBoxError::InvalidInput(
+                        "The BitBox02 must be initialized first.",
+                    )
+                    .into());
+                }
+                let bytes = self.build_encrypted(api::set_mnemonic_passphrase_enabled_request(
+                    !info.mnemonic_passphrase_enabled,
+                ))?;
+                self.state = State::TogglePassphraseWaitSet;
+                Ok(Some(encrypted_transmit(bytes).into()))
+            }
+            State::TogglePassphraseWaitSet => {
+                match self.decode_encrypted_response(data)? {
+                    pb::response::Response::Success(_) => {}
+                    _ => return Err(BitBoxError::UnexpectedResponse.into()),
+                }
+                self.state = State::Finished(BitBoxResponse::DeviceAction(true));
+                Ok(None)
+            }
         }
     }
 
@@ -1333,6 +1371,7 @@ impl TryFrom<Command> for BitBoxCommand {
                     timezone_offset,
                 })
             }
+            Command::TogglePassphrase => Ok(BitBoxCommand::TogglePassphrase),
             Command::Unlock { .. } => Ok(BitBoxCommand::UnlockAndPair),
             Command::GetVersion => Ok(BitBoxCommand::GetVersion),
             Command::GetMasterFingerprint => Ok(BitBoxCommand::GetMasterFingerprint),
@@ -1652,6 +1691,14 @@ mod tests {
                 None,
             )),
             Err(BitBoxError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn common_toggle_passphrase_maps_to_bitbox_command() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::TogglePassphrase),
+            Ok(BitBoxCommand::TogglePassphrase)
         ));
     }
 

--- a/bhwi/src/bitbox/mod.rs
+++ b/bhwi/src/bitbox/mod.rs
@@ -54,6 +54,10 @@ pub enum ManagementContext {
         timestamp: u32,
         timezone_offset: i32,
     },
+    Restore {
+        timestamp: u32,
+        timezone_offset: i32,
+    },
 }
 
 /// USB VID/PID of the BitBox02.

--- a/bhwi/src/bitbox/mod.rs
+++ b/bhwi/src/bitbox/mod.rs
@@ -10,6 +10,52 @@ pub mod u2f;
 
 pub use interpreter::{BitBoxCommand, BitBoxInterpreter, BitBoxResponse};
 
+use std::fmt;
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Host entropy used when initializing a new BitBox02 wallet.
+///
+/// The custom `Debug` implementation prevents seed material from being exposed by callers
+/// logging a command or device context.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct SetupEntropy([u8; 32]);
+
+impl SetupEntropy {
+    pub fn new(entropy: [u8; 32]) -> Self {
+        Self(entropy)
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SetupEntropy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SetupEntropy([REDACTED])")
+    }
+}
+
+/// Device-specific setup behavior selected by the transport-facing caller.
+#[derive(Clone, Debug)]
+pub enum SetupMode {
+    /// Initialize a physical device with fresh host entropy, then create its backup.
+    NewWallet { entropy: SetupEntropy },
+    /// Run the device's mnemonic restore flow. The simulator uses its fixed test mnemonic.
+    RestoreFromMnemonic,
+}
+
+/// External data needed by BitBox02 management commands while keeping the interpreter sans-I/O.
+#[derive(Clone, Debug)]
+pub enum ManagementContext {
+    Setup {
+        mode: SetupMode,
+        timestamp: u32,
+        timezone_offset: i32,
+    },
+}
+
 /// USB VID/PID of the BitBox02.
 pub const BITBOX02_VID: u16 = 0x03eb;
 pub const BITBOX02_PID: u16 = 0x2403;
@@ -33,3 +79,16 @@ pub const OP_HER_COMEZ_TEH_HANDSHAEK: u8 = b'H';
 pub const OP_I_CAN_HAS_PAIRIN_VERIFICASHUN: u8 = b'v';
 pub const OP_NOISE_MSG: u8 = b'n';
 pub const RESPONSE_SUCCESS: u8 = 0x00;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_entropy_debug_is_redacted() {
+        let entropy = SetupEntropy::new([42; 32]);
+        let debug = format!("{entropy:?}");
+        assert_eq!(debug, "SetupEntropy([REDACTED])");
+        assert!(!debug.contains("42"));
+    }
+}

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -578,6 +578,9 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::Setup(..) => Err(ColdcardError::MissingCommandInfo(
                 "Setup not supported by Coldcard",
             )),
+            Command::Wipe => Err(ColdcardError::MissingCommandInfo(
+                "Wipe not supported by Coldcard",
+            )),
             Command::Backup => Ok(Self::Backup),
             Command::Unlock { .. } => Ok(Self::StartEncryption),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -575,6 +575,9 @@ impl TryFrom<Command> for ColdcardCommand {
     type Error = ColdcardError;
     fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
+            Command::Setup(..) => Err(ColdcardError::MissingCommandInfo(
+                "Setup not supported by Coldcard",
+            )),
             Command::Backup => Ok(Self::Backup),
             Command::Unlock { .. } => Ok(Self::StartEncryption),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
@@ -836,6 +839,7 @@ impl From<ColdcardResponse> for Response {
                 version: version.as_str().into(),
                 networks: vec![],
                 firmware: Some(device_model),
+                initialized: None,
             }),
             ColdcardResponse::MyPub { encryption_key, .. } => {
                 Response::EncryptionKey(encryption_key)

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -581,6 +581,9 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::Wipe => Err(ColdcardError::MissingCommandInfo(
                 "Wipe not supported by Coldcard",
             )),
+            Command::Restore(..) => Err(ColdcardError::MissingCommandInfo(
+                "Restore not supported by Coldcard",
+            )),
             Command::Backup => Ok(Self::Backup),
             Command::Unlock { .. } => Ok(Self::StartEncryption),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -584,6 +584,9 @@ impl TryFrom<Command> for ColdcardCommand {
             Command::Restore(..) => Err(ColdcardError::MissingCommandInfo(
                 "Restore not supported by Coldcard",
             )),
+            Command::TogglePassphrase => Err(ColdcardError::MissingCommandInfo(
+                "Toggle passphrase not supported by Coldcard",
+            )),
             Command::Backup => Ok(Self::Backup),
             Command::Unlock { .. } => Ok(Self::StartEncryption),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -85,6 +85,7 @@ pub enum Command {
     Setup(SetupOptions, Option<DeviceContext>),
     Wipe,
     Restore(RestoreOptions, Option<DeviceContext>),
+    TogglePassphrase,
     GetMasterFingerprint,
     GetVersion,
     GetXpub {

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -68,6 +68,7 @@ pub enum MultisigAddressType {
 pub enum Command {
     Backup,
     Setup(SetupOptions, Option<DeviceContext>),
+    Wipe,
     GetMasterFingerprint,
     GetVersion,
     GetXpub {

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -13,6 +13,12 @@ pub struct UnlockOptions {
     pub network: Option<Network>,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct SetupOptions {
+    pub label: String,
+    pub backup_passphrase: String,
+}
+
 #[derive(Clone, Debug)]
 pub enum DisplayAddress {
     ByPath {
@@ -61,6 +67,7 @@ pub enum MultisigAddressType {
 #[allow(clippy::large_enum_variant)]
 pub enum Command {
     Backup,
+    Setup(SetupOptions, Option<DeviceContext>),
     GetMasterFingerprint,
     GetVersion,
     GetXpub {
@@ -95,10 +102,14 @@ pub enum DeviceContext {
     /// (with key origins) of the registered descriptor.
     #[cfg(feature = "bitbox")]
     BitBox { policy: WalletPolicy },
+    /// Required context for BitBox02 setup and restore operations.
+    #[cfg(feature = "bitbox")]
+    BitBoxManagement(bitbox::ManagementContext),
 }
 
 pub enum Response {
     Backup(DeviceBackup),
+    DeviceAction(bool),
     TaskDone,
     TaskBusy,
     Info(Info),
@@ -138,6 +149,8 @@ pub struct Info {
     pub version: String,
     pub networks: Vec<Network>,
     pub firmware: Option<String>,
+    /// Whether the device has initialized wallet material, when reported by the firmware.
+    pub initialized: Option<bool>,
 }
 
 pub enum Recipient {

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -20,6 +20,21 @@ pub struct SetupOptions {
 }
 
 #[derive(Clone, Debug)]
+pub struct RestoreOptions {
+    pub label: String,
+    pub word_count: i32,
+}
+
+impl Default for RestoreOptions {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            word_count: 24,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum DisplayAddress {
     ByPath {
         path: DerivationPath,
@@ -69,6 +84,7 @@ pub enum Command {
     Backup,
     Setup(SetupOptions, Option<DeviceContext>),
     Wipe,
+    Restore(RestoreOptions, Option<DeviceContext>),
     GetMasterFingerprint,
     GetVersion,
     GetXpub {

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -531,6 +531,9 @@ impl TryFrom<Command> for JadeCommand {
             Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
             Command::Wipe => Err(Error::MissingCommandInfo("Wipe not supported by Jade")),
             Command::Restore(..) => Err(Error::MissingCommandInfo("Restore not supported by Jade")),
+            Command::TogglePassphrase => Err(Error::MissingCommandInfo(
+                "Toggle passphrase not supported by Jade",
+            )),
             Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
             Command::Unlock { .. } => Ok(Self::Auth),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -528,6 +528,7 @@ impl TryFrom<Command> for JadeCommand {
 
     fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
+            Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
             Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
             Command::Unlock { .. } => Ok(Self::Auth),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
@@ -667,6 +668,7 @@ impl From<JadeResponse> for Response {
                 version: info.jade_version.as_str().into(),
                 networks: info.jade_networks.into(),
                 firmware: None,
+                initialized: None,
             }),
             JadeResponse::Address(address) => Response::Address(address),
             JadeResponse::RegisteredDescriptor => {

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -529,6 +529,7 @@ impl TryFrom<Command> for JadeCommand {
     fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
             Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
+            Command::Wipe => Err(Error::MissingCommandInfo("Wipe not supported by Jade")),
             Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
             Command::Unlock { .. } => Ok(Self::Auth),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -530,6 +530,7 @@ impl TryFrom<Command> for JadeCommand {
         match cmd {
             Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
             Command::Wipe => Err(Error::MissingCommandInfo("Wipe not supported by Jade")),
+            Command::Restore(..) => Err(Error::MissingCommandInfo("Restore not supported by Jade")),
             Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
             Command::Unlock { .. } => Ok(Self::Auth),
             Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -803,6 +803,9 @@ impl TryFrom<Command> for LedgerCommand {
             Command::Setup(..) => Err(LedgerError::MissingCommandInfo(
                 "Setup not supported by Ledger",
             )),
+            Command::Wipe => Err(LedgerError::MissingCommandInfo(
+                "Wipe not supported by Ledger",
+            )),
             Command::Backup => Err(LedgerError::MissingCommandInfo(
                 "Backup not supported by Ledger",
             )),

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -806,6 +806,9 @@ impl TryFrom<Command> for LedgerCommand {
             Command::Wipe => Err(LedgerError::MissingCommandInfo(
                 "Wipe not supported by Ledger",
             )),
+            Command::Restore(..) => Err(LedgerError::MissingCommandInfo(
+                "Restore not supported by Ledger",
+            )),
             Command::Backup => Err(LedgerError::MissingCommandInfo(
                 "Backup not supported by Ledger",
             )),

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -809,6 +809,9 @@ impl TryFrom<Command> for LedgerCommand {
             Command::Restore(..) => Err(LedgerError::MissingCommandInfo(
                 "Restore not supported by Ledger",
             )),
+            Command::TogglePassphrase => Err(LedgerError::MissingCommandInfo(
+                "Toggle passphrase not supported by Ledger",
+            )),
             Command::Backup => Err(LedgerError::MissingCommandInfo(
                 "Backup not supported by Ledger",
             )),

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -800,6 +800,9 @@ impl TryFrom<Command> for LedgerCommand {
     type Error = LedgerError;
     fn try_from(cmd: Command) -> Result<Self, Self::Error> {
         match cmd {
+            Command::Setup(..) => Err(LedgerError::MissingCommandInfo(
+                "Setup not supported by Ledger",
+            )),
             Command::Backup => Err(LedgerError::MissingCommandInfo(
                 "Backup not supported by Ledger",
             )),
@@ -853,6 +856,7 @@ impl From<LedgerResponse> for Response {
                 version: res.version.to_string(),
                 networks: vec![res.network()],
                 firmware: Some(res.app_name),
+                initialized: None,
             }),
             LedgerResponse::Signature(header, signature) => Response::Signature(header, signature),
             LedgerResponse::TaskDone => Response::TaskDone,

--- a/docs/BITBOX.md
+++ b/docs/BITBOX.md
@@ -23,15 +23,34 @@ is required.
 ## CLI e2e
 
 The `bhwi` CLI reaches the simulator over TCP through the BitBox02 emulator path
-(`tcp:127.0.0.1:15423`). The CLI has no restore command, so seed the simulator
-by running the package e2e first, then run the CLI e2e against the seeded
-device:
+(`tcp:127.0.0.1:15423`). Use the native global selectors for stateful commands
+that must address an uninitialized device without a fingerprint:
+
+```sh
+bhwi --device-type bitbox02 --device-path tcp:127.0.0.1:15423 device setup
+bhwi --device-type bitbox02 --device-path tcp:127.0.0.1:15423 device wipe
+bhwi --device-type bitbox02 --device-path tcp:127.0.0.1:15423 device restore
+bhwi --device-type bitbox02 --device-path tcp:127.0.0.1:15423 device toggle-passphrase
+```
+
+Successful action commands are quiet by default; add `--format json` for a
+structured success response. `setup` and `restore` accept `--label`. Python-HWI
+compatibility keeps its upstream command names and flags, including
+`togglepassphrase`, `--interactive`, `--word_count`, and
+`--backup_passphrase` validation.
+
+The regular seeded-device CLI suite remains:
 
 ```sh
 cargo build -p bhwi-cli
 BHWI_BIN="$PWD/target/debug/bhwi" nix develop .#bitbox \
   -c cargo test -p bhwi-e2e-cli bitbox -- --test-threads=1
 ```
+
+CI additionally runs the ignored setup/wipe and restore lifecycle tests against
+fresh simulator processes. A successful wipe resets the firmware before it can
+reply and leaves this simulator version in its reset loop, so the test harness
+restarts it before continuing.
 
 ## Upstream references
 

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -32,13 +32,13 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 |`signtx`          |`[~]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Ledger registered-wallet and non-default policy signing remains open. |
 |`signmessage`     |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for emulator-supported paths.                                 |
 |`displayaddress`  |`[x]` |`[x]`|`[~]`   |`[ ]` |`[ ]`  |`n/a`   |`[x]`   |Coldcard registered multisig display coverage remains open.           |
-|`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software setup for the unchecked devices.         |
-|`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[ ]`   |Python HWI supports software wipe for the unchecked devices.          |
-|`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
+|`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Physical setup uses fresh entropy and backup; simulator setup is covered end to end.|
+|`wipe`            |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |BitBox02 reset-disconnect behavior is covered by a stateful lifecycle.|
+|`restore`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[x]`   |Python HWI support excludes Ledger, Jade, Coldcard, and BitBox01.     |
 |`backup`          |`n/a` |`n/a`|`[x]`   |`n/a` |`n/a`  |`[ ]`   |`[x]`   |Coldcard file backup and BitBox02 mnemonic-export backup are covered. BitBox01 remains open.|
 |`promptpin`       |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
 |`sendpin`         |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
-|`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[ ]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
+|`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`n/a`   |`[x]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
 |`installudevrules`|`n/a` |`n/a`|`n/a`   |`n/a` |`n/a`  |`n/a`   |`n/a`   |Host-side Python HWI command covered by the shared udev installer.    |
 
 ## Running Parity Tests

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -81,7 +81,14 @@ pinned reference backend probes `127.0.0.1:15423`, so the BitBox emulator must b
 running and initialized before `hwi-parity-bitbox` starts.
 
 The suite covers the same implemented read/sign/display command set as the
-other wired devices, plus BitBox02 mnemonic-export `backup`. The remaining
-stateful BitBox device-management commands (`setup`, `wipe`, `restore`,
-`togglepassphrase`) stay as tracked gaps because BHWI has not claimed that
-compatibility surface yet.
+other wired devices, plus BitBox02 mnemonic-export `backup` and the stateful
+device-management commands `setup`, `wipe`, `restore`, and
+`togglepassphrase`. Differential tests cover management errors and toggle the
+passphrase setting through both implementations, returning it to its original
+state. Dedicated CLI lifecycle tests start fresh uninitialized simulators to
+exercise successful setup, wipe, and restore flows.
+
+The simulator deliberately stops replying after a successful factory reset.
+CI therefore treats only a read-side disconnect after the reset request as
+success, stops that simulator process, waits for its fixed TCP port to become
+reusable, and starts a fresh process for the restore lifecycle.

--- a/e2e/cli/src/bitbox.rs
+++ b/e2e/cli/src/bitbox.rs
@@ -5,6 +5,42 @@ use crate::support::{Cli, CommandCase, ExpectedOutput, assert_command};
 // The BitBox02 simulator restores a fixed mnemonic, so its master fingerprint is
 // deterministic (network-independent). See `e2e/bitbox` for the seed details.
 const BITBOX_FINGERPRINT: &str = "4c00739d";
+const BITBOX_PATH: &str = "tcp:127.0.0.1:15423";
+
+fn management_cli() -> Cli {
+    Cli::global().with_args(["--device-type", "bitbox02", "--device-path", BITBOX_PATH])
+}
+
+#[test]
+#[ignore = "requires a fresh uninitialized simulator and ends by resetting it"]
+fn bitbox_setup_management_lifecycle() -> Result<()> {
+    let cli = management_cli();
+
+    assert_eq!(cli.run_ok(["device", "list"])?, format!("{BITBOX_PATH}\n"));
+    assert!(
+        cli.run_ok(["device", "setup", "--label", "BHWI Setup"])?
+            .is_empty()
+    );
+    assert_eq!(cli.run_ok(["device", "list"])?.trim(), BITBOX_FINGERPRINT);
+    assert!(cli.run_ok(["device", "toggle-passphrase"])?.is_empty());
+    assert!(cli.run_ok(["device", "toggle-passphrase"])?.is_empty());
+    assert!(cli.run_ok(["device", "wipe"])?.is_empty());
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires a fresh uninitialized simulator"]
+fn bitbox_restore_management_lifecycle() -> Result<()> {
+    let cli = management_cli();
+
+    assert_eq!(cli.run_ok(["device", "list"])?, format!("{BITBOX_PATH}\n"));
+    assert!(
+        cli.run_ok(["device", "restore", "--label", "BHWI Restore"])?
+            .is_empty()
+    );
+    assert_eq!(cli.run_ok(["device", "list"])?.trim(), BITBOX_FINGERPRINT);
+    Ok(())
+}
 
 #[test]
 fn bitbox_device_list() -> Result<()> {

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -528,6 +528,47 @@ mod tests {
     }
 
     #[test]
+    fn candidate_bitbox_management_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err()
+            || expected_device_type_from_env()?.as_deref() != Some("bitbox02")
+        {
+            return Ok(());
+        }
+
+        let base = [
+            "--emulators",
+            "--chain",
+            "test",
+            "--device-type",
+            "bitbox02",
+        ];
+        for command in [
+            vec!["setup"],
+            vec![
+                "--interactive",
+                "setup",
+                "--backup_passphrase",
+                "backup passphrase",
+            ],
+            vec!["--interactive", "setup", "--label", "Already initialized"],
+            vec!["restore"],
+            vec!["--interactive", "restore", "--word_count", "12"],
+        ] {
+            assert_error_json_parity(base.into_iter().chain(command).map(str::to_owned).collect())?;
+        }
+
+        // The reference toggles the setting once and the candidate toggles it back, so the
+        // shared simulator is returned to its original state after the parity assertion.
+        assert_json_parity(
+            base.into_iter()
+                .chain(["togglepassphrase"])
+                .map(str::to_owned)
+                .collect::<Vec<_>>(),
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn candidate_installudevrules_matches_reference_or_avoids_getlogin_failure() -> Result<()> {
         if env::var("HWI_BIN").is_err() {
             return Ok(());


### PR DESCRIPTION
## Stack

- Depends on #59.
- Merge only after #59 lands. This branch was created from the #59 head, so its displayed diff against `main` will automatically shrink to the BitBox management commits when #59 merges.

## Summary

- Add BitBox02 `setup`, `wipe`, `restore`, and `togglepassphrase` support through the core interpreter, async API, HWI-compatible CLI, and native CLI.
- Handle initialized-state checks, reset-time transport disconnects, and uninitialized-device discovery.
- Add HWI differential coverage and fresh-simulator lifecycle tests for setup/toggle/wipe and restore.
- Mark the BitBox02 stateful management parity items complete in the docs.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
- `cargo test --verbose --no-default-features`
- `cargo test --verbose --color always -- --nocapture`
- `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
- `nix develop .#bitbox -c cargo test -p bhwi-e2e-bitbox -- --test-threads=1` (8 passed)
- BitBox CLI e2e suite (4 passed; stateful lifecycle tests are ignored by default)
- Fresh-simulator setup/toggle/wipe lifecycle (passed)
- Fresh-simulator restore lifecycle (passed)
- `nix run .#hwi-parity-bitbox -- -- --test-threads=1` (14 passed)
- `nix run .#hwi-upstream-bitbox` (15 passed, 1 upstream-authored skip)

The upstream HWI BitBox02 suite does not directly exercise these four management commands; the differential and lifecycle tests provide that coverage.