### PR TITLE
HWI parity: complete Ledger registered-wallet signing

### DIFF
--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -14,7 +14,7 @@ use bhwi::{
 };
 use bhwi_async::{DeviceBackup, DeviceContext, DisplayAddress, RestoreOptions, SetupOptions};
 use bitcoin::{
-    Network, NetworkKind, PublicKey, ScriptBuf,
+    Address, CompressedPublicKey, Network, NetworkKind, PublicKey, ScriptBuf, TxOut,
     base64::prelude::{BASE64_STANDARD, Engine as _},
     bip32::{ChildNumber, DerivationPath, Fingerprint, KeySource, Xpub},
     blockdata::{
@@ -22,7 +22,7 @@ use bitcoin::{
         script::{Instruction, PushBytes},
     },
     psbt::Input,
-    secp256k1::{PublicKey as SecpPublicKey, XOnlyPublicKey},
+    secp256k1::{PublicKey as SecpPublicKey, Secp256k1, XOnlyPublicKey},
 };
 use chrono::{Datelike, Local, Timelike};
 use clap::{ArgAction, ArgGroup, Parser, Subcommand, ValueEnum, error::ErrorKind};
@@ -1018,6 +1018,7 @@ async fn sign_tx(selector: DeviceSelector, psbt: String) -> HwiResponse {
         }
     };
 
+    let network = selector.network;
     let manager = DeviceManager::new(selector);
     let mut device = match manager.get_device_with_fingerprint().await {
         Ok(Some(device)) => device,
@@ -1036,24 +1037,52 @@ async fn sign_tx(selector: DeviceSelector, psbt: String) -> HwiResponse {
     };
 
     let original = parsed.to_string();
-    let context = if device.device_type() == DeviceType::Ledger {
-        match ledger_signing_context(&mut device, &parsed).await {
-            Ok(Some(context)) => Some(context),
-            Ok(None) => {
+    if device.device_type() == DeviceType::Ledger {
+        let contexts = match ledger_signing_contexts(&mut device, &parsed, network).await {
+            Ok(contexts) if contexts.is_empty() => {
                 return HwiResponse::SignTx(HwiSignTxResponse {
                     psbt: original,
                     signed: false,
                 });
             }
-            Err(err) => {
+            Ok(contexts) => contexts,
+            Err(LedgerSigningError::BadArgument(err)) => {
                 return HwiResponse::Error(HwiError::new(HwiErrorCode::BadArgument, err));
             }
-        }
-    } else {
-        None
-    };
+            Err(LedgerSigningError::Device(err)) => {
+                return HwiResponse::Error(HwiError::new(HwiErrorCode::DeviceConnectionError, err));
+            }
+        };
 
-    match device.device().sign_tx(parsed, context).await {
+        let mut signed_psbt = parsed;
+        for signing in contexts {
+            let mut signing_psbt = signed_psbt.clone();
+            if signing.address_type == LedgerAddressType::Legacy {
+                strip_legacy_witness_utxos(&mut signing_psbt);
+            }
+            let result = match device
+                .device()
+                .sign_tx(signing_psbt, Some(signing.context))
+                .await
+            {
+                Ok(psbt) => psbt,
+                Err(err) => {
+                    return HwiResponse::Error(HwiError::new(
+                        HwiErrorCode::DeviceConnectionError,
+                        err.to_string(),
+                    ));
+                }
+            };
+            merge_psbt_signatures(&mut signed_psbt, result);
+        }
+        let signed = signed_psbt.to_string();
+        return HwiResponse::SignTx(HwiSignTxResponse {
+            signed: signed != original,
+            psbt: signed,
+        });
+    }
+
+    match device.device().sign_tx(parsed, None).await {
         Ok(signed_psbt) => {
             let signed = signed_psbt.to_string();
             HwiResponse::SignTx(HwiSignTxResponse {
@@ -1542,144 +1571,552 @@ async fn get_keypool(selector: DeviceSelector, request: HwiGetKeypoolRequest) ->
     HwiResponse::GetKeypool(entries)
 }
 
-async fn ledger_signing_context(
-    device: &mut Device,
-    psbt: &Psbt,
-) -> Result<Option<DeviceContext>, String> {
-    let fingerprint = device.fingerprint().await.map_err(|err| err.to_string())?;
-    if let Some(context) = ledger_singlesig_context(device, psbt, fingerprint).await? {
-        return Ok(Some(context));
-    }
-    if let Some(context) = ledger_multisig_context(device, psbt, fingerprint).await? {
-        return Ok(Some(context));
-    }
-    Ok(None)
+#[derive(Debug)]
+enum LedgerSigningError {
+    BadArgument(String),
+    Device(String),
 }
 
-async fn ledger_singlesig_context(
-    device: &mut Device,
-    psbt: &Psbt,
-    fingerprint: Fingerprint,
-) -> Result<Option<DeviceContext>, String> {
-    let Some(path) = ledger_singlesig_account_path(psbt, fingerprint)? else {
-        return Ok(None);
-    };
-    let xpub = device
-        .device()
-        .get_extended_pubkey(path.clone(), false)
-        .await
-        .map_err(|err| err.to_string())?;
-    let policy = singlesig_wallet_policy(&extend_account_path_for_policy(&path), fingerprint, xpub)
-        .map_err(|err| err.to_string())?;
-    Ok(Some(DeviceContext::Ledger {
-        wallet_policy: LedgerWalletPolicy::new(String::new(), Version::V2, policy),
-        wallet_hmac: None,
-    }))
+struct LedgerSigningContext {
+    address_type: LedgerAddressType,
+    context: DeviceContext,
 }
 
-async fn ledger_multisig_context(
-    device: &mut Device,
-    psbt: &Psbt,
-    fingerprint: Fingerprint,
-) -> Result<Option<DeviceContext>, String> {
-    let Some(policy) = ledger_multisig_policy(psbt, fingerprint)? else {
-        return Ok(None);
-    };
-    let name = ledger_multisig_wallet_name(&policy);
-    let registration = device
-        .device()
-        .register_wallet(&name, &policy)
-        .await
-        .map_err(|err| err.to_string())?;
-    let hmac = registration
-        .hmac()
-        .ok_or_else(|| "Ledger wallet registration returned no HMAC".to_string())?;
-    let wallet_policy = WalletPolicy::from_str(&policy).map_err(|err| err.to_string())?;
-    Ok(Some(DeviceContext::Ledger {
-        wallet_policy: LedgerWalletPolicy::new(name, Version::V2, wallet_policy),
-        wallet_hmac: Some(hmac),
-    }))
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum LedgerAddressType {
+    Tap,
+    Wit,
+    ShWit,
+    Legacy,
 }
 
-fn ledger_singlesig_account_path(
-    psbt: &Psbt,
-    fingerprint: Fingerprint,
-) -> Result<Option<DerivationPath>, String> {
-    let mut account_path = None;
-    for input in &psbt.inputs {
-        if multisig_script(input).is_some() {
-            continue;
+impl LedgerAddressType {
+    fn priority(self) -> u8 {
+        match self {
+            Self::Tap => 0,
+            Self::Wit => 1,
+            Self::ShWit => 2,
+            Self::Legacy => 3,
         }
-        for (origin_fingerprint, path) in input.bip32_derivation.values() {
-            if *origin_fingerprint != fingerprint || !is_standard_singlesig_path(path) {
+    }
+
+    fn purpose(self) -> u32 {
+        match self {
+            Self::Legacy => 44,
+            Self::ShWit => 49,
+            Self::Wit => 84,
+            Self::Tap => 86,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum LedgerSigningPlan {
+    Default {
+        address_type: LedgerAddressType,
+        account_path: DerivationPath,
+    },
+    Registered {
+        address_type: LedgerAddressType,
+        name: String,
+        policy: String,
+    },
+}
+
+impl LedgerSigningPlan {
+    fn priority(&self) -> u8 {
+        match self {
+            Self::Default { address_type, .. } | Self::Registered { address_type, .. } => {
+                address_type.priority()
+            }
+        }
+    }
+}
+
+async fn ledger_signing_contexts(
+    device: &mut Device,
+    psbt: &Psbt,
+    network: Network,
+) -> Result<Vec<LedgerSigningContext>, LedgerSigningError> {
+    let fingerprint = device
+        .fingerprint()
+        .await
+        .map_err(|err| LedgerSigningError::Device(err.to_string()))?;
+    let plans = ledger_signing_plans(psbt, fingerprint, network)
+        .map_err(LedgerSigningError::BadArgument)?;
+    let mut contexts = Vec::with_capacity(plans.len());
+
+    for plan in plans {
+        match plan {
+            LedgerSigningPlan::Default {
+                address_type,
+                account_path,
+            } => {
+                let xpub = device
+                    .device()
+                    .get_extended_pubkey(account_path.clone(), false)
+                    .await
+                    .map_err(|err| LedgerSigningError::Device(err.to_string()))?;
+                let policy = singlesig_wallet_policy(
+                    &extend_account_path_for_policy(&account_path),
+                    fingerprint,
+                    xpub,
+                )
+                .map_err(|err| LedgerSigningError::BadArgument(err.to_string()))?;
+                contexts.push(LedgerSigningContext {
+                    address_type,
+                    context: DeviceContext::Ledger {
+                        wallet_policy: LedgerWalletPolicy::new(String::new(), Version::V2, policy),
+                        wallet_hmac: None,
+                    },
+                });
+            }
+            LedgerSigningPlan::Registered {
+                address_type,
+                name,
+                policy,
+            } => {
+                let registration = device
+                    .device()
+                    .register_wallet(&name, &policy)
+                    .await
+                    .map_err(|err| LedgerSigningError::Device(err.to_string()))?;
+                let hmac = registration.hmac().ok_or_else(|| {
+                    LedgerSigningError::Device(
+                        "Ledger wallet registration returned no HMAC".to_string(),
+                    )
+                })?;
+                if hmac.len() != 32 {
+                    return Err(LedgerSigningError::Device(format!(
+                        "Ledger wallet registration returned a {}-byte HMAC instead of 32 bytes",
+                        hmac.len()
+                    )));
+                }
+                let wallet_policy = WalletPolicy::from_str(&policy)
+                    .map_err(|err| LedgerSigningError::BadArgument(err.to_string()))?;
+                contexts.push(LedgerSigningContext {
+                    address_type,
+                    context: DeviceContext::Ledger {
+                        wallet_policy: LedgerWalletPolicy::new(name, Version::V2, wallet_policy),
+                        wallet_hmac: Some(hmac),
+                    },
+                });
+            }
+        }
+    }
+
+    Ok(contexts)
+}
+
+fn strip_legacy_witness_utxos(psbt: &mut Psbt) {
+    for (index, input) in psbt.inputs.iter_mut().enumerate() {
+        let Some(utxo) = input.non_witness_utxo.as_ref().and_then(|tx| {
+            tx.output
+                .get(psbt.unsigned_tx.input[index].previous_output.vout as usize)
+        }) else {
+            continue;
+        };
+        if !utxo.script_pubkey.is_witness_program() {
+            input.witness_utxo = None;
+        }
+    }
+}
+
+fn merge_psbt_signatures(target: &mut Psbt, signed: Psbt) {
+    for (target, signed) in target.inputs.iter_mut().zip(signed.inputs) {
+        target.partial_sigs.extend(signed.partial_sigs);
+        target.tap_script_sigs.extend(signed.tap_script_sigs);
+        if signed.tap_key_sig.is_some() {
+            target.tap_key_sig = signed.tap_key_sig;
+        }
+    }
+}
+
+fn ledger_signing_plans(
+    psbt: &Psbt,
+    fingerprint: Fingerprint,
+    network: Network,
+) -> Result<Vec<LedgerSigningPlan>, String> {
+    let mut plans = Vec::new();
+
+    for (input_index, input) in psbt.inputs.iter().enumerate() {
+        let Some(utxo) = input_utxo(psbt, input_index)? else {
+            continue;
+        };
+        let owns_input = input_has_fingerprint(input, fingerprint);
+        let envelope = match multisig_script(input, &utxo, input_index) {
+            Ok(envelope) => envelope,
+            Err(err) if owns_input => return Err(err),
+            Err(_) => None,
+        };
+
+        if let Some((address_type, script)) = envelope.as_ref()
+            && let Some((threshold, pubkeys)) = parse_multisig_script(script)?
+        {
+            let owns_multisig = pubkeys.iter().any(|pubkey| {
+                input
+                    .bip32_derivation
+                    .get(&pubkey.inner)
+                    .is_some_and(|(key_fingerprint, _)| *key_fingerprint == fingerprint)
+            });
+            if owns_multisig {
+                let plan = ledger_multisig_plan(
+                    psbt,
+                    input,
+                    input_index,
+                    *address_type,
+                    threshold,
+                    &pubkeys,
+                )?;
+                if !plans.contains(&plan) {
+                    plans.push(plan);
+                }
                 continue;
             }
-            let candidate = account_path_from_full_path(path)?;
-            match &account_path {
-                Some(existing) if existing != &candidate => {
-                    return Err("Conflicting Ledger single-sig account paths in PSBT".to_owned());
-                }
-                Some(_) => {}
-                None => account_path = Some(candidate),
+        }
+
+        if let Some(plan) = ledger_singlesig_plan(input, &utxo, input_index, fingerprint, network)?
+        {
+            if !plans.contains(&plan) {
+                plans.push(plan);
             }
+            continue;
+        }
+
+        if owns_input {
+            let policy = if utxo.script_pubkey.is_p2tr() {
+                "taproot script-path"
+            } else if envelope.is_some() {
+                "non-sorted-multisig or miniscript"
+            } else {
+                "non-default"
+            };
+            return Err(format!(
+                "input {input_index}: Ledger HWI signtx cannot infer {policy} wallet policy; use explicit descriptor and HMAC signing"
+            ));
         }
     }
-    Ok(account_path)
+
+    plans.sort_by_key(LedgerSigningPlan::priority);
+    Ok(plans)
 }
 
-fn ledger_multisig_policy(psbt: &Psbt, fingerprint: Fingerprint) -> Result<Option<String>, String> {
-    let mut policy = None;
-    for input in &psbt.inputs {
-        let Some((address_type, script)) = multisig_script(input) else {
-            continue;
-        };
-        let Some((threshold, pubkeys)) = parse_multisig_script(&script)? else {
-            continue;
-        };
-        if !pubkeys.iter().any(|pubkey| {
-            input
-                .bip32_derivation
-                .get(&pubkey.inner)
-                .is_some_and(|(key_fingerprint, _)| *key_fingerprint == fingerprint)
-        }) {
-            continue;
-        }
+fn ledger_singlesig_plan(
+    input: &Input,
+    utxo: &TxOut,
+    input_index: usize,
+    fingerprint: Fingerprint,
+    network: Network,
+) -> Result<Option<LedgerSigningPlan>, String> {
+    let Some(address_type) = singlesig_address_type(input, utxo) else {
+        return Ok(None);
+    };
 
-        let mut keys = Vec::with_capacity(pubkeys.len());
-        let mut complete = true;
-        for pubkey in pubkeys {
-            let Some(key_source) = input.bip32_derivation.get(&pubkey.inner) else {
-                complete = false;
-                break;
-            };
-            let Some(key) = global_xpub_key_expression(psbt, key_source) else {
-                complete = false;
-                break;
-            };
-            keys.push(format!("{key}/<0;1>/*"));
+    if address_type == LedgerAddressType::Tap {
+        let owned: Vec<_> = input
+            .tap_key_origins
+            .iter()
+            .filter(|(_, (_, (key_fingerprint, _)))| *key_fingerprint == fingerprint)
+            .collect();
+        if owned.is_empty() {
+            return Ok(None);
         }
-        if !complete {
-            continue;
+        let Some(internal_key) = input.tap_internal_key else {
+            return Err(format!(
+                "input {input_index}: Ledger BIP86 input is missing tap_internal_key; use explicit descriptor and HMAC signing for non-default taproot policies"
+            ));
+        };
+        let candidates: Vec<_> = owned
+            .into_iter()
+            .filter(|(key, (leaf_hashes, _))| **key == internal_key && leaf_hashes.is_empty())
+            .collect();
+        if candidates.len() != 1 || input.tap_merkle_root.is_some() {
+            return Err(format!(
+                "input {input_index}: Ledger HWI signtx supports only unambiguous BIP86 key-path inputs; use explicit descriptor and HMAC signing for taproot script paths"
+            ));
         }
-
-        let candidate = multisig_policy_descriptor(address_type, threshold, &keys);
-        match &policy {
-            Some(existing) if existing != &candidate => {
-                return Err("Conflicting Ledger multisig policies in PSBT".to_owned());
-            }
-            Some(_) => {}
-            None => policy = Some(candidate),
+        let (_, (_, (_, path))) = candidates[0];
+        let account_path =
+            validate_standard_singlesig_path(path, address_type, network, input_index)?;
+        let secp = Secp256k1::verification_only();
+        let expected = Address::p2tr(&secp, internal_key, None, network).script_pubkey();
+        if expected != utxo.script_pubkey {
+            return Err(format!(
+                "input {input_index}: BIP86 internal key does not match the prevout script; use explicit descriptor and HMAC signing for non-default taproot policies"
+            ));
         }
+        return Ok(Some(LedgerSigningPlan::Default {
+            address_type,
+            account_path,
+        }));
     }
-    Ok(policy)
+
+    let owned: Vec<_> = input
+        .bip32_derivation
+        .iter()
+        .filter(|(_, (key_fingerprint, _))| *key_fingerprint == fingerprint)
+        .collect();
+    if owned.is_empty() {
+        return Ok(None);
+    }
+    let candidates: Vec<_> = owned
+        .into_iter()
+        .filter(|(key, _)| singlesig_key_matches(**key, address_type, input, utxo, network))
+        .collect();
+    if candidates.len() != 1 {
+        return Err(format!(
+            "input {input_index}: Ledger single-sig key metadata is missing or ambiguous"
+        ));
+    }
+    let (_, (_, path)) = candidates[0];
+    let account_path = validate_standard_singlesig_path(path, address_type, network, input_index)?;
+    Ok(Some(LedgerSigningPlan::Default {
+        address_type,
+        account_path,
+    }))
 }
 
-fn account_path_from_full_path(path: &DerivationPath) -> Result<DerivationPath, String> {
+fn singlesig_address_type(input: &Input, utxo: &TxOut) -> Option<LedgerAddressType> {
+    if utxo.script_pubkey.is_p2pkh() {
+        Some(LedgerAddressType::Legacy)
+    } else if utxo.script_pubkey.is_p2wpkh() {
+        Some(LedgerAddressType::Wit)
+    } else if utxo.script_pubkey.is_p2tr() {
+        Some(LedgerAddressType::Tap)
+    } else if utxo.script_pubkey.is_p2sh()
+        && input
+            .redeem_script
+            .as_ref()
+            .is_some_and(|script| script.is_p2wpkh() && script.to_p2sh() == utxo.script_pubkey)
+    {
+        Some(LedgerAddressType::ShWit)
+    } else {
+        None
+    }
+}
+
+fn singlesig_key_matches(
+    key: bitcoin::secp256k1::PublicKey,
+    address_type: LedgerAddressType,
+    input: &Input,
+    utxo: &TxOut,
+    network: Network,
+) -> bool {
+    let key = PublicKey::new(key);
+    match address_type {
+        LedgerAddressType::Legacy => {
+            Address::p2pkh(key, network).script_pubkey() == utxo.script_pubkey
+        }
+        LedgerAddressType::Wit => CompressedPublicKey::try_from(key)
+            .is_ok_and(|key| Address::p2wpkh(&key, network).script_pubkey() == utxo.script_pubkey),
+        LedgerAddressType::ShWit => CompressedPublicKey::try_from(key).is_ok_and(|key| {
+            input.redeem_script.as_ref().is_some_and(|script| {
+                Address::p2wpkh(&key, network).script_pubkey() == *script
+                    && script.to_p2sh() == utxo.script_pubkey
+            })
+        }),
+        LedgerAddressType::Tap => false,
+    }
+}
+
+fn validate_standard_singlesig_path(
+    path: &DerivationPath,
+    address_type: LedgerAddressType,
+    network: Network,
+    input_index: usize,
+) -> Result<DerivationPath, String> {
     let children = path.as_ref();
-    if children.len() < 3 {
-        return Err("Derivation path is too short for Ledger account policy".to_owned());
+    if children.len() != 5 {
+        return Err(format!(
+            "input {input_index}: Ledger default wallet requires an exact five-level derivation path"
+        ));
+    }
+    let purpose = hardened_index(children[0]);
+    let coin_type = hardened_index(children[1]);
+    let account = hardened_index(children[2]);
+    let branch = normal_index(children[3]);
+    let index = normal_index(children[4]);
+    let expected_coin_type = if network == Network::Bitcoin { 0 } else { 1 };
+    if purpose != Some(address_type.purpose())
+        || coin_type != Some(expected_coin_type)
+        || account.is_none()
+        || !matches!(branch, Some(0 | 1))
+        || index.is_none()
+    {
+        return Err(format!(
+            "input {input_index}: derivation path {path} is not a standard Ledger {:?} wallet path",
+            address_type
+        ));
     }
     Ok(DerivationPath::from(children[..3].to_vec()))
+}
+
+fn hardened_index(child: ChildNumber) -> Option<u32> {
+    match child {
+        ChildNumber::Hardened { index } => Some(index),
+        ChildNumber::Normal { .. } => None,
+    }
+}
+
+fn normal_index(child: ChildNumber) -> Option<u32> {
+    match child {
+        ChildNumber::Normal { index } => Some(index),
+        ChildNumber::Hardened { .. } => None,
+    }
+}
+
+fn ledger_multisig_plan(
+    psbt: &Psbt,
+    input: &Input,
+    input_index: usize,
+    address_type: LedgerAddressType,
+    threshold: usize,
+    pubkeys: &[PublicKey],
+) -> Result<LedgerSigningPlan, String> {
+    if !pubkeys
+        .windows(2)
+        .all(|keys| keys[0].inner.serialize() < keys[1].inner.serialize())
+    {
+        return Err(format!(
+            "input {input_index}: Ledger HWI signtx supports only sorted multisig scripts"
+        ));
+    }
+
+    let mut keys = Vec::with_capacity(pubkeys.len());
+    let mut expected_suffix = None;
+    for pubkey in pubkeys {
+        let key_source = input.bip32_derivation.get(&pubkey.inner).ok_or_else(|| {
+            format!("input {input_index}: multisig public key is missing BIP32 derivation metadata")
+        })?;
+        let resolved = global_xpub_key_expression(psbt, key_source, pubkey, input_index)?;
+        match expected_suffix {
+            Some(suffix) if suffix != resolved.suffix => {
+                return Err(format!(
+                    "input {input_index}: multisig keys do not share one receive/change derivation"
+                ));
+            }
+            None => expected_suffix = Some(resolved.suffix),
+            Some(_) => {}
+        }
+        keys.push(format!("{}/<0;1>/*", resolved.expression));
+    }
+    // sortedmulti semantics do not depend on the key-info order. Canonicalize it so
+    // inputs at different indexes reconstruct one stable registered wallet.
+    keys.sort();
+    let policy = multisig_policy_descriptor(address_type, threshold, &keys);
+    Ok(LedgerSigningPlan::Registered {
+        address_type,
+        name: format!("{threshold} of {} Multisig", pubkeys.len()),
+        policy,
+    })
+}
+
+struct ResolvedMultisigKey {
+    expression: String,
+    suffix: (u32, u32),
+}
+
+fn global_xpub_key_expression(
+    psbt: &Psbt,
+    key_source: &KeySource,
+    pubkey: &PublicKey,
+    input_index: usize,
+) -> Result<ResolvedMultisigKey, String> {
+    let (fingerprint, key_path) = key_source;
+    let children = key_path.as_ref();
+    if children.len() < 2 {
+        return Err(format!(
+            "input {input_index}: multisig derivation path is too short"
+        ));
+    }
+    let branch = normal_index(children[children.len() - 2]);
+    let index = normal_index(children[children.len() - 1]);
+    if !matches!(branch, Some(0 | 1)) || index.is_none() {
+        return Err(format!(
+            "input {input_index}: Ledger multisig derivation must end in /0/index or /1/index"
+        ));
+    }
+    let suffix = (
+        branch.expect("branch checked"),
+        index.expect("index checked"),
+    );
+    let xpub_path = DerivationPath::from(children[..children.len() - 2].to_vec());
+    let matches: Vec<_> = psbt
+        .xpub
+        .iter()
+        .filter(|(_, (xpub_fingerprint, path))| {
+            *xpub_fingerprint == *fingerprint && *path == xpub_path
+        })
+        .collect();
+    if matches.len() != 1 {
+        return Err(format!(
+            "input {input_index}: expected one account-level global xpub for {fingerprint}, found {}",
+            matches.len()
+        ));
+    }
+    let (xpub, (_, origin_path)) = matches[0];
+    let secp = Secp256k1::verification_only();
+    let derived = xpub
+        .derive_pub(
+            &secp,
+            &[
+                ChildNumber::from_normal_idx(suffix.0).expect("branch checked"),
+                ChildNumber::from_normal_idx(suffix.1).expect("index checked"),
+            ],
+        )
+        .map_err(|err| format!("input {input_index}: failed to derive global xpub: {err}"))?;
+    if derived.public_key != pubkey.inner {
+        return Err(format!(
+            "input {input_index}: global xpub derivation does not match multisig public key"
+        ));
+    }
+    let origin = origin_path.to_string();
+    let origin = origin.trim_start_matches('m').trim_start_matches('/');
+    let expression = if origin.is_empty() {
+        format!("[{fingerprint}]{xpub}")
+    } else {
+        format!("[{fingerprint}/{origin}]{xpub}")
+    };
+    Ok(ResolvedMultisigKey { expression, suffix })
+}
+
+fn input_has_fingerprint(input: &Input, fingerprint: Fingerprint) -> bool {
+    input
+        .bip32_derivation
+        .values()
+        .any(|(key_fingerprint, _)| *key_fingerprint == fingerprint)
+        || input
+            .tap_key_origins
+            .values()
+            .any(|(_, (key_fingerprint, _))| *key_fingerprint == fingerprint)
+}
+
+fn input_utxo(psbt: &Psbt, input_index: usize) -> Result<Option<TxOut>, String> {
+    let input = &psbt.inputs[input_index];
+    let txin = &psbt.unsigned_tx.input[input_index];
+    let non_witness = if let Some(tx) = &input.non_witness_utxo {
+        if tx.compute_txid() != txin.previous_output.txid {
+            return Err(format!(
+                "input {input_index}: non_witness_utxo transaction id does not match prevout"
+            ));
+        }
+        Some(
+            tx.output
+                .get(txin.previous_output.vout as usize)
+                .cloned()
+                .ok_or_else(|| format!("input {input_index}: prevout index is out of range"))?,
+        )
+    } else {
+        None
+    };
+    if let (Some(witness), Some(non_witness)) = (&input.witness_utxo, &non_witness)
+        && witness != non_witness
+    {
+        return Err(format!(
+            "input {input_index}: witness_utxo and non_witness_utxo disagree"
+        ));
+    }
+    Ok(input.witness_utxo.clone().or(non_witness))
 }
 
 fn extend_account_path_for_policy(path: &DerivationPath) -> DerivationPath {
@@ -1689,43 +2126,48 @@ fn extend_account_path_for_policy(path: &DerivationPath) -> DerivationPath {
     DerivationPath::from(children)
 }
 
-fn is_standard_singlesig_path(path: &DerivationPath) -> bool {
-    let children = path.as_ref();
-    if children.len() < 5 {
-        return false;
+fn multisig_script(
+    input: &Input,
+    utxo: &TxOut,
+    input_index: usize,
+) -> Result<Option<(LedgerAddressType, ScriptBuf)>, String> {
+    if utxo.script_pubkey.is_p2wsh() {
+        let witness_script = input
+            .witness_script
+            .as_ref()
+            .ok_or_else(|| format!("input {input_index}: P2WSH input is missing witness_script"))?;
+        if witness_script.to_p2wsh() != utxo.script_pubkey {
+            return Err(format!(
+                "input {input_index}: witness_script does not match P2WSH prevout"
+            ));
+        }
+        return Ok(Some((LedgerAddressType::Wit, witness_script.clone())));
     }
-    matches!(
-        children[0],
-        child if child == hardened(44)
-            || child == hardened(49)
-            || child == hardened(84)
-            || child == hardened(86)
-    ) && children[1].is_hardened()
-        && children[2].is_hardened()
-        && !children[3].is_hardened()
-        && !children[4].is_hardened()
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum LedgerMultisigAddressType {
-    Legacy,
-    ShWit,
-    Wit,
-}
-
-fn multisig_script(input: &Input) -> Option<(LedgerMultisigAddressType, ScriptBuf)> {
-    if let Some(witness_script) = &input.witness_script {
-        let address_type = if input.redeem_script.as_ref().is_some_and(|s| s.is_p2wsh()) {
-            LedgerMultisigAddressType::ShWit
-        } else {
-            LedgerMultisigAddressType::Wit
-        };
-        return Some((address_type, witness_script.clone()));
+    if !utxo.script_pubkey.is_p2sh() {
+        return Ok(None);
     }
-    input
+    let redeem_script = input
         .redeem_script
         .as_ref()
-        .map(|script| (LedgerMultisigAddressType::Legacy, script.clone()))
+        .ok_or_else(|| format!("input {input_index}: P2SH input is missing redeem_script"))?;
+    if redeem_script.to_p2sh() != utxo.script_pubkey {
+        return Err(format!(
+            "input {input_index}: redeem_script does not match P2SH prevout"
+        ));
+    }
+    if redeem_script.is_p2wsh() {
+        let witness_script = input.witness_script.as_ref().ok_or_else(|| {
+            format!("input {input_index}: nested P2WSH input is missing witness_script")
+        })?;
+        if witness_script.to_p2wsh() != *redeem_script {
+            return Err(format!(
+                "input {input_index}: witness_script does not match nested P2WSH redeem_script"
+            ));
+        }
+        Ok(Some((LedgerAddressType::ShWit, witness_script.clone())))
+    } else {
+        Ok(Some((LedgerAddressType::Legacy, redeem_script.clone())))
+    }
 }
 
 fn parse_multisig_script(script: &ScriptBuf) -> Result<Option<(usize, Vec<PublicKey>)>, String> {
@@ -1734,7 +2176,7 @@ fn parse_multisig_script(script: &ScriptBuf) -> Result<Option<(usize, Vec<Public
         return Ok(None);
     };
     let threshold = match first.map_err(|err| err.to_string())? {
-        Instruction::Op(op) => pushnum(op).filter(|n| *n <= 15),
+        Instruction::Op(op) => pushnum(op).filter(|n| *n <= 16),
         Instruction::PushBytes(_) => None,
     };
     let Some(threshold) = threshold else {
@@ -1776,52 +2218,18 @@ fn parse_multisig_script(script: &ScriptBuf) -> Result<Option<(usize, Vec<Public
     Ok(Some((threshold, pubkeys)))
 }
 
-fn global_xpub_key_expression(psbt: &Psbt, key_source: &KeySource) -> Option<String> {
-    let (fingerprint, key_path) = key_source;
-    psbt.xpub
-        .iter()
-        .find(|(_, (xpub_fingerprint, xpub_path))| {
-            xpub_fingerprint == fingerprint && path_starts_with(key_path, xpub_path)
-        })
-        .map(|(xpub, (_, xpub_path))| {
-            let origin = xpub_path.to_string();
-            let origin = origin.trim_start_matches('m').trim_start_matches('/');
-            if origin.is_empty() {
-                format!("[{fingerprint}]{xpub}")
-            } else {
-                format!("[{fingerprint}/{origin}]{xpub}")
-            }
-        })
-}
-
-fn path_starts_with(path: &DerivationPath, prefix: &DerivationPath) -> bool {
-    path.as_ref().starts_with(prefix.as_ref())
-}
-
 fn multisig_policy_descriptor(
-    address_type: LedgerMultisigAddressType,
+    address_type: LedgerAddressType,
     threshold: usize,
     keys: &[String],
 ) -> String {
     let body = format!("sortedmulti({threshold},{})", keys.join(","));
     match address_type {
-        LedgerMultisigAddressType::Legacy => format!("sh({body})"),
-        LedgerMultisigAddressType::ShWit => format!("sh(wsh({body}))"),
-        LedgerMultisigAddressType::Wit => format!("wsh({body})"),
+        LedgerAddressType::Legacy => format!("sh({body})"),
+        LedgerAddressType::ShWit => format!("sh(wsh({body}))"),
+        LedgerAddressType::Wit => format!("wsh({body})"),
+        LedgerAddressType::Tap => unreachable!("taproot is not classic multisig"),
     }
-}
-
-fn ledger_multisig_wallet_name(policy: &str) -> String {
-    let threshold = policy
-        .split_once("sortedmulti(")
-        .and_then(|(_, rest)| rest.split_once(','))
-        .and_then(|(threshold, _)| threshold.parse::<usize>().ok())
-        .unwrap_or(0);
-    let signers = policy
-        .matches("/**")
-        .count()
-        .max(policy.matches("/<0;1>/*").count());
-    format!("{threshold} of {signers} Multisig")
 }
 
 fn pushnum(op: bitcoin::blockdata::opcodes::Opcode) -> Option<usize> {
@@ -1836,10 +2244,6 @@ fn pushnum(op: bitcoin::blockdata::opcodes::Opcode) -> Option<usize> {
 
 fn push_bytes_as_bytes(bytes: &PushBytes) -> &[u8] {
     bytes.as_bytes()
-}
-
-fn hardened(index: u32) -> ChildNumber {
-    ChildNumber::from_hardened_idx(index).expect("valid hardened child")
 }
 
 fn master_xpub_path(
@@ -2540,6 +2944,7 @@ mod tests {
     use bitcoin::{
         Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Witness,
         absolute::LockTime,
+        bip32::Xpriv,
         blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
         secp256k1::Secp256k1,
         transaction::Version as TxVersion,
@@ -3510,30 +3915,114 @@ mod tests {
     }
 
     #[test]
-    fn ledger_singlesig_account_path_accepts_standard_bip84() {
+    fn ledger_signing_plans_cover_all_default_wallets() {
         let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
-        let path = DerivationPath::from_str("m/84'/1'/0'/0/0").unwrap();
+        let pubkey = sample_child_pubkey(0);
+        for (address_type, path, input) in [
+            (
+                LedgerAddressType::Legacy,
+                "m/44'/1'/0'/0/0",
+                Input {
+                    witness_utxo: Some(TxOut {
+                        value: Amount::from_sat(50_000),
+                        script_pubkey: Address::p2pkh(pubkey, Network::Testnet).script_pubkey(),
+                    }),
+                    ..Default::default()
+                },
+            ),
+            (LedgerAddressType::ShWit, "m/49'/1'/0'/0/0", {
+                let redeem_script = Address::p2wpkh(
+                    &CompressedPublicKey::try_from(pubkey).unwrap(),
+                    Network::Testnet,
+                )
+                .script_pubkey();
+                Input {
+                    witness_utxo: Some(TxOut {
+                        value: Amount::from_sat(50_000),
+                        script_pubkey: redeem_script.to_p2sh(),
+                    }),
+                    redeem_script: Some(redeem_script),
+                    ..Default::default()
+                }
+            }),
+            (
+                LedgerAddressType::Wit,
+                "m/84'/1'/0'/0/0",
+                Input {
+                    witness_utxo: Some(TxOut {
+                        value: Amount::from_sat(50_000),
+                        script_pubkey: Address::p2wpkh(
+                            &CompressedPublicKey::try_from(pubkey).unwrap(),
+                            Network::Testnet,
+                        )
+                        .script_pubkey(),
+                    }),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let path = DerivationPath::from_str(path).unwrap();
+            let mut input = input;
+            input
+                .bip32_derivation
+                .insert(pubkey.inner, (fingerprint, path));
+            assert_eq!(
+                ledger_signing_plans(&psbt_with_input(input), fingerprint, Network::Testnet)
+                    .unwrap(),
+                vec![LedgerSigningPlan::Default {
+                    address_type,
+                    account_path: DerivationPath::from_str(&format!(
+                        "m/{}'/1'/0'",
+                        address_type.purpose()
+                    ))
+                    .unwrap(),
+                }]
+            );
+        }
+
+        let internal_key = pubkey.inner.x_only_public_key().0;
+        let path = DerivationPath::from_str("m/86'/1'/0'/0/0").unwrap();
         let psbt = psbt_with_input(Input {
-            bip32_derivation: [(sample_child_pubkey(0).inner, (fingerprint, path))].into(),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: Address::p2tr(
+                    &Secp256k1::verification_only(),
+                    internal_key,
+                    None,
+                    Network::Testnet,
+                )
+                .script_pubkey(),
+            }),
+            tap_internal_key: Some(internal_key),
+            tap_key_origins: [(internal_key, (Vec::new(), (fingerprint, path)))].into(),
             ..Default::default()
         });
-
         assert_eq!(
-            ledger_singlesig_account_path(&psbt, fingerprint)
-                .unwrap()
-                .unwrap()
-                .to_string(),
-            "84'/1'/0'"
+            ledger_signing_plans(&psbt, fingerprint, Network::Testnet).unwrap(),
+            vec![LedgerSigningPlan::Default {
+                address_type: LedgerAddressType::Tap,
+                account_path: DerivationPath::from_str("m/86'/1'/0'").unwrap(),
+            }]
         );
     }
 
     #[test]
-    fn ledger_singlesig_account_path_rejects_conflicting_accounts() {
+    fn ledger_signing_plans_support_multiple_singlesig_accounts() {
         let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
+        let pubkey_a = sample_child_pubkey(0);
+        let pubkey_b = sample_child_pubkey(1);
         let psbt = psbt_with_inputs(vec![
             Input {
+                witness_utxo: Some(TxOut {
+                    value: Amount::from_sat(50_000),
+                    script_pubkey: Address::p2wpkh(
+                        &CompressedPublicKey::try_from(pubkey_a).unwrap(),
+                        Network::Testnet,
+                    )
+                    .script_pubkey(),
+                }),
                 bip32_derivation: [(
-                    sample_child_pubkey(0).inner,
+                    pubkey_a.inner,
                     (
                         fingerprint,
                         DerivationPath::from_str("m/84'/1'/0'/0/0").unwrap(),
@@ -3543,8 +4032,16 @@ mod tests {
                 ..Default::default()
             },
             Input {
+                witness_utxo: Some(TxOut {
+                    value: Amount::from_sat(50_000),
+                    script_pubkey: Address::p2wpkh(
+                        &CompressedPublicKey::try_from(pubkey_b).unwrap(),
+                        Network::Testnet,
+                    )
+                    .script_pubkey(),
+                }),
                 bip32_derivation: [(
-                    sample_child_pubkey(1).inner,
+                    pubkey_b.inner,
                     (
                         fingerprint,
                         DerivationPath::from_str("m/84'/1'/1'/0/0").unwrap(),
@@ -3555,81 +4052,91 @@ mod tests {
             },
         ]);
 
-        let err = ledger_singlesig_account_path(&psbt, fingerprint).expect_err("conflict");
-        assert!(err.contains("Conflicting Ledger single-sig account paths"));
+        let plans = ledger_signing_plans(&psbt, fingerprint, Network::Testnet).unwrap();
+        assert_eq!(plans.len(), 2);
+        assert!(plans.iter().all(|plan| matches!(
+            plan,
+            LedgerSigningPlan::Default {
+                address_type: LedgerAddressType::Wit,
+                ..
+            }
+        )));
     }
 
     #[test]
-    fn ledger_multisig_policy_reconstructs_hwi_like_wsh_sortedmulti() {
-        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
-        let account_path = DerivationPath::from_str("m/48'/1'/0'/2'").unwrap();
-        let xpub = sample_xpub();
-        let pubkey_a = sample_child_pubkey(0);
-        let pubkey_b = sample_child_pubkey(1);
-        let mut psbt = psbt_with_input(Input {
-            witness_script: Some(multisig_script_buf(2, &[pubkey_a, pubkey_b])),
-            bip32_derivation: [
+    fn ledger_signing_plans_support_mixed_default_and_registered_policies() {
+        let (multisig, fingerprint) = sample_multisig_psbt(LedgerAddressType::Wit, true);
+        let pubkey = sample_child_pubkey(0);
+        let singlesig = Input {
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: Address::p2wpkh(
+                    &CompressedPublicKey::try_from(pubkey).unwrap(),
+                    Network::Testnet,
+                )
+                .script_pubkey(),
+            }),
+            bip32_derivation: [(
+                pubkey.inner,
                 (
-                    pubkey_a.inner,
-                    (
-                        fingerprint,
-                        DerivationPath::from_str("m/48'/1'/0'/2'/0/0").unwrap(),
-                    ),
+                    fingerprint,
+                    DerivationPath::from_str("m/84'/1'/0'/0/0").unwrap(),
                 ),
-                (
-                    pubkey_b.inner,
-                    (
-                        fingerprint,
-                        DerivationPath::from_str("m/48'/1'/0'/2'/0/1").unwrap(),
-                    ),
-                ),
-            ]
+            )]
             .into(),
             ..Default::default()
-        });
-        psbt.xpub.insert(xpub, (fingerprint, account_path));
+        };
+        let mut psbt = psbt_with_inputs(vec![singlesig, multisig.inputs[0].clone()]);
+        psbt.xpub = multisig.xpub;
 
-        let policy = ledger_multisig_policy(&psbt, fingerprint)
-            .unwrap()
-            .expect("policy");
-
-        assert!(policy.starts_with("wsh(sortedmulti(2,"));
-        assert_eq!(policy.matches("/<0;1>/*").count(), 2);
-        assert!(policy.contains("[f5acc2fd/48'/1'/0'/2']"));
+        let plans = ledger_signing_plans(&psbt, fingerprint, Network::Testnet).unwrap();
+        assert_eq!(plans.len(), 2);
+        assert!(matches!(plans[0], LedgerSigningPlan::Default { .. }));
+        assert!(matches!(plans[1], LedgerSigningPlan::Registered { .. }));
     }
 
     #[test]
-    fn ledger_multisig_policy_skips_missing_global_xpub() {
-        let fingerprint = Fingerprint::from([0xf5, 0xac, 0xc2, 0xfd]);
-        let pubkey_a = sample_child_pubkey(0);
-        let pubkey_b = sample_child_pubkey(1);
-        let psbt = psbt_with_input(Input {
-            witness_script: Some(multisig_script_buf(2, &[pubkey_a, pubkey_b])),
-            bip32_derivation: [
-                (
-                    pubkey_a.inner,
-                    (
-                        fingerprint,
-                        DerivationPath::from_str("m/48'/1'/0'/2'/0/0").unwrap(),
-                    ),
-                ),
-                (
-                    pubkey_b.inner,
-                    (
-                        fingerprint,
-                        DerivationPath::from_str("m/48'/1'/0'/2'/0/1").unwrap(),
-                    ),
-                ),
-            ]
-            .into(),
-            ..Default::default()
-        });
+    fn ledger_multisig_plans_cover_all_hwi_wrappers() {
+        for address_type in [
+            LedgerAddressType::Legacy,
+            LedgerAddressType::ShWit,
+            LedgerAddressType::Wit,
+        ] {
+            let (psbt, fingerprint) = sample_multisig_psbt(address_type, true);
+            let plans = ledger_signing_plans(&psbt, fingerprint, Network::Testnet).unwrap();
+            let LedgerSigningPlan::Registered { policy, name, .. } = &plans[0] else {
+                panic!("registered policy");
+            };
+            assert_eq!(name, "2 of 2 Multisig");
+            assert_eq!(policy.matches("/<0;1>/*").count(), 2);
+            match address_type {
+                LedgerAddressType::Legacy => assert!(policy.starts_with("sh(sortedmulti(2,")),
+                LedgerAddressType::ShWit => {
+                    assert!(policy.starts_with("sh(wsh(sortedmulti(2,"))
+                }
+                LedgerAddressType::Wit => assert!(policy.starts_with("wsh(sortedmulti(2,")),
+                LedgerAddressType::Tap => unreachable!(),
+            }
+        }
+    }
 
-        assert!(
-            ledger_multisig_policy(&psbt, fingerprint)
-                .unwrap()
-                .is_none()
-        );
+    #[test]
+    fn ledger_multisig_plan_rejects_missing_global_xpub() {
+        let (mut psbt, fingerprint) = sample_multisig_psbt(LedgerAddressType::Wit, true);
+        psbt.xpub.clear();
+
+        let err =
+            ledger_signing_plans(&psbt, fingerprint, Network::Testnet).expect_err("missing xpub");
+        assert!(err.contains("expected one account-level global xpub"));
+    }
+
+    #[test]
+    fn ledger_multisig_plan_rejects_unsorted_script() {
+        let (psbt, fingerprint) = sample_multisig_psbt(LedgerAddressType::Wit, false);
+
+        let err = ledger_signing_plans(&psbt, fingerprint, Network::Testnet)
+            .expect_err("unsorted multisig");
+        assert!(err.contains("supports only sorted multisig"));
     }
 
     fn sample_xpub() -> Xpub {
@@ -3660,6 +4167,68 @@ mod tests {
             .push_int(pubkeys.len() as i64)
             .push_opcode(OP_CHECKMULTISIG)
             .into_script()
+    }
+
+    fn sample_multisig_psbt(address_type: LedgerAddressType, sorted: bool) -> (Psbt, Fingerprint) {
+        let secp = Secp256k1::new();
+        let account_path = DerivationPath::from_str("m/48'/1'/0'/2'").unwrap();
+        let suffix = [
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ];
+        let mut sources = Vec::new();
+        for seed in [1_u8, 2] {
+            let master = Xpriv::new_master(NetworkKind::Test, &[seed; 32]).unwrap();
+            let fingerprint = master.fingerprint(&secp);
+            let account = master.derive_priv(&secp, &account_path).unwrap();
+            let xpub = Xpub::from_priv(&secp, &account);
+            let child = xpub.derive_pub(&secp, &suffix).unwrap();
+            sources.push((fingerprint, xpub, PublicKey::new(child.public_key)));
+        }
+        sources.sort_by_key(|(_, _, pubkey)| pubkey.inner.serialize());
+        if !sorted {
+            sources.reverse();
+        }
+        let pubkeys: Vec<_> = sources.iter().map(|(_, _, pubkey)| *pubkey).collect();
+        let script = multisig_script_buf(2, &pubkeys);
+        let mut input = Input {
+            bip32_derivation: sources
+                .iter()
+                .map(|(fingerprint, _, pubkey)| {
+                    let mut path = account_path.as_ref().to_vec();
+                    path.extend_from_slice(&suffix);
+                    (pubkey.inner, (*fingerprint, DerivationPath::from(path)))
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let script_pubkey = match address_type {
+            LedgerAddressType::Legacy => {
+                input.redeem_script = Some(script.clone());
+                script.to_p2sh()
+            }
+            LedgerAddressType::ShWit => {
+                let redeem_script = script.to_p2wsh();
+                input.redeem_script = Some(redeem_script.clone());
+                input.witness_script = Some(script);
+                redeem_script.to_p2sh()
+            }
+            LedgerAddressType::Wit => {
+                input.witness_script = Some(script.clone());
+                script.to_p2wsh()
+            }
+            LedgerAddressType::Tap => unreachable!(),
+        };
+        input.witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey,
+        });
+        let mut psbt = psbt_with_input(input);
+        for (fingerprint, xpub, _) in &sources {
+            psbt.xpub
+                .insert(*xpub, (*fingerprint, account_path.clone()));
+        }
+        (psbt, sources[0].0)
     }
 
     fn psbt_with_input(input: Input) -> Psbt {

--- a/bhwi/src/common/adapters/ledger.rs
+++ b/bhwi/src/common/adapters/ledger.rs
@@ -3,6 +3,7 @@ use crate::common::{
     WalletRegistration,
 };
 use crate::ledger::apdu::ApduCommand;
+use crate::ledger::store::StoreError;
 use crate::ledger::{
     LedgerCommand, LedgerDisplayAddress, LedgerError, LedgerResponse, LedgerWalletPolicy, Version,
 };
@@ -125,7 +126,17 @@ impl From<LedgerError> for Error {
             LedgerError::MissingCommandInfo(error) => Self::MissingCommandInfo(error),
             LedgerError::NoErrorOrResult => Self::NoErrorOrResult,
             LedgerError::Apdu(error) => Self::Serialization(format!("{error:?}")),
-            LedgerError::Store(_) => Self::Request("Store operation failed"),
+            LedgerError::Store(error) => Self::Request(match error {
+                StoreError::EmptyInput => "Store operation failed: empty request",
+                StoreError::UnknownCommand(_) => "Store operation failed: unknown command",
+                StoreError::UnsupportedRequest(_) => "Store operation failed: unsupported request",
+                StoreError::InvalidIndexOrSize => {
+                    "Store operation failed: invalid Merkle index or size"
+                }
+                StoreError::UnknownHash => "Store operation failed: unknown hash",
+                StoreError::UnknownMerkleRoot => "Store operation failed: unknown Merkle root",
+                StoreError::UnexpectedQueue => "Store operation failed: unexpected queue state",
+            }),
             LedgerError::Wallet(_) => Self::Request("Wallet operation failed"),
             LedgerError::Interrupted => Self::Request("Operation interrupted"),
             LedgerError::UnexpectedResult(data, context) => Self::unexpected_result(data, context),

--- a/bhwi/src/ledger/store.rs
+++ b/bhwi/src/ledger/store.rs
@@ -182,7 +182,7 @@ fn get_merkle_leaf_proof(
     let tree = trees
         .iter()
         .find(|tree| tree.root_hash() == root)
-        .ok_or(StoreError::UnknownHash)?;
+        .ok_or(StoreError::UnknownMerkleRoot)?;
 
     if leaf_index >= tree_size || tree_size.0 != tree.size() as u64 {
         return Err(StoreError::InvalidIndexOrSize);
@@ -226,11 +226,13 @@ fn get_merkle_leaf_index(trees: &[MerkleTree], request: &[u8]) -> Result<Vec<u8>
     let tree = trees
         .iter()
         .find(|tree| tree.root_hash() == root)
-        .ok_or(StoreError::UnknownHash)?;
+        .ok_or(StoreError::UnknownMerkleRoot)?;
 
-    let leaf_index = tree.get_leaf_index(hash).ok_or(StoreError::UnknownHash)?;
+    let (found, leaf_index) = tree
+        .get_leaf_index(hash)
+        .map_or((0_u8, 0_usize), |index| (1, index));
 
-    let mut response = 1_u8.to_be_bytes().to_vec();
+    let mut response = found.to_be_bytes().to_vec();
     response.extend(encode::serialize(&VarInt(leaf_index as u64)));
     Ok(response)
 }
@@ -314,4 +316,21 @@ pub enum StoreError {
 
     #[error("unexpected queue state")]
     UnexpectedQueue,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_merkle_leaf_returns_not_found() {
+        let mut store = DelegatedStore::new();
+        let root = store.add_known_list(&[b"known"]);
+        let missing = sha256::Hash::hash(b"\0missing").to_byte_array();
+        let mut command = vec![ClientCommandCode::GetMerkleLeafIndex as u8];
+        command.extend(root);
+        command.extend(missing);
+
+        assert_eq!(store.execute(command).unwrap(), vec![0, 0]);
+    }
 }

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -29,7 +29,7 @@ Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 |`getxpub`         |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for normal and expert output shape.                           |
 |`getdescriptors`  |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for account descriptors.                                      |
 |`getkeypool`      |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for receive/change ranges and address types.                  |
-|`signtx`          |`[~]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Ledger registered-wallet and non-default policy signing remains open. |
+|`signtx`          |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Ledger covers default BIP44/49/84/86 wallets and classic registered sorted multisig. |
 |`signmessage`     |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Covered for emulator-supported paths.                                 |
 |`displayaddress`  |`[x]` |`[x]`|`[x]`   |`[ ]` |`[ ]`  |`n/a`   |`[x]`   |Registered Coldcard multisig display is covered for all script wrappers.|
 |`setup`           |`n/a` |`n/a`|`n/a`   |`[ ]` |`[ ]`  |`[ ]`   |`[x]`   |Physical setup uses fresh entropy and backup; simulator setup is covered end to end.|

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -80,6 +80,29 @@ and candidate run. The harness also repeats each descriptor without
 registration to preserve error-response parity. Set `BHWI_BIN` when the native
 binary is not next to the candidate `HWI_BIN`.
 
+## Ledger signing policy scope
+
+Ledger `signtx` parity covers the wallet policies that Python HWI can derive
+unambiguously from PSBT metadata:
+
+- default single-key wallets using exact BIP44 `pkh`, BIP49 `sh(wpkh)`, BIP84
+  `wpkh`, or BIP86 key-path `tr` derivations;
+- registered `sh(sortedmulti)`, `sh(wsh(sortedmulti))`, and
+  `wsh(sortedmulti)` policies with complete account-level global xpubs; and
+- PSBTs containing inputs from more than one supported policy.
+
+The adapter validates derivation paths and script commitments before asking the
+device to sign. It rejects ambiguous or unsupported owned inputs, including
+unsorted multisig, arbitrary witness miniscript, and taproot script paths, with
+an input-indexed error directing callers to explicit descriptor and HMAC
+signing.
+
+Ledger does not persist a wallet registry. Registration authenticates a policy
+and returns an HMAC, so an "already registered" wallet means the caller retained
+the policy name, descriptor, and HMAC and supplies them again for later signing.
+The native `register-wallet` and `sign-psbt` commands expose that reusable flow;
+HWI `signtx` registers inferred non-default policies for the current invocation.
+
 ## BitBox02 parity notes
 
 BitBox02 parity is wired against Python HWI's built-in simulator transport. The

--- a/e2e/cli/src/ledger.rs
+++ b/e2e/cli/src/ledger.rs
@@ -13,6 +13,7 @@ use bitcoin::{
     bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
     psbt::{Input, Output as PsbtOutput, Psbt},
     secp256k1::Secp256k1,
+    sighash::SighashCache,
     transaction::Version as TxVersion,
 };
 
@@ -188,11 +189,42 @@ fn ledger_sign_psbt() -> Result<()> {
         "--hmac",
         &hmac,
     ])?;
-    fs::remove_file(psbt_file)?;
-
     let signed = Psbt::from_str(signed.trim())?;
+    assert_ledger_psbt_signature(&psbt, &signed)?;
+
+    // A fresh CLI process can reuse the caller-retained policy and HMAC. No
+    // registration call is required because Ledger itself stores no registry.
+    set_ledger_automation(&automation(include_str!(
+        "../../ledger/automations/sign_psbt.json"
+    )))?;
+    let signed_again = Cli::for_device(LEDGER_FINGERPRINT).run_ok([
+        "sign-psbt",
+        "--psbt",
+        psbt_file.to_str().context("utf-8 temp path")?,
+        "--name",
+        "clipsbttest",
+        "--descriptor",
+        &policy,
+        "--hmac",
+        &hmac,
+    ])?;
+    fs::remove_file(psbt_file)?;
+    assert_ledger_psbt_signature(&psbt, &Psbt::from_str(signed_again.trim())?)?;
+    Ok(())
+}
+
+fn assert_ledger_psbt_signature(original: &Psbt, signed: &Psbt) -> Result<()> {
     assert_eq!(signed.inputs.len(), 1);
     assert_eq!(signed.inputs[0].partial_sigs.len(), 1);
+    let (pubkey, signature) = signed.inputs[0]
+        .partial_sigs
+        .iter()
+        .next()
+        .context("missing Ledger signature")?;
+    let mut cache = SighashCache::new(&original.unsigned_tx);
+    let (message, sighash_type) = original.sighash_ecdsa(0, &mut cache)?;
+    assert_eq!(signature.sighash_type, sighash_type);
+    Secp256k1::verification_only().verify_ecdsa(&message, &signature.signature, &pubkey.inner)?;
     Ok(())
 }
 

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -288,8 +288,10 @@ mod tests {
         base64::prelude::{BASE64_STANDARD, Engine as _},
         bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub},
         blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
+        key::TapTweak,
         psbt::{Input, Output as PsbtOutput, Psbt},
-        secp256k1::Secp256k1,
+        secp256k1::{Message, Secp256k1},
+        sighash::{Prevouts, SighashCache},
         transaction::Version as TxVersion,
     };
 
@@ -467,14 +469,26 @@ mod tests {
             return Ok(());
         };
 
-        let singlesig = build_singlesig_signtx_case(&device_type)?;
-        assert_signtx_parity(signtx_args(&device_type, &singlesig.psbt), &singlesig)
-            .with_context(|| format!("signtx singlesig parity failed for {device_type}"))?;
-
         if device_type == "ledger" {
-            let multisig = build_ledger_multisig_signtx_case(&device_type)?;
-            assert_signtx_parity(signtx_args(&device_type, &multisig.psbt), &multisig)
-                .context("signtx Ledger multisig parity failed")?;
+            for wrapper in LedgerSinglesigWrapper::ALL {
+                let case = build_singlesig_signtx_case(&device_type, wrapper)?;
+                assert_signtx_parity(signtx_args(&device_type, &case.psbt), &case).with_context(
+                    || format!("signtx Ledger {wrapper:?} singlesig parity failed"),
+                )?;
+            }
+            for wrapper in LedgerMultisigWrapper::ALL {
+                let case = build_ledger_multisig_signtx_case(&device_type, wrapper)?;
+                assert_signtx_parity(signtx_args(&device_type, &case.psbt), &case)
+                    .with_context(|| format!("signtx Ledger {wrapper:?} multisig parity failed"))?;
+            }
+
+            let mixed = build_ledger_mixed_policy_signtx_case(&device_type)?;
+            assert_signtx_parity(signtx_args(&device_type, &mixed.psbt), &mixed)
+                .context("signtx Ledger mixed-policy parity failed")?;
+        } else {
+            let singlesig = build_singlesig_signtx_case(&device_type, LedgerSinglesigWrapper::Wit)?;
+            assert_signtx_parity(signtx_args(&device_type, &singlesig.psbt), &singlesig)
+                .with_context(|| format!("signtx singlesig parity failed for {device_type}"))?;
         }
 
         Ok(())
@@ -1152,13 +1166,92 @@ mod tests {
         if signed_psbt.inputs.len() != case.original.inputs.len() {
             bail!("{label} hwi signtx changed the input count");
         }
-        if !signed_psbt.inputs[0]
-            .partial_sigs
-            .contains_key(&case.expected_pubkey)
-        {
-            bail!("{label} hwi signtx did not add the expected device signature");
+        for expected in &case.expected_signatures {
+            assert_expected_signature(label, &signed_psbt, case, *expected)?;
         }
         Ok(signed_psbt)
+    }
+
+    fn assert_expected_signature(
+        label: &str,
+        signed: &Psbt,
+        case: &SigntxCase,
+        expected: ExpectedSignature,
+    ) -> Result<()> {
+        let input = &signed.inputs[expected.input_index];
+        match expected.kind {
+            ExpectedSignatureKind::Ecdsa => {
+                let signature = input.partial_sigs.get(&expected.pubkey).with_context(|| {
+                    format!(
+                        "{label} hwi signtx did not add the expected device signature to input {}",
+                        expected.input_index
+                    )
+                })?;
+                if case.verify_signatures {
+                    let mut cache = SighashCache::new(&case.original.unsigned_tx);
+                    let (message, sighash_type) = case
+                        .original
+                        .sighash_ecdsa(expected.input_index, &mut cache)
+                        .with_context(|| {
+                            format!("calculate input {} sighash", expected.input_index)
+                        })?;
+                    if signature.sighash_type != sighash_type {
+                        bail!(
+                            "{label} hwi signtx used an unexpected sighash type on input {}",
+                            expected.input_index
+                        );
+                    }
+                    Secp256k1::verification_only()
+                        .verify_ecdsa(&message, &signature.signature, &expected.pubkey.inner)
+                        .with_context(|| {
+                            format!(
+                                "{label} hwi signtx returned an invalid signature on input {}",
+                                expected.input_index
+                            )
+                        })?;
+                }
+            }
+            ExpectedSignatureKind::TapKey => {
+                let signature = input.tap_key_sig.as_ref().with_context(|| {
+                    format!(
+                        "{label} hwi signtx did not add the expected taproot signature to input {}",
+                        expected.input_index
+                    )
+                })?;
+                if case.verify_signatures {
+                    let prevouts = case
+                        .original
+                        .inputs
+                        .iter()
+                        .enumerate()
+                        .map(|(index, _)| case.original.spend_utxo(index).cloned())
+                        .collect::<std::result::Result<Vec<_>, _>>()?;
+                    let sighash = SighashCache::new(&case.original.unsigned_tx)
+                        .taproot_key_spend_signature_hash(
+                            expected.input_index,
+                            &Prevouts::All(&prevouts),
+                            signature.sighash_type,
+                        )?;
+                    let internal_key = expected.pubkey.inner.x_only_public_key().0;
+                    let tweaked = internal_key
+                        .tap_tweak(
+                            &Secp256k1::verification_only(),
+                            case.original.inputs[expected.input_index].tap_merkle_root,
+                        )
+                        .0
+                        .to_x_only_public_key();
+                    Secp256k1::verification_only()
+                        .verify_schnorr(&signature.signature, &Message::from(sighash), &tweaked)
+                        .with_context(|| {
+                            format!(
+                                "{label} hwi signtx returned an invalid taproot signature on input {}",
+                                expected.input_index
+                            )
+                        })?;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn assert_getxpub_shape(label: &str, json: &Value, expert: bool) -> Result<()> {
@@ -1483,16 +1576,65 @@ mod tests {
     struct SigntxCase {
         psbt: String,
         original: Psbt,
-        expected_pubkey: PublicKey,
+        expected_signatures: Vec<ExpectedSignature>,
         ledger_registers_wallet: bool,
+        verify_signatures: bool,
     }
 
-    fn build_singlesig_signtx_case(device_type: &str) -> Result<SigntxCase> {
+    #[derive(Clone, Copy)]
+    struct ExpectedSignature {
+        input_index: usize,
+        pubkey: PublicKey,
+        kind: ExpectedSignatureKind,
+    }
+
+    #[derive(Clone, Copy)]
+    enum ExpectedSignatureKind {
+        Ecdsa,
+        TapKey,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum LedgerSinglesigWrapper {
+        Legacy,
+        ShWit,
+        Wit,
+        Tap,
+    }
+
+    impl LedgerSinglesigWrapper {
+        const ALL: [Self; 4] = [Self::Legacy, Self::ShWit, Self::Wit, Self::Tap];
+
+        fn purpose(self) -> u32 {
+            match self {
+                Self::Legacy => 44,
+                Self::ShWit => 49,
+                Self::Wit => 84,
+                Self::Tap => 86,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum LedgerMultisigWrapper {
+        Legacy,
+        ShWit,
+        Wit,
+    }
+
+    impl LedgerMultisigWrapper {
+        const ALL: [Self; 3] = [Self::Legacy, Self::ShWit, Self::Wit];
+    }
+
+    fn build_singlesig_signtx_case(
+        device_type: &str,
+        wrapper: LedgerSinglesigWrapper,
+    ) -> Result<SigntxCase> {
         let fingerprint = reference_fingerprint(device_type)?;
-        let account_xpub = reference_xpub(device_type, "m/84'/1'/0'")?;
+        let purpose = wrapper.purpose();
+        let account_path = DerivationPath::from_str(&format!("m/{purpose}'/1'/0'"))?;
+        let account_xpub = reference_xpub(device_type, &format!("m/{purpose}'/1'/0'"))?;
         let secp = Secp256k1::verification_only();
-        let input_path = DerivationPath::from_str("m/84'/1'/0'/0/0")?;
-        let change_path = DerivationPath::from_str("m/84'/1'/0'/1/0")?;
         let input_child_path = DerivationPath::from(vec![
             ChildNumber::from_normal_idx(0)?,
             ChildNumber::from_normal_idx(0)?,
@@ -1505,36 +1647,110 @@ mod tests {
         let change_xpub = account_xpub.derive_pub(&secp, &change_child_path)?;
         let input_pubkey = PublicKey::new(input_xpub.public_key);
         let change_pubkey = PublicKey::new(change_xpub.public_key);
-        let input_script = Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey();
-        let change_script =
-            Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey();
+        let input_path = join_derivation_path(&account_path, &input_child_path);
+        let change_path = join_derivation_path(&account_path, &change_child_path);
+        let input_script = singlesig_script(wrapper, input_pubkey, &secp);
+        let change_script = singlesig_script(wrapper, change_pubkey, &secp);
         let mut psbt = spending_psbt(input_script.clone(), change_script);
-        psbt.inputs[0] = Input {
-            non_witness_utxo: Some(previous_tx(input_script.clone())),
-            witness_utxo: Some(TxOut {
-                value: Amount::from_sat(50_000),
-                script_pubkey: input_script,
-            }),
-            bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
-            ..Default::default()
+        let prev_tx = previous_tx(input_script.clone());
+        let input_txout = TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: input_script,
         };
-        psbt.outputs[0] = PsbtOutput {
-            bip32_derivation: [(change_pubkey.inner, (fingerprint, change_path))].into(),
-            ..Default::default()
-        };
+        if matches!(wrapper, LedgerSinglesigWrapper::Tap) {
+            let input_xonly = input_pubkey.inner.x_only_public_key().0;
+            let change_xonly = change_pubkey.inner.x_only_public_key().0;
+            psbt.inputs[0] = Input {
+                non_witness_utxo: Some(prev_tx),
+                witness_utxo: Some(input_txout),
+                tap_internal_key: Some(input_xonly),
+                tap_key_origins: [(input_xonly, (Vec::new(), (fingerprint, input_path)))].into(),
+                ..Default::default()
+            };
+            psbt.outputs[0] = PsbtOutput {
+                tap_internal_key: Some(change_xonly),
+                tap_key_origins: [(change_xonly, (Vec::new(), (fingerprint, change_path)))].into(),
+                ..Default::default()
+            };
+        } else {
+            let redeem_script = matches!(wrapper, LedgerSinglesigWrapper::ShWit)
+                .then(|| Address::p2wpkh(&input_xpub.to_pub(), Network::Testnet).script_pubkey());
+            let change_redeem_script = matches!(wrapper, LedgerSinglesigWrapper::ShWit)
+                .then(|| Address::p2wpkh(&change_xpub.to_pub(), Network::Testnet).script_pubkey());
+            psbt.inputs[0] = Input {
+                non_witness_utxo: Some(prev_tx),
+                witness_utxo: (!matches!(wrapper, LedgerSinglesigWrapper::Legacy))
+                    .then_some(input_txout),
+                redeem_script,
+                bip32_derivation: [(input_pubkey.inner, (fingerprint, input_path))].into(),
+                ..Default::default()
+            };
+            psbt.outputs[0] = PsbtOutput {
+                redeem_script: change_redeem_script,
+                bip32_derivation: [(change_pubkey.inner, (fingerprint, change_path))].into(),
+                ..Default::default()
+            };
+        }
 
         Ok(SigntxCase {
             psbt: psbt.to_string(),
             original: psbt,
-            expected_pubkey: input_pubkey,
+            expected_signatures: vec![ExpectedSignature {
+                input_index: 0,
+                pubkey: input_pubkey,
+                kind: if matches!(wrapper, LedgerSinglesigWrapper::Tap) {
+                    ExpectedSignatureKind::TapKey
+                } else {
+                    ExpectedSignatureKind::Ecdsa
+                },
+            }],
             ledger_registers_wallet: false,
+            verify_signatures: device_type == "ledger",
         })
     }
 
-    fn build_ledger_multisig_signtx_case(device_type: &str) -> Result<SigntxCase> {
+    fn singlesig_script(
+        wrapper: LedgerSinglesigWrapper,
+        pubkey: PublicKey,
+        secp: &Secp256k1<bitcoin::secp256k1::VerifyOnly>,
+    ) -> ScriptBuf {
+        match wrapper {
+            LedgerSinglesigWrapper::Legacy => {
+                Address::p2pkh(pubkey, Network::Testnet).script_pubkey()
+            }
+            LedgerSinglesigWrapper::ShWit => Address::p2wpkh(
+                &pubkey.try_into().expect("compressed key"),
+                Network::Testnet,
+            )
+            .script_pubkey()
+            .to_p2sh(),
+            LedgerSinglesigWrapper::Wit => Address::p2wpkh(
+                &pubkey.try_into().expect("compressed key"),
+                Network::Testnet,
+            )
+            .script_pubkey(),
+            LedgerSinglesigWrapper::Tap => Address::p2tr(
+                secp,
+                pubkey.inner.x_only_public_key().0,
+                None,
+                Network::Testnet,
+            )
+            .script_pubkey(),
+        }
+    }
+
+    fn build_ledger_multisig_signtx_case(
+        device_type: &str,
+        wrapper: LedgerMultisigWrapper,
+    ) -> Result<SigntxCase> {
         let fingerprint = reference_fingerprint(device_type)?;
-        let device_xpub = reference_xpub(device_type, "m/48'/1'/0'/2'")?;
-        let device_path = DerivationPath::from_str("m/48'/1'/0'/2'")?;
+        let account_path = match wrapper {
+            LedgerMultisigWrapper::Legacy => "m/48'/1'/0'/0'",
+            LedgerMultisigWrapper::ShWit => "m/48'/1'/0'/1'",
+            LedgerMultisigWrapper::Wit => "m/48'/1'/0'/2'",
+        };
+        let device_xpub = reference_xpub(device_type, account_path)?;
+        let device_path = DerivationPath::from_str(account_path)?;
         let secp = Secp256k1::new();
         let change_suffix = DerivationPath::from(vec![
             ChildNumber::from_normal_idx(1)?,
@@ -1548,19 +1764,28 @@ mod tests {
             fingerprint,
             cosigner_xpub,
             cosigner_fingerprint,
+            &device_path,
             &change_suffix,
         )?;
         let input_script = multisig_script(2, &receive);
         let change_script = multisig_script(2, &change);
-        let mut psbt = spending_psbt(input_script.to_p2wsh(), change_script.to_p2wsh());
+        let input_script_pubkey = multisig_script_pubkey(wrapper, &input_script);
+        let change_script_pubkey = multisig_script_pubkey(wrapper, &change_script);
+        let mut psbt = spending_psbt(input_script_pubkey.clone(), change_script_pubkey);
 
         psbt.inputs[0] = Input {
-            non_witness_utxo: Some(previous_tx(input_script.to_p2wsh())),
-            witness_utxo: Some(TxOut {
+            non_witness_utxo: Some(previous_tx(input_script_pubkey.clone())),
+            witness_utxo: (!matches!(wrapper, LedgerMultisigWrapper::Legacy)).then_some(TxOut {
                 value: Amount::from_sat(50_000),
-                script_pubkey: input_script.to_p2wsh(),
+                script_pubkey: input_script_pubkey,
             }),
-            witness_script: Some(input_script),
+            redeem_script: match wrapper {
+                LedgerMultisigWrapper::Legacy => Some(input_script.clone()),
+                LedgerMultisigWrapper::ShWit => Some(input_script.to_p2wsh()),
+                LedgerMultisigWrapper::Wit => None,
+            },
+            witness_script: (!matches!(wrapper, LedgerMultisigWrapper::Legacy))
+                .then_some(input_script),
             bip32_derivation: [
                 (
                     receive[0].inner,
@@ -1575,7 +1800,13 @@ mod tests {
             ..Default::default()
         };
         psbt.outputs[0] = PsbtOutput {
-            witness_script: Some(change_script),
+            redeem_script: match wrapper {
+                LedgerMultisigWrapper::Legacy => Some(change_script.clone()),
+                LedgerMultisigWrapper::ShWit => Some(change_script.to_p2wsh()),
+                LedgerMultisigWrapper::Wit => None,
+            },
+            witness_script: (!matches!(wrapper, LedgerMultisigWrapper::Legacy))
+                .then_some(change_script),
             bip32_derivation: [
                 (
                     change[0].inner,
@@ -1603,8 +1834,66 @@ mod tests {
         Ok(SigntxCase {
             psbt: psbt.to_string(),
             original: psbt,
-            expected_pubkey,
+            expected_signatures: vec![ExpectedSignature {
+                input_index: 0,
+                pubkey: expected_pubkey,
+                kind: ExpectedSignatureKind::Ecdsa,
+            }],
             ledger_registers_wallet: true,
+            verify_signatures: true,
+        })
+    }
+
+    fn multisig_script_pubkey(wrapper: LedgerMultisigWrapper, script: &ScriptBuf) -> ScriptBuf {
+        match wrapper {
+            LedgerMultisigWrapper::Legacy => script.to_p2sh(),
+            LedgerMultisigWrapper::ShWit => script.to_p2wsh().to_p2sh(),
+            LedgerMultisigWrapper::Wit => script.to_p2wsh(),
+        }
+    }
+
+    fn build_ledger_mixed_policy_signtx_case(device_type: &str) -> Result<SigntxCase> {
+        let singlesig = build_singlesig_signtx_case(device_type, LedgerSinglesigWrapper::Wit)?;
+        let multisig = build_ledger_multisig_signtx_case(device_type, LedgerMultisigWrapper::Wit)?;
+        let mut single_input = singlesig.original.unsigned_tx.input[0].clone();
+        let multi_input = multisig.original.unsigned_tx.input[0].clone();
+        single_input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+
+        let unsigned_tx = Transaction {
+            version: TxVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![single_input, multi_input],
+            output: vec![TxOut {
+                value: Amount::from_sat(99_000),
+                script_pubkey: singlesig.original.unsigned_tx.output[0]
+                    .script_pubkey
+                    .clone(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx)?;
+        psbt.inputs = vec![
+            singlesig.original.inputs[0].clone(),
+            multisig.original.inputs[0].clone(),
+        ];
+        psbt.outputs = vec![singlesig.original.outputs[0].clone()];
+        psbt.xpub = multisig.original.xpub.clone();
+
+        let expected_signatures = vec![
+            ExpectedSignature {
+                input_index: 0,
+                ..singlesig.expected_signatures[0]
+            },
+            ExpectedSignature {
+                input_index: 1,
+                ..multisig.expected_signatures[0]
+            },
+        ];
+        Ok(SigntxCase {
+            psbt: psbt.to_string(),
+            original: psbt,
+            expected_signatures,
+            ledger_registers_wallet: true,
+            verify_signatures: true,
         })
     }
 
@@ -1631,6 +1920,7 @@ mod tests {
                 device_fingerprint,
                 cosigner_xpub,
                 cosigner_fingerprint,
+                device_path,
                 &receive_suffix,
             )?;
             if receive
@@ -1656,21 +1946,21 @@ mod tests {
         device_fingerprint: Fingerprint,
         cosigner_xpub: Xpub,
         cosigner_fingerprint: Fingerprint,
+        account_path: &DerivationPath,
         suffix: &DerivationPath,
     ) -> Result<Vec<DerivedKey>> {
         let device = device_xpub.derive_pub(secp, suffix)?;
         let cosigner = cosigner_xpub.derive_pub(secp, suffix)?;
-        let account_path = DerivationPath::from_str("m/48'/1'/0'/2'")?;
         let mut keys = vec![
             DerivedKey {
                 inner: device.public_key,
                 fingerprint: device_fingerprint,
-                derivation_path: join_derivation_path(&account_path, suffix),
+                derivation_path: join_derivation_path(account_path, suffix),
             },
             DerivedKey {
                 inner: cosigner.public_key,
                 fingerprint: cosigner_fingerprint,
-                derivation_path: join_derivation_path(&account_path, suffix),
+                derivation_path: join_derivation_path(account_path, suffix),
             },
         ];
         keys.sort_by_key(|key| key.inner.serialize());
@@ -1748,6 +2038,11 @@ mod tests {
     }
 
     fn reference_xpub(device_type: &str, path: &str) -> Result<Xpub> {
+        if device_type == "ledger" {
+            // Ledger asks for confirmation before exporting non-standard paths,
+            // including the BIP-48 legacy and nested multisig branches.
+            set_ledger_automation(true)?;
+        }
         let output = HwiBinary::reference()?.run(args([
             "--emulators",
             "--chain",

--- a/e2e/ledger/src/multisig.rs
+++ b/e2e/ledger/src/multisig.rs
@@ -13,8 +13,9 @@ use bhwi::bitcoin::{
     Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
     absolute::LockTime,
     bip32::{ChainCode, ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub},
-    psbt::{Input, Psbt},
+    psbt::Psbt,
     secp256k1::{All, Secp256k1},
+    sighash::SighashCache,
     transaction::Version as TxVersion,
 };
 use bhwi::ledger::{LedgerWalletPolicy, Version};
@@ -26,7 +27,9 @@ use miniscript::psbt::{PsbtInputExt, PsbtOutputExt};
 
 use crate::tests::{SpeculosDevice, SpeculosReqwestClient, init};
 
-/// Account-level derivation path for BIP-48 native segwit / taproot multisig.
+/// Account-level derivation paths for Ledger's BIP-48 multisig policies.
+const LEGACY_MULTISIG_ACCOUNT_PATH: &str = "m/48'/1'/0'/0'";
+const NESTED_MULTISIG_ACCOUNT_PATH: &str = "m/48'/1'/0'/1'";
 const MULTISIG_ACCOUNT_PATH: &str = "m/48'/1'/0'/2'";
 
 /// BIP-341 NUMS point `H`, used as an unspendable taproot internal key so a
@@ -180,6 +183,7 @@ fn build_psbt(
     secp: &Secp256k1<All>,
     receive: &Descriptor<DefiniteDescriptorKey>,
     change: &Descriptor<DefiniteDescriptorKey>,
+    legacy: bool,
 ) -> Psbt {
     let input_script = receive.derived_descriptor(secp).script_pubkey();
     let change_script = change.derived_descriptor(secp).script_pubkey();
@@ -217,10 +221,12 @@ fn build_psbt(
     };
 
     let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
-    psbt.inputs[0].witness_utxo = Some(TxOut {
-        value: INPUT_VALUE,
-        script_pubkey: input_script,
-    });
+    if !legacy {
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: INPUT_VALUE,
+            script_pubkey: input_script,
+        });
+    }
     psbt.inputs[0].non_witness_utxo = Some(prev_tx);
     psbt.inputs[0]
         .update_with_descriptor_unchecked(receive)
@@ -234,7 +240,8 @@ fn build_psbt(
 /// Asserts the signed input carries exactly one signature and it is the
 /// device's (ecdsa `partial_sigs` for wsh, schnorr `tap_script_sigs` for the
 /// taproot script path).
-fn assert_device_signed_once(input: &Input, device: PublicKey) {
+fn assert_device_signed_once(psbt: &Psbt, device: PublicKey) {
+    let input = &psbt.inputs[0];
     let total = input.partial_sigs.len()
         + input.tap_script_sigs.len()
         + usize::from(input.tap_key_sig.is_some());
@@ -247,15 +254,33 @@ fn assert_device_signed_once(input: &Input, device: PublicKey) {
             .keys()
             .any(|(xonly, _)| *xonly == device_xonly);
     assert!(signed, "device key signature missing");
+
+    if let Some(signature) = input.partial_sigs.get(&device) {
+        let mut cache = SighashCache::new(&psbt.unsigned_tx);
+        let (message, sighash_type) = psbt.sighash_ecdsa(0, &mut cache).unwrap();
+        assert_eq!(signature.sighash_type, sighash_type);
+        Secp256k1::verification_only()
+            .verify_ecdsa(&message, &signature.signature, &device.inner)
+            .expect("device ECDSA signature must verify");
+    }
 }
 
 /// Reads the device key, builds the descriptor via `build`, then runs the full
 /// register + display-address + sign flow over a single device connection.
 /// `build` receives the secp context and the device key (always `keys[0]`).
 async fn run_flow(name: &str, build: impl FnOnce(&Secp256k1<All>, &Key) -> String) {
+    run_flow_at_path(MULTISIG_ACCOUNT_PATH, name, build).await;
+}
+
+async fn run_flow_at_path(
+    account_path: &str,
+    name: &str,
+    build: impl FnOnce(&Secp256k1<All>, &Key) -> String,
+) {
     let secp = Secp256k1::new();
     let (mut dev, client) = init().await;
-    let device = Key::device(&mut dev, MULTISIG_ACCOUNT_PATH).await;
+    load_automation(&client, include_str!("../automations/hwi_speculos.json")).await;
+    let device = Key::device(&mut dev, account_path).await;
     let descriptor = build(&secp, &device);
 
     let ctx = register(&mut dev, &client, name, &descriptor).await;
@@ -287,14 +312,62 @@ async fn run_flow(name: &str, build: impl FnOnce(&Secp256k1<All>, &Key) -> Strin
         .expect("display multisig address");
     assert_eq!(address, expected_address);
 
-    let psbt = build_psbt(&secp, &receive, &change);
+    let psbt = build_psbt(
+        &secp,
+        &receive,
+        &change,
+        descriptor.starts_with("sh(sortedmulti("),
+    );
     load_automation(&client, include_str!("../automations/sign_psbt.json")).await;
     let signed = dev
-        .sign_tx(psbt, Some(ctx))
+        .sign_tx(psbt.clone(), Some(ctx.clone()))
         .await
         .expect("sign multisig psbt");
     assert_eq!(signed.inputs.len(), 1);
-    assert_device_signed_once(&signed.inputs[0], device.receive_pubkey(&secp));
+    assert_device_signed_once(&signed, device.receive_pubkey(&secp));
+
+    // Ledger stores no wallet registry. Reusing the caller-retained descriptor
+    // and HMAC must sign again without another registration round trip.
+    load_automation(&client, include_str!("../automations/sign_psbt.json")).await;
+    let signed_again = dev
+        .sign_tx(psbt, Some(ctx))
+        .await
+        .expect("sign previously registered multisig psbt");
+    assert_device_signed_once(&signed_again, device.receive_pubkey(&secp));
+}
+
+#[tokio::test]
+async fn sh_sortedmulti_2of2() {
+    run_flow_at_path(
+        LEGACY_MULTISIG_ACCOUNT_PATH,
+        "legacymulti",
+        |secp, device| {
+            let cosigner = Key::cosigner(secp, 0xa5, LEGACY_MULTISIG_ACCOUNT_PATH);
+            format!(
+                "sh(sortedmulti(2,{},{}))",
+                device.descriptor_key(),
+                cosigner.descriptor_key()
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn sh_wsh_sortedmulti_2of2() {
+    run_flow_at_path(
+        NESTED_MULTISIG_ACCOUNT_PATH,
+        "nestedmulti",
+        |secp, device| {
+            let cosigner = Key::cosigner(secp, 0xa5, NESTED_MULTISIG_ACCOUNT_PATH);
+            format!(
+                "sh(wsh(sortedmulti(2,{},{})))",
+                device.descriptor_key(),
+                cosigner.descriptor_key()
+            )
+        },
+    )
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #70.

## Summary

- complete Ledger HWI `signtx` support for default policies and registered classic sorted multisig
- discover mixed policies across PSBT inputs, sign them sequentially, and merge signatures into the original PSBT
- validate policy derivations, scripts, UTXOs, and retained registration HMACs with contextual errors for unsupported shapes
- fix Ledger Merkle lookups for optional missing PSBT keys used during legacy signing
- document the supported parity set and add direct, CLI, and differential emulator coverage

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
- `cargo test --verbose --no-default-features`
- `cargo test --verbose --color always -- --nocapture`
- `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
- Ledger direct and CLI emulator cases passed; aggregate runs encountered a cumulative Speculos `UnicodeDecodeError`, and the affected cases passed individually on a fresh emulator
- `nix run .#hwi-parity-ledger -- candidate_signtx_matches_reference -- --test-threads=1`
- `nix run .#hwi-upstream-ledger` (22 passed, 6 expected skips)

## Compatibility

- no public API changes
- native `register-wallet` and `sign-psbt` behavior is unchanged
