### PR TITLE
refactor(bhwi): isolate device interpreters from common types

### DIFF
--- a/bhwi-async/src/bitbox.rs
+++ b/bhwi-async/src/bitbox.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use bhwi::{
     Interpreter,
     bitbox::{
-        BitBoxCommand, BitBoxInterpreter, BitBoxResponse,
+        BitBoxCommand, BitBoxInterpreter, BitBoxResponse, BitBoxTransmit,
         error::BitBoxError,
         noise::{NoiseConfigData, NoiseState, PairingCodeHook},
     },
@@ -105,7 +105,7 @@ impl<T: Transport> BitBox<T> {
         use crate::CommonInterface;
         let (transport, _http, mut interpreter) = <BitBox<T> as CommonInterface<
             RawCommand,
-            common::Transmit,
+            BitBoxTransmit,
             BitBoxResponse,
             BitBoxError,
         >>::components(self);
@@ -130,7 +130,7 @@ impl<T: Transport> BitBox<T> {
 impl<C, T, R, E, F> crate::CommonInterface<C, T, R, E> for BitBox<F>
 where
     C: TryInto<BitBoxCommand, Error = BitBoxError>,
-    T: From<common::Transmit>,
+    T: From<BitBoxTransmit>,
     R: From<BitBoxResponse>,
     E: From<BitBoxError>,
     F: Transport,

--- a/bhwi/src/bitbox/interpreter.rs
+++ b/bhwi/src/bitbox/interpreter.rs
@@ -1,15 +1,10 @@
 use std::marker::PhantomData;
 
-use bitcoin::address::AddressType;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
 use prost::Message;
 
 use crate::Interpreter;
-use crate::common::{
-    Command, DeviceBackup, DeviceContext, DisplayAddress, Error, Info, Recipient, Response,
-    Transmit,
-};
 
 use super::api;
 use super::error::{BitBoxDeviceError, BitBoxError};
@@ -17,14 +12,13 @@ use super::noise::{HandshakeState, NoiseState};
 use super::proto as pb;
 use super::sign::{OurKey, Transaction, TxOutput, apply_signatures, is_schnorr};
 use super::{
-    ManagementContext, OP_HER_COMEZ_TEH_HANDSHAEK, OP_I_CAN_HAS_HANDSHAEK,
-    OP_I_CAN_HAS_PAIRIN_VERIFICASHUN, OP_NOISE_MSG, OP_UNLOCK, RESPONSE_SUCCESS, SetupMode,
+    OP_HER_COMEZ_TEH_HANDSHAEK, OP_I_CAN_HAS_HANDSHAEK, OP_I_CAN_HAS_PAIRIN_VERIFICASHUN,
+    OP_NOISE_MSG, OP_UNLOCK, RESPONSE_SUCCESS, SetupMode,
 };
 use super::{antiklepto, policy};
 
-/// Public BitBox02 command surface. Mirrors the shape of Coldcard/Ledger command enums
-/// in this crate: converted from `common::Command` by `TryFrom`. The target network is not
-/// carried per-command; it is interpreter state (see `BitBoxInterpreter::with_network`).
+/// Public BitBox02 command surface. The target network is not carried per-command;
+/// it is interpreter state (see `BitBoxInterpreter::with_network`).
 #[derive(Clone, Debug)]
 pub enum BitBoxCommand {
     UnlockAndPair,
@@ -106,7 +100,7 @@ pub enum BitBoxCommand {
 pub enum BitBoxResponse {
     TaskDone,
     DeviceAction(bool),
-    Info(Info),
+    Info(BitBoxDeviceInfo),
     MasterFingerprint(Fingerprint),
     Xpub(Xpub),
     Address(String),
@@ -117,6 +111,18 @@ pub enum BitBoxResponse {
     SignedPsbt(Box<Psbt>),
     Signature(u8, bitcoin::secp256k1::ecdsa::Signature),
     Backup,
+}
+
+#[derive(Clone, Debug)]
+pub struct BitBoxDeviceInfo {
+    pub version: String,
+    pub name: String,
+    pub initialized: bool,
+}
+
+pub struct BitBoxTransmit {
+    pub payload: Vec<u8>,
+    pub encrypted: bool,
 }
 
 /// Internal state machine.
@@ -274,17 +280,15 @@ fn expect_success(response: &[u8]) -> Result<&[u8], BitBoxError> {
     Ok(&response[1..])
 }
 
-fn encrypted_transmit(bytes: Vec<u8>) -> Transmit {
-    Transmit {
-        recipient: Recipient::Device,
+fn encrypted_transmit(bytes: Vec<u8>) -> BitBoxTransmit {
+    BitBoxTransmit {
         payload: bytes,
         encrypted: true,
     }
 }
 
-fn plain_transmit(bytes: Vec<u8>) -> Transmit {
-    Transmit {
-        recipient: Recipient::Device,
+fn plain_transmit(bytes: Vec<u8>) -> BitBoxTransmit {
+    BitBoxTransmit {
         payload: bytes,
         encrypted: false,
     }
@@ -302,36 +306,6 @@ fn build_sign_init_request(coin: pb::BtcCoin, tx: &Transaction) -> pb::request::
         format_unit: pb::btc_sign_init_request::FormatUnit::Default as _,
         contains_silent_payment_outputs: false,
     })
-}
-
-/// Pick the single-sig script type BitBox02 signs a message under, from the BIP-44-style
-/// purpose in the keypath. Defaults to native segwit.
-fn simple_type_from_path(path: &DerivationPath) -> pb::btc_script_config::SimpleType {
-    use pb::btc_script_config::SimpleType;
-    match path.into_iter().next() {
-        Some(ChildNumber::Hardened { index: 49 }) => SimpleType::P2wpkhP2sh,
-        Some(ChildNumber::Hardened { index: 86 }) => SimpleType::P2tr,
-        _ => SimpleType::P2wpkh,
-    }
-}
-
-fn simple_type_from_address_format(
-    path: &DerivationPath,
-    address_format: Option<AddressType>,
-) -> Result<pb::btc_script_config::SimpleType, BitBoxError> {
-    use pb::btc_script_config::SimpleType;
-    match address_format {
-        None => Ok(simple_type_from_path(path)),
-        Some(AddressType::P2sh) => Ok(SimpleType::P2wpkhP2sh),
-        Some(AddressType::P2wpkh) => Ok(SimpleType::P2wpkh),
-        Some(AddressType::P2tr) => Ok(SimpleType::P2tr),
-        Some(AddressType::P2pkh | AddressType::P2wsh) => Err(BitBoxError::InvalidInput(
-            "BitBox does not support this address format",
-        )),
-        _ => Err(BitBoxError::InvalidInput(
-            "BitBox does not support this address format",
-        )),
-    }
 }
 
 /// Build the full address keypath for a policy address: our account origin path (identified
@@ -672,12 +646,13 @@ impl<C, T, R, E> BitBoxInterpreter<'_, C, T, R, E> {
         let response = self.decode_encrypted_response(data)?;
         use pb::response::Response as R;
         match (ctx, response) {
-            (EncryptedContext::Version, R::DeviceInfo(info)) => Ok(BitBoxResponse::Info(Info {
-                version: info.version,
-                networks: vec![],
-                firmware: Some(info.name),
-                initialized: Some(info.initialized),
-            })),
+            (EncryptedContext::Version, R::DeviceInfo(info)) => {
+                Ok(BitBoxResponse::Info(BitBoxDeviceInfo {
+                    version: info.version,
+                    name: info.name,
+                    initialized: info.initialized,
+                }))
+            }
             (EncryptedContext::MasterFingerprint, R::Fingerprint(f)) => {
                 if f.fingerprint.len() != 4 {
                     return Err(BitBoxError::InvalidSignature);
@@ -715,7 +690,7 @@ impl<C, T, R, E> BitBoxInterpreter<'_, C, T, R, E> {
 impl<C, T, R, E> Interpreter for BitBoxInterpreter<'_, C, T, R, E>
 where
     C: TryInto<BitBoxCommand, Error = BitBoxError>,
-    T: From<Transmit>,
+    T: From<BitBoxTransmit>,
     R: From<BitBoxResponse>,
     E: From<BitBoxError>,
 {
@@ -1327,173 +1302,6 @@ where
     }
 }
 
-impl TryFrom<Command> for BitBoxCommand {
-    type Error = BitBoxError;
-    fn try_from(cmd: Command) -> Result<Self, Self::Error> {
-        match cmd {
-            Command::Setup(options, context) => {
-                if !options.backup_passphrase.is_empty() {
-                    return Err(BitBoxError::InvalidInput(
-                        "Passphrase not needed when setting up a BitBox02.",
-                    ));
-                }
-                let Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
-                    mode,
-                    timestamp,
-                    timezone_offset,
-                })) = context
-                else {
-                    return Err(BitBoxError::InvalidInput(
-                        "BitBox setup requires DeviceContext::BitBoxManagement",
-                    ));
-                };
-                Ok(BitBoxCommand::Setup {
-                    label: options.label,
-                    mode,
-                    timestamp,
-                    timezone_offset,
-                })
-            }
-            Command::Wipe => Ok(BitBoxCommand::Wipe),
-            Command::Restore(options, context) => {
-                let Some(DeviceContext::BitBoxManagement(ManagementContext::Restore {
-                    timestamp,
-                    timezone_offset,
-                })) = context
-                else {
-                    return Err(BitBoxError::InvalidInput(
-                        "BitBox restore requires DeviceContext::BitBoxManagement",
-                    ));
-                };
-                Ok(BitBoxCommand::Restore {
-                    label: options.label,
-                    timestamp,
-                    timezone_offset,
-                })
-            }
-            Command::TogglePassphrase => Ok(BitBoxCommand::TogglePassphrase),
-            Command::Unlock { .. } => Ok(BitBoxCommand::UnlockAndPair),
-            Command::GetVersion => Ok(BitBoxCommand::GetVersion),
-            Command::GetMasterFingerprint => Ok(BitBoxCommand::GetMasterFingerprint),
-            Command::GetXpub { path, display } => Ok(BitBoxCommand::GetXpub {
-                keypath: path,
-                display,
-            }),
-            Command::DisplayAddress(
-                DisplayAddress::ByPath {
-                    path,
-                    display,
-                    address_format,
-                },
-                _,
-            ) => {
-                let simple_type = simple_type_from_address_format(&path, address_format)?;
-                Ok(BitBoxCommand::ShowSimpleAddress {
-                    keypath: path,
-                    simple_type,
-                    display,
-                })
-            }
-            Command::DisplayAddress(
-                DisplayAddress::ByDescriptor {
-                    index,
-                    change,
-                    display,
-                    ..
-                },
-                context,
-            ) => {
-                let policy = match context {
-                    Some(DeviceContext::BitBox { policy }) => {
-                        policy::Policy::from_wallet_policy(&policy)?
-                    }
-                    _ => {
-                        return Err(BitBoxError::InvalidInput(
-                            "BitBox requires DeviceContext::BitBox for descriptor address display",
-                        ));
-                    }
-                };
-                Ok(BitBoxCommand::ShowDescriptorAddress {
-                    policy,
-                    change,
-                    index,
-                    display,
-                })
-            }
-            Command::DisplayAddress(DisplayAddress::ByMultisig(_), _) => Err(
-                BitBoxError::InvalidInput("BitBox raw multisig display is not implemented"),
-            ),
-            Command::RegisterWallet { name, policy } => Ok(BitBoxCommand::RegisterScriptConfig {
-                policy: policy::Policy::from_wallet_policy(&policy)?,
-                name,
-            }),
-            Command::SignTx(psbt, context) => {
-                // A `DeviceContext::BitBox` carries the registered wallet policy to sign under;
-                // without it, only single-sig inputs (inferred from the PSBT) can be signed.
-                let policy = match context {
-                    None => None,
-                    Some(DeviceContext::BitBox { policy }) => {
-                        Some(policy::Policy::from_wallet_policy(&policy)?)
-                    }
-                    Some(_) => {
-                        return Err(BitBoxError::InvalidInput(
-                            "BitBox requires DeviceContext::BitBox for policy signing",
-                        ));
-                    }
-                };
-                Ok(BitBoxCommand::SignPsbt {
-                    psbt: Box::new(psbt),
-                    force_script_config: None,
-                    policy,
-                })
-            }
-            Command::SignMessage { message, path } => Ok(BitBoxCommand::SignMessage {
-                simple_type: simple_type_from_path(&path),
-                keypath: path,
-                message,
-            }),
-            Command::Backup => Ok(BitBoxCommand::Backup),
-        }
-    }
-}
-
-impl From<BitBoxResponse> for Response {
-    fn from(res: BitBoxResponse) -> Response {
-        match res {
-            BitBoxResponse::TaskDone => Response::TaskDone,
-            BitBoxResponse::DeviceAction(success) => Response::DeviceAction(success),
-            BitBoxResponse::Info(info) => Response::Info(info),
-            BitBoxResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
-            BitBoxResponse::Xpub(xpub) => Response::Xpub(xpub),
-            BitBoxResponse::Address(addr) => Response::Address(addr),
-            BitBoxResponse::IsRegistered(_) => Response::TaskDone,
-            BitBoxResponse::Registered => {
-                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
-                    hmac: None,
-                })
-            }
-            BitBoxResponse::SignedPsbt(psbt) => Response::SignedPsbt(*psbt),
-            BitBoxResponse::Signature(header, sig) => Response::Signature(header, sig),
-            BitBoxResponse::Backup => Response::Backup(DeviceBackup::Complete),
-        }
-    }
-}
-
-impl From<BitBoxError> for Error {
-    fn from(e: BitBoxError) -> Error {
-        match e {
-            BitBoxError::Device(super::error::BitBoxDeviceError::UserAbort) => {
-                Error::AuthenticationRefused
-            }
-            BitBoxError::NoisePairingRejected => Error::AuthenticationRefused,
-            BitBoxError::ProtobufDecode(s) | BitBoxError::ProtobufEncode(s) => {
-                Error::Serialization(s)
-            }
-            other => Error::Serialization(other.to_string()),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1501,39 +1309,8 @@ mod tests {
     use miniscript::descriptor::WalletPolicy;
     use std::str::FromStr;
 
-    fn simple(path: &str) -> pb::btc_script_config::SimpleType {
-        simple_type_from_path(&DerivationPath::from_str(path).unwrap())
-    }
-
     fn policy_from(descriptor: &str) -> policy::Policy {
         policy::Policy::from_wallet_policy(&WalletPolicy::from_str(descriptor).unwrap()).unwrap()
-    }
-
-    #[test]
-    fn simple_type_matches_purpose() {
-        use pb::btc_script_config::SimpleType;
-        assert_eq!(simple("m/84'/0'/0'/0/0"), SimpleType::P2wpkh);
-        assert_eq!(simple("m/49'/0'/0'/0/0"), SimpleType::P2wpkhP2sh);
-        assert_eq!(simple("m/86'/0'/0'/0/0"), SimpleType::P2tr);
-        // Unknown/legacy purposes fall back to native segwit.
-        assert_eq!(simple("m/44'/0'/0'/0/0"), SimpleType::P2wpkh);
-    }
-
-    #[test]
-    fn display_path_address_format_selects_simple_type() {
-        use pb::btc_script_config::SimpleType;
-        let path = DerivationPath::from_str("m/49'/0'/0'/0/0").unwrap();
-
-        let nested = simple_type_from_address_format(&path, Some(AddressType::P2sh)).unwrap();
-        let native = simple_type_from_address_format(&path, Some(AddressType::P2wpkh)).unwrap();
-        let taproot = simple_type_from_address_format(&path, Some(AddressType::P2tr)).unwrap();
-        let default = simple_type_from_address_format(&path, None).unwrap();
-
-        assert_eq!(nested, SimpleType::P2wpkhP2sh);
-        assert_eq!(native, SimpleType::P2wpkh);
-        assert_eq!(taproot, SimpleType::P2tr);
-        assert_eq!(default, SimpleType::P2wpkhP2sh);
-        assert!(simple_type_from_address_format(&path, Some(AddressType::P2pkh)).is_err());
     }
 
     #[test]
@@ -1587,124 +1364,5 @@ mod tests {
         let policy = policy_from(DECAYING_POLICY);
         let unknown = Fingerprint::from_str("deadbeef").unwrap();
         assert!(policy_script_config(&policy, &unknown.as_bytes()[..]).is_err());
-    }
-
-    #[test]
-    fn common_backup_maps_to_bitbox_backup() {
-        let command = BitBoxCommand::try_from(Command::Backup).unwrap();
-        assert!(matches!(command, BitBoxCommand::Backup));
-    }
-
-    #[test]
-    fn common_setup_maps_to_bitbox_setup() {
-        let command = BitBoxCommand::try_from(Command::Setup(
-            crate::common::SetupOptions {
-                label: "BHWI".into(),
-                backup_passphrase: String::new(),
-            },
-            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
-                mode: SetupMode::NewWallet {
-                    entropy: super::super::SetupEntropy::new([42; 32]),
-                },
-                timestamp: 1_601_450_521,
-                timezone_offset: 3_600,
-            })),
-        ))
-        .unwrap();
-        assert!(matches!(
-            command,
-            BitBoxCommand::Setup {
-                label,
-                mode: SetupMode::NewWallet { .. },
-                timestamp: 1_601_450_521,
-                timezone_offset: 3_600,
-            } if label == "BHWI"
-        ));
-    }
-
-    #[test]
-    fn common_setup_requires_context_and_rejects_passphrase() {
-        let missing_context =
-            BitBoxCommand::try_from(Command::Setup(crate::common::SetupOptions::default(), None));
-        assert!(matches!(missing_context, Err(BitBoxError::InvalidInput(_))));
-
-        let passphrase = BitBoxCommand::try_from(Command::Setup(
-            crate::common::SetupOptions {
-                label: String::new(),
-                backup_passphrase: "secret".into(),
-            },
-            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
-                mode: SetupMode::RestoreFromMnemonic,
-                timestamp: 0,
-                timezone_offset: 0,
-            })),
-        ));
-        assert!(matches!(passphrase, Err(BitBoxError::InvalidInput(_))));
-    }
-
-    #[test]
-    fn bitbox_setup_response_maps_to_device_action() {
-        assert!(matches!(
-            Response::from(BitBoxResponse::DeviceAction(false)),
-            Response::DeviceAction(false)
-        ));
-    }
-
-    #[test]
-    fn common_wipe_maps_to_bitbox_wipe() {
-        assert!(matches!(
-            BitBoxCommand::try_from(Command::Wipe),
-            Ok(BitBoxCommand::Wipe)
-        ));
-    }
-
-    #[test]
-    fn common_restore_maps_to_bitbox_restore_and_ignores_word_count() {
-        let command = BitBoxCommand::try_from(Command::Restore(
-            crate::common::RestoreOptions {
-                label: "Recovered".into(),
-                word_count: 12,
-            },
-            Some(DeviceContext::BitBoxManagement(
-                ManagementContext::Restore {
-                    timestamp: 1_601_450_521,
-                    timezone_offset: -3_600,
-                },
-            )),
-        ))
-        .unwrap();
-        assert!(matches!(
-            command,
-            BitBoxCommand::Restore {
-                label,
-                timestamp: 1_601_450_521,
-                timezone_offset: -3_600,
-            } if label == "Recovered"
-        ));
-    }
-
-    #[test]
-    fn common_restore_requires_context() {
-        assert!(matches!(
-            BitBoxCommand::try_from(Command::Restore(
-                crate::common::RestoreOptions::default(),
-                None,
-            )),
-            Err(BitBoxError::InvalidInput(_))
-        ));
-    }
-
-    #[test]
-    fn common_toggle_passphrase_maps_to_bitbox_command() {
-        assert!(matches!(
-            BitBoxCommand::try_from(Command::TogglePassphrase),
-            Ok(BitBoxCommand::TogglePassphrase)
-        ));
-    }
-
-    #[test]
-    fn bitbox_backup_response_maps_to_completed_backup() {
-        let response = Response::from(BitBoxResponse::Backup);
-        assert!(matches!(response, Response::Backup(DeviceBackup::Complete)));
     }
 }

--- a/bhwi/src/bitbox/mod.rs
+++ b/bhwi/src/bitbox/mod.rs
@@ -8,7 +8,9 @@ pub mod proto;
 pub mod sign;
 pub mod u2f;
 
-pub use interpreter::{BitBoxCommand, BitBoxInterpreter, BitBoxResponse};
+pub use interpreter::{
+    BitBoxCommand, BitBoxDeviceInfo, BitBoxInterpreter, BitBoxResponse, BitBoxTransmit,
+};
 
 use std::fmt;
 

--- a/bhwi/src/coldcard/mod.rs
+++ b/bhwi/src/coldcard/mod.rs
@@ -8,19 +8,11 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder};
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
-use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature};
+use bitcoin::secp256k1::ecdsa::Signature;
 
 use crate::Interpreter;
 use crate::coldcard::api::response::ResponseMessage;
-use crate::common::{
-    Command, DeviceBackup, DisplayAddress, Error, Info, MultisigAddressType,
-    MultisigDisplayAddress, Recipient, Response, Transmit,
-};
 use crate::device::DeviceId;
-use crate::miniscript::{
-    Descriptor, Miniscript, ScriptContext, Terminal,
-    descriptor::{DescriptorPublicKey, ShInner, SinglePubKey, WalletPolicy, Wildcard},
-};
 
 pub const DEFAULT_CKCC_SOCKET: &str = "/tmp/ckcc-simulator.sock";
 pub const COLDCARD_DEVICE_ID: DeviceId = DeviceId::new(0xd13e)
@@ -100,15 +92,15 @@ pub enum ColdcardCommand {
 }
 
 pub struct ColdcardMultisigDisplayAddress {
-    threshold: u8,
-    address_type: MultisigAddressType,
-    keys: Vec<ColdcardMultisigDisplayKey>,
+    pub threshold: u8,
+    pub address_format: u32,
+    pub keys: Vec<ColdcardMultisigDisplayKey>,
 }
 
-struct ColdcardMultisigDisplayKey {
-    fingerprint: Fingerprint,
-    path: DerivationPath,
-    public_key: PublicKey,
+pub struct ColdcardMultisigDisplayKey {
+    pub fingerprint: Fingerprint,
+    pub path: DerivationPath,
+    pub public_key: PublicKey,
 }
 
 pub enum ColdcardResponse {
@@ -271,7 +263,7 @@ where
                         .map(|key| (key.fingerprint, key.path.clone()))
                         .collect::<Vec<_>>(),
                     &multisig_redeem_script(address)?,
-                    multisig_addr_fmt(address.address_type),
+                    address.address_format,
                 ),
                 self.encryption,
             )?,
@@ -571,254 +563,6 @@ where
     }
 }
 
-impl TryFrom<Command> for ColdcardCommand {
-    type Error = ColdcardError;
-    fn try_from(cmd: Command) -> Result<Self, Self::Error> {
-        match cmd {
-            Command::Setup(..) => Err(ColdcardError::MissingCommandInfo(
-                "Setup not supported by Coldcard",
-            )),
-            Command::Wipe => Err(ColdcardError::MissingCommandInfo(
-                "Wipe not supported by Coldcard",
-            )),
-            Command::Restore(..) => Err(ColdcardError::MissingCommandInfo(
-                "Restore not supported by Coldcard",
-            )),
-            Command::TogglePassphrase => Err(ColdcardError::MissingCommandInfo(
-                "Toggle passphrase not supported by Coldcard",
-            )),
-            Command::Backup => Ok(Self::Backup),
-            Command::Unlock { .. } => Ok(Self::StartEncryption),
-            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
-            Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
-            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
-            Command::GetVersion => Ok(Self::GetVersion),
-            Command::DisplayAddress(
-                DisplayAddress::ByPath {
-                    path,
-                    address_format,
-                    ..
-                },
-                ..,
-            ) => Ok(Self::ShowAddress {
-                path,
-                addr_fmt: address_format
-                    .map(api::request::addr_fmt::from_address_type)
-                    .unwrap_or(api::request::addr_fmt::AF_P2WPKH),
-            }),
-            Command::DisplayAddress(
-                DisplayAddress::ByDescriptor {
-                    descriptor_name,
-                    change,
-                    index,
-                    ..
-                },
-                ..,
-            ) => Ok(Self::MiniscriptAddress {
-                name: descriptor_name,
-                change,
-                index,
-            }),
-            Command::DisplayAddress(DisplayAddress::ByMultisig(address), ..) => {
-                Ok(Self::ShowP2shAddress {
-                    address: coldcard_multisig_display_address(address)?,
-                })
-            }
-            Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
-                payload: coldcard_registration_payload(&name, &policy)?,
-            }),
-            Command::SignTx(psbt, context) => {
-                if context.is_some() {
-                    return Err(ColdcardError::MissingCommandInfo(
-                        "Coldcard SignTx does not support device context",
-                    ));
-                }
-                Ok(Self::SignPsbt { psbt })
-            }
-        }
-    }
-}
-
-fn coldcard_registration_payload(
-    name: &str,
-    policy: &WalletPolicy,
-) -> Result<Vec<u8>, ColdcardError> {
-    if !(2..=20).contains(&name.len())
-        || !name
-            .bytes()
-            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
-    {
-        return Err(ColdcardError::InvalidInput(
-            "Coldcard wallet names must be 2 to 20 printable ASCII characters".to_string(),
-        ));
-    }
-
-    let descriptor = policy
-        .clone()
-        .into_descriptor()
-        .map_err(|error| ColdcardError::InvalidInput(error.to_string()))?;
-    let (threshold, signer_count) = coldcard_sortedmulti_size(&descriptor).ok_or_else(|| {
-        ColdcardError::InvalidInput(
-            "Coldcard registration supports only sh(sortedmulti), wsh(sortedmulti), and sh(wsh(sortedmulti)) descriptors"
-                .to_string(),
-        )
-    })?;
-    if threshold == 0 || threshold > signer_count || signer_count > 15 {
-        return Err(ColdcardError::InvalidInput(
-            "Coldcard multisig policies require 1 to 15 signers and a valid threshold".to_string(),
-        ));
-    }
-    for key in descriptor.iter_pk() {
-        validate_coldcard_registration_key(&key)?;
-    }
-
-    let descriptor = format!("{descriptor:#}");
-    let payload = serde_json::to_vec(&serde_json::json!({
-        "name": name,
-        "desc": descriptor,
-    }))
-    .map_err(|error| ColdcardError::Serialization(error.to_string()))?;
-    if !(101..=4000).contains(&payload.len()) {
-        return Err(ColdcardError::InvalidInput(
-            "Coldcard multisig registration payload must be 101 to 4000 bytes".to_string(),
-        ));
-    }
-    Ok(payload)
-}
-
-fn coldcard_sortedmulti_size(
-    descriptor: &Descriptor<DescriptorPublicKey>,
-) -> Option<(usize, usize)> {
-    match descriptor {
-        Descriptor::Sh(sh) => match sh.as_inner() {
-            ShInner::Ms(miniscript) => sortedmulti_size(miniscript),
-            ShInner::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
-            ShInner::Wpkh(_) => None,
-        },
-        Descriptor::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
-        _ => None,
-    }
-}
-
-fn sortedmulti_size<Ctx: ScriptContext>(
-    miniscript: &Miniscript<DescriptorPublicKey, Ctx>,
-) -> Option<(usize, usize)> {
-    match &miniscript.node {
-        Terminal::SortedMulti(threshold) => Some((threshold.k(), threshold.n())),
-        _ => None,
-    }
-}
-
-fn validate_coldcard_registration_key(key: &DescriptorPublicKey) -> Result<(), ColdcardError> {
-    let normal = |index| bitcoin::bip32::ChildNumber::from_normal_idx(index).expect("small index");
-    let valid_single_path = |path: &DerivationPath| path.as_ref() == [normal(0)];
-    let valid_multi_paths = |paths: &[DerivationPath]| {
-        if paths.len() != 2 || paths.iter().any(|path| path.as_ref().len() != 1) {
-            return false;
-        }
-        let mut branches = paths
-            .iter()
-            .map(|path| path.as_ref()[0])
-            .collect::<Vec<_>>();
-        branches.sort_unstable();
-        branches == [normal(0), normal(1)]
-    };
-
-    let valid = match key {
-        DescriptorPublicKey::XPub(key) => {
-            key.origin.is_some()
-                && key.wildcard == Wildcard::Unhardened
-                && valid_single_path(&key.derivation_path)
-        }
-        DescriptorPublicKey::MultiXPub(key) => {
-            key.origin.is_some()
-                && key.wildcard == Wildcard::Unhardened
-                && valid_multi_paths(key.derivation_paths.paths())
-        }
-        DescriptorPublicKey::Single(_) => false,
-    };
-    if valid {
-        Ok(())
-    } else {
-        Err(ColdcardError::InvalidInput(
-            "Coldcard multisig keys require origins, extended public keys, and /0/* or /<0;1>/* derivation"
-                .to_string(),
-        ))
-    }
-}
-
-fn multisig_addr_fmt(address_type: MultisigAddressType) -> u32 {
-    match address_type {
-        MultisigAddressType::Legacy => api::request::addr_fmt::AF_P2SH,
-        MultisigAddressType::ShWit => api::request::addr_fmt::AF_P2WSH_P2SH,
-        MultisigAddressType::Wit => api::request::addr_fmt::AF_P2WSH,
-    }
-}
-
-fn coldcard_multisig_display_address(
-    address: MultisigDisplayAddress,
-) -> Result<ColdcardMultisigDisplayAddress, ColdcardError> {
-    if !address.sorted {
-        return Err(ColdcardError::Device(
-            "Coldcards only allow sortedmulti descriptors".to_string(),
-        ));
-    }
-    let secp = Secp256k1::verification_only();
-    let mut keys = address
-        .keys
-        .into_iter()
-        .map(|key| match key {
-            DescriptorPublicKey::Single(single) => {
-                let (fingerprint, path) = single.origin.ok_or_else(|| {
-                    ColdcardError::Serialization(
-                        "Coldcard multisig display requires key origin information".to_string(),
-                    )
-                })?;
-                let SinglePubKey::FullKey(public_key) = single.key else {
-                    return Err(ColdcardError::Serialization(
-                        "Coldcard multisig display requires full public keys".to_string(),
-                    ));
-                };
-                Ok(ColdcardMultisigDisplayKey {
-                    fingerprint,
-                    path,
-                    public_key,
-                })
-            }
-            DescriptorPublicKey::XPub(xpub) => {
-                if xpub.wildcard != Wildcard::None {
-                    return Err(ColdcardError::Serialization(
-                        "Coldcard multisig display requires a concrete derivation path".to_string(),
-                    ));
-                }
-                let (fingerprint, origin_path) = xpub.origin.ok_or_else(|| {
-                    ColdcardError::Serialization(
-                        "Coldcard multisig display requires key origin information".to_string(),
-                    )
-                })?;
-                let derived = xpub
-                    .xkey
-                    .derive_pub(&secp, &xpub.derivation_path)
-                    .map_err(|err| ColdcardError::Serialization(err.to_string()))?;
-                Ok(ColdcardMultisigDisplayKey {
-                    fingerprint,
-                    path: origin_path.extend(&xpub.derivation_path),
-                    public_key: PublicKey::new(derived.public_key),
-                })
-            }
-            DescriptorPublicKey::MultiXPub(_) => Err(ColdcardError::Serialization(
-                "Coldcard multisig display does not support multipath keys".to_string(),
-            )),
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    keys.sort_by_key(|key| key.public_key.inner.serialize());
-    Ok(ColdcardMultisigDisplayAddress {
-        threshold: address.threshold,
-        address_type: address.address_type,
-        keys,
-    })
-}
-
 fn multisig_redeem_script(
     address: &ColdcardMultisigDisplayAddress,
 ) -> Result<Vec<u8>, ColdcardError> {
@@ -836,65 +580,6 @@ fn multisig_redeem_script(
         .to_bytes())
 }
 
-impl From<ColdcardResponse> for Response {
-    fn from(res: ColdcardResponse) -> Response {
-        match res {
-            ColdcardResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
-            ColdcardResponse::Xpub(xpub) => Response::Xpub(xpub),
-            ColdcardResponse::Version {
-                version,
-                device_model,
-            } => Response::Info(Info {
-                version: version.as_str().into(),
-                networks: vec![],
-                firmware: Some(device_model),
-                initialized: None,
-            }),
-            ColdcardResponse::MyPub { encryption_key, .. } => {
-                Response::EncryptionKey(encryption_key)
-            }
-            ColdcardResponse::Signature(header, signature) => {
-                Response::Signature(header, signature)
-            }
-            ColdcardResponse::Ok => Response::TaskDone,
-            ColdcardResponse::Busy => Response::TaskBusy,
-            ColdcardResponse::Address(address) => Response::Address(address),
-            ColdcardResponse::Backup(bytes) => Response::Backup(DeviceBackup::File(bytes)),
-            ColdcardResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
-            ColdcardResponse::WalletRegistrationPending => Response::WalletRegistration(
-                crate::common::WalletRegistration::PendingUserConfirmation,
-            ),
-        }
-    }
-}
-
-impl From<ColdcardTransmit> for Transmit {
-    fn from(transmit: ColdcardTransmit) -> Transmit {
-        Transmit {
-            recipient: Recipient::Device,
-            payload: transmit.payload,
-            encrypted: transmit.encrypted,
-        }
-    }
-}
-
-impl From<ColdcardError> for Error {
-    fn from(error: ColdcardError) -> Error {
-        match error {
-            ColdcardError::Encryption(e) => Error::Encryption(e),
-            ColdcardError::MissingCommandInfo(e) => Error::MissingCommandInfo(e),
-            ColdcardError::Device(s) => Error::Device(format!("Coldcard Error: {s}")),
-            ColdcardError::NoErrorOrResult => Error::NoErrorOrResult,
-            ColdcardError::Serialization(s) => Error::Serialization(s),
-            ColdcardError::InvalidInput(s) => Error::InvalidInput(s),
-            ColdcardError::UnexpectedResponseMessage { got, expected } => Error::unexpected_result(
-                format!("{got:?}").into_bytes(),
-                format!("coldcard unexpected response: expected {expected:?}, got {got:?}"),
-            ),
-        }
-    }
-}
-
 impl From<FromUtf8Error> for ColdcardError {
     fn from(error: FromUtf8Error) -> Self {
         ColdcardError::Serialization(error.to_string())
@@ -908,6 +593,8 @@ mod tests {
     use bitcoin::hashes::{Hash, sha256};
 
     use super::*;
+    use crate::common::{Command, DeviceBackup, Error, Response, Transmit, WalletRegistration};
+    use crate::miniscript::descriptor::WalletPolicy;
 
     const REGISTRATION_POLICY: &str = "wsh(sortedmulti(2,[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))";
 
@@ -985,39 +672,6 @@ mod tests {
     }
 
     #[test]
-    fn registration_payload_contains_name_and_full_descriptor() {
-        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
-        let payload = coldcard_registration_payload("cold-wallet", &policy).unwrap();
-        let payload: serde_json::Value = serde_json::from_slice(&payload).unwrap();
-        assert_eq!(payload["name"], "cold-wallet");
-        assert_eq!(payload["desc"], REGISTRATION_POLICY);
-    }
-
-    #[test]
-    fn registration_rejects_unsupported_policy_and_name() {
-        let singlesig = WalletPolicy::from_str(
-            "wpkh([f5acc2fd/84'/1'/0']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*)",
-        )
-        .unwrap();
-        let error = coldcard_registration_payload("cold-wallet", &singlesig).unwrap_err();
-        assert!(error.to_string().contains("supports only"));
-
-        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
-        let error = coldcard_registration_payload("x", &policy).unwrap_err();
-        assert!(error.to_string().contains("2 to 20"));
-    }
-
-    #[test]
-    fn registration_rejects_keys_without_origins() {
-        let policy = WalletPolicy::from_str(
-            "wsh(sortedmulti(2,tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))",
-        )
-        .unwrap();
-        let error = coldcard_registration_payload("cold-wallet", &policy).unwrap_err();
-        assert!(error.to_string().contains("require origins"));
-    }
-
-    #[test]
     fn register_wallet_uploads_verifies_and_starts_enrollment() {
         let (mut host, mut device) = paired_engines();
         let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
@@ -1068,9 +722,7 @@ mod tests {
         );
         assert!(matches!(
             interpreter.end().unwrap(),
-            Response::WalletRegistration(
-                crate::common::WalletRegistration::PendingUserConfirmation
-            )
+            Response::WalletRegistration(WalletRegistration::PendingUserConfirmation)
         ));
     }
 }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -8,6 +8,8 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 
+mod adapters;
+
 #[derive(Default)]
 pub struct UnlockOptions {
     pub network: Option<Network>,

--- a/bhwi/src/common/adapters.rs
+++ b/bhwi/src/common/adapters.rs
@@ -1,0 +1,1 @@
+mod ledger;

--- a/bhwi/src/common/adapters.rs
+++ b/bhwi/src/common/adapters.rs
@@ -1,1 +1,2 @@
+mod coldcard;
 mod ledger;

--- a/bhwi/src/common/adapters.rs
+++ b/bhwi/src/common/adapters.rs
@@ -1,2 +1,3 @@
 mod coldcard;
+mod jade;
 mod ledger;

--- a/bhwi/src/common/adapters.rs
+++ b/bhwi/src/common/adapters.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bitbox")]
+mod bitbox;
 mod coldcard;
 mod jade;
 mod ledger;

--- a/bhwi/src/common/adapters/bitbox.rs
+++ b/bhwi/src/common/adapters/bitbox.rs
@@ -1,0 +1,398 @@
+use bitcoin::address::AddressType;
+use bitcoin::bip32::{ChildNumber, DerivationPath};
+
+use crate::bitbox::error::{BitBoxDeviceError, BitBoxError};
+use crate::bitbox::policy;
+use crate::bitbox::proto as pb;
+use crate::bitbox::{BitBoxCommand, BitBoxResponse, BitBoxTransmit, ManagementContext};
+use crate::common::{
+    Command, DeviceBackup, DeviceContext, DisplayAddress, Error, Info, Recipient, Response,
+    Transmit, WalletRegistration,
+};
+
+impl TryFrom<Command> for BitBoxCommand {
+    type Error = BitBoxError;
+
+    fn try_from(command: Command) -> Result<Self, Self::Error> {
+        match command {
+            Command::Setup(options, context) => {
+                if !options.backup_passphrase.is_empty() {
+                    return Err(BitBoxError::InvalidInput(
+                        "Passphrase not needed when setting up a BitBox02.",
+                    ));
+                }
+                let Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                    mode,
+                    timestamp,
+                    timezone_offset,
+                })) = context
+                else {
+                    return Err(BitBoxError::InvalidInput(
+                        "BitBox setup requires DeviceContext::BitBoxManagement",
+                    ));
+                };
+                Ok(Self::Setup {
+                    label: options.label,
+                    mode,
+                    timestamp,
+                    timezone_offset,
+                })
+            }
+            Command::Wipe => Ok(Self::Wipe),
+            Command::Restore(options, context) => {
+                let Some(DeviceContext::BitBoxManagement(ManagementContext::Restore {
+                    timestamp,
+                    timezone_offset,
+                })) = context
+                else {
+                    return Err(BitBoxError::InvalidInput(
+                        "BitBox restore requires DeviceContext::BitBoxManagement",
+                    ));
+                };
+                Ok(Self::Restore {
+                    label: options.label,
+                    timestamp,
+                    timezone_offset,
+                })
+            }
+            Command::TogglePassphrase => Ok(Self::TogglePassphrase),
+            Command::Unlock { .. } => Ok(Self::UnlockAndPair),
+            Command::GetVersion => Ok(Self::GetVersion),
+            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
+            Command::GetXpub { path, display } => Ok(Self::GetXpub {
+                keypath: path,
+                display,
+            }),
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    display,
+                    address_format,
+                },
+                _,
+            ) => Ok(Self::ShowSimpleAddress {
+                simple_type: simple_type_from_address_format(&path, address_format)?,
+                keypath: path,
+                display,
+            }),
+            Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    index,
+                    change,
+                    display,
+                    ..
+                },
+                context,
+            ) => {
+                let policy = match context {
+                    Some(DeviceContext::BitBox { policy }) => {
+                        policy::Policy::from_wallet_policy(&policy)?
+                    }
+                    _ => {
+                        return Err(BitBoxError::InvalidInput(
+                            "BitBox requires DeviceContext::BitBox for descriptor address display",
+                        ));
+                    }
+                };
+                Ok(Self::ShowDescriptorAddress {
+                    policy,
+                    change,
+                    index,
+                    display,
+                })
+            }
+            Command::DisplayAddress(DisplayAddress::ByMultisig(_), _) => Err(
+                BitBoxError::InvalidInput("BitBox raw multisig display is not implemented"),
+            ),
+            Command::RegisterWallet { name, policy } => Ok(Self::RegisterScriptConfig {
+                policy: policy::Policy::from_wallet_policy(&policy)?,
+                name,
+            }),
+            Command::SignTx(psbt, context) => {
+                // A BitBox context supplies the registered policy. Without it, the
+                // interpreter can still infer single-sig inputs from the PSBT.
+                let policy = match context {
+                    None => None,
+                    Some(DeviceContext::BitBox { policy }) => {
+                        Some(policy::Policy::from_wallet_policy(&policy)?)
+                    }
+                    Some(_) => {
+                        return Err(BitBoxError::InvalidInput(
+                            "BitBox requires DeviceContext::BitBox for policy signing",
+                        ));
+                    }
+                };
+                Ok(Self::SignPsbt {
+                    psbt: Box::new(psbt),
+                    force_script_config: None,
+                    policy,
+                })
+            }
+            Command::SignMessage { message, path } => Ok(Self::SignMessage {
+                simple_type: simple_type_from_path(&path),
+                keypath: path,
+                message,
+            }),
+            Command::Backup => Ok(Self::Backup),
+        }
+    }
+}
+
+fn simple_type_from_path(path: &DerivationPath) -> pb::btc_script_config::SimpleType {
+    use pb::btc_script_config::SimpleType;
+
+    match path.into_iter().next() {
+        Some(ChildNumber::Hardened { index: 49 }) => SimpleType::P2wpkhP2sh,
+        Some(ChildNumber::Hardened { index: 86 }) => SimpleType::P2tr,
+        _ => SimpleType::P2wpkh,
+    }
+}
+
+fn simple_type_from_address_format(
+    path: &DerivationPath,
+    address_format: Option<AddressType>,
+) -> Result<pb::btc_script_config::SimpleType, BitBoxError> {
+    use pb::btc_script_config::SimpleType;
+
+    match address_format {
+        None => Ok(simple_type_from_path(path)),
+        Some(AddressType::P2sh) => Ok(SimpleType::P2wpkhP2sh),
+        Some(AddressType::P2wpkh) => Ok(SimpleType::P2wpkh),
+        Some(AddressType::P2tr) => Ok(SimpleType::P2tr),
+        Some(AddressType::P2pkh | AddressType::P2wsh) | Some(_) => Err(BitBoxError::InvalidInput(
+            "BitBox does not support this address format",
+        )),
+    }
+}
+
+impl From<BitBoxResponse> for Response {
+    fn from(response: BitBoxResponse) -> Self {
+        match response {
+            BitBoxResponse::TaskDone => Self::TaskDone,
+            BitBoxResponse::DeviceAction(success) => Self::DeviceAction(success),
+            BitBoxResponse::Info(info) => Self::Info(Info {
+                version: info.version,
+                networks: vec![],
+                firmware: Some(info.name),
+                initialized: Some(info.initialized),
+            }),
+            BitBoxResponse::MasterFingerprint(fingerprint) => Self::MasterFingerprint(fingerprint),
+            BitBoxResponse::Xpub(xpub) => Self::Xpub(xpub),
+            BitBoxResponse::Address(address) => Self::Address(address),
+            BitBoxResponse::IsRegistered(_) => Self::TaskDone,
+            BitBoxResponse::Registered => {
+                Self::WalletRegistration(WalletRegistration::Complete { hmac: None })
+            }
+            BitBoxResponse::SignedPsbt(psbt) => Self::SignedPsbt(*psbt),
+            BitBoxResponse::Signature(header, signature) => Self::Signature(header, signature),
+            BitBoxResponse::Backup => Self::Backup(DeviceBackup::Complete),
+        }
+    }
+}
+
+impl From<BitBoxError> for Error {
+    fn from(error: BitBoxError) -> Self {
+        match error {
+            BitBoxError::Device(BitBoxDeviceError::UserAbort)
+            | BitBoxError::NoisePairingRejected => Self::AuthenticationRefused,
+            BitBoxError::ProtobufDecode(error) | BitBoxError::ProtobufEncode(error) => {
+                Self::Serialization(error)
+            }
+            other => Self::Serialization(other.to_string()),
+        }
+    }
+}
+
+impl From<BitBoxTransmit> for Transmit {
+    fn from(transmit: BitBoxTransmit) -> Self {
+        Self {
+            recipient: Recipient::Device,
+            payload: transmit.payload,
+            encrypted: transmit.encrypted,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::bip32::DerivationPath;
+
+    use super::*;
+    use crate::bitbox::{SetupEntropy, SetupMode};
+    use crate::common::{RestoreOptions, SetupOptions};
+
+    fn simple(path: &str) -> pb::btc_script_config::SimpleType {
+        simple_type_from_path(&DerivationPath::from_str(path).unwrap())
+    }
+
+    #[test]
+    fn simple_type_matches_purpose() {
+        use pb::btc_script_config::SimpleType;
+
+        assert_eq!(simple("m/84'/0'/0'/0/0"), SimpleType::P2wpkh);
+        assert_eq!(simple("m/49'/0'/0'/0/0"), SimpleType::P2wpkhP2sh);
+        assert_eq!(simple("m/86'/0'/0'/0/0"), SimpleType::P2tr);
+        assert_eq!(simple("m/44'/0'/0'/0/0"), SimpleType::P2wpkh);
+    }
+
+    #[test]
+    fn display_path_address_format_selects_simple_type() {
+        use pb::btc_script_config::SimpleType;
+
+        let path = DerivationPath::from_str("m/49'/0'/0'/0/0").unwrap();
+
+        assert_eq!(
+            simple_type_from_address_format(&path, Some(AddressType::P2sh)).unwrap(),
+            SimpleType::P2wpkhP2sh
+        );
+        assert_eq!(
+            simple_type_from_address_format(&path, Some(AddressType::P2wpkh)).unwrap(),
+            SimpleType::P2wpkh
+        );
+        assert_eq!(
+            simple_type_from_address_format(&path, Some(AddressType::P2tr)).unwrap(),
+            SimpleType::P2tr
+        );
+        assert_eq!(
+            simple_type_from_address_format(&path, None).unwrap(),
+            SimpleType::P2wpkhP2sh
+        );
+        assert!(simple_type_from_address_format(&path, Some(AddressType::P2pkh)).is_err());
+    }
+
+    #[test]
+    fn backup_maps_to_bitbox_backup() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::Backup),
+            Ok(BitBoxCommand::Backup)
+        ));
+    }
+
+    #[test]
+    fn setup_maps_to_bitbox_setup() {
+        let command = BitBoxCommand::try_from(Command::Setup(
+            SetupOptions {
+                label: "BHWI".into(),
+                backup_passphrase: String::new(),
+            },
+            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                mode: SetupMode::NewWallet {
+                    entropy: SetupEntropy::new([42; 32]),
+                },
+                timestamp: 1_601_450_521,
+                timezone_offset: 3_600,
+            })),
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            BitBoxCommand::Setup {
+                label,
+                mode: SetupMode::NewWallet { .. },
+                timestamp: 1_601_450_521,
+                timezone_offset: 3_600,
+            } if label == "BHWI"
+        ));
+    }
+
+    #[test]
+    fn setup_requires_context_and_rejects_passphrase() {
+        let missing_context =
+            BitBoxCommand::try_from(Command::Setup(SetupOptions::default(), None));
+        assert!(matches!(missing_context, Err(BitBoxError::InvalidInput(_))));
+
+        let passphrase = BitBoxCommand::try_from(Command::Setup(
+            SetupOptions {
+                label: String::new(),
+                backup_passphrase: "secret".into(),
+            },
+            Some(DeviceContext::BitBoxManagement(ManagementContext::Setup {
+                mode: SetupMode::RestoreFromMnemonic,
+                timestamp: 0,
+                timezone_offset: 0,
+            })),
+        ));
+        assert!(matches!(passphrase, Err(BitBoxError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn setup_response_maps_to_device_action() {
+        assert!(matches!(
+            Response::from(BitBoxResponse::DeviceAction(false)),
+            Response::DeviceAction(false)
+        ));
+    }
+
+    #[test]
+    fn wipe_maps_to_bitbox_wipe() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::Wipe),
+            Ok(BitBoxCommand::Wipe)
+        ));
+    }
+
+    #[test]
+    fn restore_maps_to_bitbox_restore_and_ignores_word_count() {
+        let command = BitBoxCommand::try_from(Command::Restore(
+            RestoreOptions {
+                label: "Recovered".into(),
+                word_count: 12,
+            },
+            Some(DeviceContext::BitBoxManagement(
+                ManagementContext::Restore {
+                    timestamp: 1_601_450_521,
+                    timezone_offset: -3_600,
+                },
+            )),
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            BitBoxCommand::Restore {
+                label,
+                timestamp: 1_601_450_521,
+                timezone_offset: -3_600,
+            } if label == "Recovered"
+        ));
+    }
+
+    #[test]
+    fn restore_requires_context() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::Restore(RestoreOptions::default(), None)),
+            Err(BitBoxError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn toggle_passphrase_maps_to_bitbox_command() {
+        assert!(matches!(
+            BitBoxCommand::try_from(Command::TogglePassphrase),
+            Ok(BitBoxCommand::TogglePassphrase)
+        ));
+    }
+
+    #[test]
+    fn backup_response_maps_to_completed_backup() {
+        assert!(matches!(
+            Response::from(BitBoxResponse::Backup),
+            Response::Backup(DeviceBackup::Complete)
+        ));
+    }
+
+    #[test]
+    fn native_transmit_maps_to_device_recipient() {
+        let transmit = Transmit::from(BitBoxTransmit {
+            payload: vec![1, 2, 3],
+            encrypted: true,
+        });
+
+        assert!(matches!(transmit.recipient, Recipient::Device));
+        assert_eq!(transmit.payload, vec![1, 2, 3]);
+        assert!(transmit.encrypted);
+    }
+}

--- a/bhwi/src/common/adapters/coldcard.rs
+++ b/bhwi/src/common/adapters/coldcard.rs
@@ -1,0 +1,397 @@
+use bitcoin::PublicKey;
+use bitcoin::bip32::{ChildNumber, DerivationPath};
+use bitcoin::secp256k1::Secp256k1;
+use miniscript::{
+    Descriptor, Miniscript, ScriptContext, Terminal,
+    descriptor::{DescriptorPublicKey, ShInner, SinglePubKey, WalletPolicy, Wildcard},
+};
+
+use crate::coldcard::api;
+use crate::coldcard::{
+    ColdcardCommand, ColdcardError, ColdcardMultisigDisplayAddress, ColdcardMultisigDisplayKey,
+    ColdcardResponse, ColdcardTransmit,
+};
+use crate::common::{
+    Command, DeviceBackup, DisplayAddress, Error, Info, MultisigAddressType,
+    MultisigDisplayAddress, Recipient, Response, Transmit, WalletRegistration,
+};
+
+impl TryFrom<Command> for ColdcardCommand {
+    type Error = ColdcardError;
+
+    fn try_from(command: Command) -> Result<Self, Self::Error> {
+        match command {
+            Command::Setup(..) => Err(ColdcardError::MissingCommandInfo(
+                "Setup not supported by Coldcard",
+            )),
+            Command::Wipe => Err(ColdcardError::MissingCommandInfo(
+                "Wipe not supported by Coldcard",
+            )),
+            Command::Restore(..) => Err(ColdcardError::MissingCommandInfo(
+                "Restore not supported by Coldcard",
+            )),
+            Command::TogglePassphrase => Err(ColdcardError::MissingCommandInfo(
+                "Toggle passphrase not supported by Coldcard",
+            )),
+            Command::Backup => Ok(Self::Backup),
+            Command::Unlock { .. } => Ok(Self::StartEncryption),
+            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
+            Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
+            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
+            Command::GetVersion => Ok(Self::GetVersion),
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    address_format,
+                    ..
+                },
+                ..,
+            ) => Ok(Self::ShowAddress {
+                path,
+                addr_fmt: address_format
+                    .map(api::request::addr_fmt::from_address_type)
+                    .unwrap_or(api::request::addr_fmt::AF_P2WPKH),
+            }),
+            Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    descriptor_name,
+                    change,
+                    index,
+                    ..
+                },
+                ..,
+            ) => Ok(Self::MiniscriptAddress {
+                name: descriptor_name,
+                change,
+                index,
+            }),
+            Command::DisplayAddress(DisplayAddress::ByMultisig(address), ..) => {
+                Ok(Self::ShowP2shAddress {
+                    address: coldcard_multisig_display_address(address)?,
+                })
+            }
+            Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
+                payload: coldcard_registration_payload(&name, &policy)?,
+            }),
+            Command::SignTx(psbt, context) => {
+                if context.is_some() {
+                    return Err(ColdcardError::MissingCommandInfo(
+                        "Coldcard SignTx does not support device context",
+                    ));
+                }
+                Ok(Self::SignPsbt { psbt })
+            }
+        }
+    }
+}
+
+fn coldcard_registration_payload(
+    name: &str,
+    policy: &WalletPolicy,
+) -> Result<Vec<u8>, ColdcardError> {
+    if !(2..=20).contains(&name.len())
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
+    {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard wallet names must be 2 to 20 printable ASCII characters".to_string(),
+        ));
+    }
+
+    let descriptor = policy
+        .clone()
+        .into_descriptor()
+        .map_err(|error| ColdcardError::InvalidInput(error.to_string()))?;
+    let (threshold, signer_count) = coldcard_sortedmulti_size(&descriptor).ok_or_else(|| {
+        ColdcardError::InvalidInput(
+            "Coldcard registration supports only sh(sortedmulti), wsh(sortedmulti), and sh(wsh(sortedmulti)) descriptors"
+                .to_string(),
+        )
+    })?;
+    if threshold == 0 || threshold > signer_count || signer_count > 15 {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard multisig policies require 1 to 15 signers and a valid threshold".to_string(),
+        ));
+    }
+    for key in descriptor.iter_pk() {
+        validate_coldcard_registration_key(&key)?;
+    }
+
+    let descriptor = format!("{descriptor:#}");
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "name": name,
+        "desc": descriptor,
+    }))
+    .map_err(|error| ColdcardError::Serialization(error.to_string()))?;
+    if !(101..=4000).contains(&payload.len()) {
+        return Err(ColdcardError::InvalidInput(
+            "Coldcard multisig registration payload must be 101 to 4000 bytes".to_string(),
+        ));
+    }
+    Ok(payload)
+}
+
+fn coldcard_sortedmulti_size(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+) -> Option<(usize, usize)> {
+    match descriptor {
+        Descriptor::Sh(sh) => match sh.as_inner() {
+            ShInner::Ms(miniscript) => sortedmulti_size(miniscript),
+            ShInner::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
+            ShInner::Wpkh(_) => None,
+        },
+        Descriptor::Wsh(wsh) => sortedmulti_size(wsh.as_inner()),
+        _ => None,
+    }
+}
+
+fn sortedmulti_size<Ctx: ScriptContext>(
+    miniscript: &Miniscript<DescriptorPublicKey, Ctx>,
+) -> Option<(usize, usize)> {
+    match &miniscript.node {
+        Terminal::SortedMulti(threshold) => Some((threshold.k(), threshold.n())),
+        _ => None,
+    }
+}
+
+fn validate_coldcard_registration_key(key: &DescriptorPublicKey) -> Result<(), ColdcardError> {
+    let normal = |index| ChildNumber::from_normal_idx(index).expect("small index");
+    let valid_single_path = |path: &DerivationPath| path.as_ref() == [normal(0)];
+    let valid_multi_paths = |paths: &[DerivationPath]| {
+        if paths.len() != 2 || paths.iter().any(|path| path.as_ref().len() != 1) {
+            return false;
+        }
+        let mut branches = paths
+            .iter()
+            .map(|path| path.as_ref()[0])
+            .collect::<Vec<_>>();
+        branches.sort_unstable();
+        branches == [normal(0), normal(1)]
+    };
+
+    let valid = match key {
+        DescriptorPublicKey::XPub(key) => {
+            key.origin.is_some()
+                && key.wildcard == Wildcard::Unhardened
+                && valid_single_path(&key.derivation_path)
+        }
+        DescriptorPublicKey::MultiXPub(key) => {
+            key.origin.is_some()
+                && key.wildcard == Wildcard::Unhardened
+                && valid_multi_paths(key.derivation_paths.paths())
+        }
+        DescriptorPublicKey::Single(_) => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(ColdcardError::InvalidInput(
+            "Coldcard multisig keys require origins, extended public keys, and /0/* or /<0;1>/* derivation"
+                .to_string(),
+        ))
+    }
+}
+
+fn multisig_address_format(address_type: MultisigAddressType) -> u32 {
+    match address_type {
+        MultisigAddressType::Legacy => api::request::addr_fmt::AF_P2SH,
+        MultisigAddressType::ShWit => api::request::addr_fmt::AF_P2WSH_P2SH,
+        MultisigAddressType::Wit => api::request::addr_fmt::AF_P2WSH,
+    }
+}
+
+fn coldcard_multisig_display_address(
+    address: MultisigDisplayAddress,
+) -> Result<ColdcardMultisigDisplayAddress, ColdcardError> {
+    if !address.sorted {
+        return Err(ColdcardError::Device(
+            "Coldcards only allow sortedmulti descriptors".to_string(),
+        ));
+    }
+    let secp = Secp256k1::verification_only();
+    let mut keys = address
+        .keys
+        .into_iter()
+        .map(|key| match key {
+            DescriptorPublicKey::Single(single) => {
+                let (fingerprint, path) = single.origin.ok_or_else(|| {
+                    ColdcardError::Serialization(
+                        "Coldcard multisig display requires key origin information".to_string(),
+                    )
+                })?;
+                let SinglePubKey::FullKey(public_key) = single.key else {
+                    return Err(ColdcardError::Serialization(
+                        "Coldcard multisig display requires full public keys".to_string(),
+                    ));
+                };
+                Ok(ColdcardMultisigDisplayKey {
+                    fingerprint,
+                    path,
+                    public_key,
+                })
+            }
+            DescriptorPublicKey::XPub(xpub) => {
+                if xpub.wildcard != Wildcard::None {
+                    return Err(ColdcardError::Serialization(
+                        "Coldcard multisig display requires a concrete derivation path".to_string(),
+                    ));
+                }
+                let (fingerprint, origin_path) = xpub.origin.ok_or_else(|| {
+                    ColdcardError::Serialization(
+                        "Coldcard multisig display requires key origin information".to_string(),
+                    )
+                })?;
+                let derived = xpub
+                    .xkey
+                    .derive_pub(&secp, &xpub.derivation_path)
+                    .map_err(|error| ColdcardError::Serialization(error.to_string()))?;
+                Ok(ColdcardMultisigDisplayKey {
+                    fingerprint,
+                    path: origin_path.extend(&xpub.derivation_path),
+                    public_key: PublicKey::new(derived.public_key),
+                })
+            }
+            DescriptorPublicKey::MultiXPub(_) => Err(ColdcardError::Serialization(
+                "Coldcard multisig display does not support multipath keys".to_string(),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    keys.sort_by_key(|key| key.public_key.inner.serialize());
+    Ok(ColdcardMultisigDisplayAddress {
+        threshold: address.threshold,
+        address_format: multisig_address_format(address.address_type),
+        keys,
+    })
+}
+
+impl From<ColdcardResponse> for Response {
+    fn from(response: ColdcardResponse) -> Self {
+        match response {
+            ColdcardResponse::MasterFingerprint(fingerprint) => {
+                Self::MasterFingerprint(fingerprint)
+            }
+            ColdcardResponse::Xpub(xpub) => Self::Xpub(xpub),
+            ColdcardResponse::Version {
+                version,
+                device_model,
+            } => Self::Info(Info {
+                version,
+                networks: vec![],
+                firmware: Some(device_model),
+                initialized: None,
+            }),
+            ColdcardResponse::MyPub { encryption_key, .. } => Self::EncryptionKey(encryption_key),
+            ColdcardResponse::Signature(header, signature) => Self::Signature(header, signature),
+            ColdcardResponse::Ok => Self::TaskDone,
+            ColdcardResponse::Busy => Self::TaskBusy,
+            ColdcardResponse::Address(address) => Self::Address(address),
+            ColdcardResponse::Backup(bytes) => Self::Backup(DeviceBackup::File(bytes)),
+            ColdcardResponse::SignedPsbt(psbt) => Self::SignedPsbt(psbt),
+            ColdcardResponse::WalletRegistrationPending => {
+                Self::WalletRegistration(WalletRegistration::PendingUserConfirmation)
+            }
+        }
+    }
+}
+
+impl From<ColdcardTransmit> for Transmit {
+    fn from(transmit: ColdcardTransmit) -> Self {
+        Self {
+            recipient: Recipient::Device,
+            payload: transmit.payload,
+            encrypted: transmit.encrypted,
+        }
+    }
+}
+
+impl From<ColdcardError> for Error {
+    fn from(error: ColdcardError) -> Self {
+        match error {
+            ColdcardError::Encryption(error) => Self::Encryption(error),
+            ColdcardError::MissingCommandInfo(error) => Self::MissingCommandInfo(error),
+            ColdcardError::Device(error) => Self::Device(format!("Coldcard Error: {error}")),
+            ColdcardError::NoErrorOrResult => Self::NoErrorOrResult,
+            ColdcardError::Serialization(error) => Self::Serialization(error),
+            ColdcardError::InvalidInput(error) => Self::InvalidInput(error),
+            ColdcardError::UnexpectedResponseMessage { got, expected } => Self::unexpected_result(
+                format!("{got:?}").into_bytes(),
+                format!("coldcard unexpected response: expected {expected:?}, got {got:?}"),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    const REGISTRATION_POLICY: &str = "wsh(sortedmulti(2,[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))";
+
+    #[test]
+    fn registration_payload_contains_name_and_full_descriptor() {
+        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
+        let payload = coldcard_registration_payload("cold-wallet", &policy).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(payload["name"], "cold-wallet");
+        assert_eq!(payload["desc"], REGISTRATION_POLICY);
+    }
+
+    #[test]
+    fn registration_rejects_unsupported_policy_and_name() {
+        let singlesig = WalletPolicy::from_str(
+            "wpkh([f5acc2fd/84'/1'/0']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*)",
+        )
+        .unwrap();
+        let error = coldcard_registration_payload("cold-wallet", &singlesig).unwrap_err();
+        assert!(error.to_string().contains("supports only"));
+
+        let policy = WalletPolicy::from_str(REGISTRATION_POLICY).unwrap();
+        let error = coldcard_registration_payload("x", &policy).unwrap_err();
+        assert!(error.to_string().contains("2 to 20"));
+    }
+
+    #[test]
+    fn registration_rejects_keys_without_origins() {
+        let policy = WalletPolicy::from_str(
+            "wsh(sortedmulti(2,tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*,tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*))",
+        )
+        .unwrap();
+        let error = coldcard_registration_payload("cold-wallet", &policy).unwrap_err();
+        assert!(error.to_string().contains("require origins"));
+    }
+
+    #[test]
+    fn path_display_maps_to_protocol_address_format() {
+        let command = ColdcardCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByPath {
+                path: "m/49'/1'/0'/0/0".parse().unwrap(),
+                display: true,
+                address_format: Some(bitcoin::address::AddressType::P2sh),
+            },
+            None,
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            ColdcardCommand::ShowAddress {
+                addr_fmt: api::request::addr_fmt::AF_P2WPKH_P2SH,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn transmit_maps_to_device_recipient() {
+        let transmit = Transmit::from(ColdcardTransmit {
+            payload: vec![1, 2, 3],
+            encrypted: true,
+        });
+        assert!(matches!(transmit.recipient, Recipient::Device));
+        assert_eq!(transmit.payload, vec![1, 2, 3]);
+        assert!(transmit.encrypted);
+    }
+}

--- a/bhwi/src/common/adapters/jade.rs
+++ b/bhwi/src/common/adapters/jade.rs
@@ -1,0 +1,287 @@
+use bitcoin::address::AddressType;
+use bitcoin::hashes::{Hash, sha256};
+use miniscript::descriptor::{DescriptorPublicKey, Wildcard};
+
+use crate::common::{
+    Command, DisplayAddress, Error, Info, MultisigAddressType, MultisigDisplayAddress, Recipient,
+    Response, Transmit, WalletRegistration,
+};
+use crate::jade::api;
+use crate::jade::{
+    JadeCommand, JadeError, JadeRecipient, JadeResponse, JadeTransmit, ReceiveAddress,
+};
+
+impl TryFrom<Command> for JadeCommand {
+    type Error = Error;
+
+    fn try_from(command: Command) -> Result<Self, Self::Error> {
+        match command {
+            Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
+            Command::Wipe => Err(Error::MissingCommandInfo("Wipe not supported by Jade")),
+            Command::Restore(..) => Err(Error::MissingCommandInfo("Restore not supported by Jade")),
+            Command::TogglePassphrase => Err(Error::MissingCommandInfo(
+                "Toggle passphrase not supported by Jade",
+            )),
+            Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
+            Command::Unlock { .. } => Ok(Self::Auth),
+            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
+            Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
+            Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    index,
+                    change,
+                    descriptor_name,
+                    ..
+                },
+                _,
+            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Descriptor {
+                index,
+                change,
+                descriptor_name,
+            })),
+            Command::DisplayAddress(
+                DisplayAddress::ByPath {
+                    path,
+                    address_format,
+                    ..
+                },
+                _,
+            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Path {
+                path,
+                variant: jade_path_variant(address_format)?,
+            })),
+            Command::DisplayAddress(DisplayAddress::ByMultisig(address), _) => {
+                jade_multisig_command(address)
+            }
+            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
+            Command::GetVersion => Ok(Self::GetInfo),
+            Command::RegisterWallet { name, policy } => {
+                let (descriptor, keys) = crate::policy::extract_parts(&policy)
+                    .map_err(|error| Error::Serialization(error.to_string()))?;
+                // Jade requires the explicit multipath spelling instead of the
+                // BIP-388 wallet-policy shorthand.
+                let descriptor = descriptor.replace("/**", "/<0;1>/*");
+                let datavalues = keys
+                    .iter()
+                    .enumerate()
+                    .map(|(index, key)| (format!("@{index}"), crate::policy::format_key_info(key)))
+                    .collect();
+                Ok(Self::RegisterDescriptor {
+                    descriptor_name: name,
+                    descriptor,
+                    datavalues,
+                })
+            }
+            Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
+        }
+    }
+}
+
+fn jade_multisig_command(address: MultisigDisplayAddress) -> Result<JadeCommand, Error> {
+    let variant = match address.address_type {
+        MultisigAddressType::Legacy => "sh(multi(k))",
+        MultisigAddressType::Wit => "wsh(multi(k))",
+        MultisigAddressType::ShWit => "sh(wsh(multi(k)))",
+    };
+    let mut signer_origins = Vec::with_capacity(address.keys.len());
+    let mut signers = Vec::with_capacity(address.keys.len());
+    let mut paths = Vec::with_capacity(address.keys.len());
+
+    for key in address.keys {
+        let DescriptorPublicKey::XPub(key) = key else {
+            return Err(Error::InvalidInput(
+                "Jade multisig display requires extended public keys".into(),
+            ));
+        };
+        if key.wildcard != Wildcard::None {
+            return Err(Error::InvalidInput(
+                "Jade multisig display requires concrete key derivation paths".into(),
+            ));
+        }
+        let (fingerprint, origin_path) = key.origin.ok_or_else(|| {
+            Error::InvalidInput("Jade multisig display requires key origin information".into())
+        })?;
+        let origin = origin_path.to_u32_vec();
+        signer_origins.push((fingerprint.to_bytes(), origin.clone()));
+        signers.push(api::MultisigSigner {
+            fingerprint: fingerprint.to_bytes().to_vec(),
+            derivation: origin,
+            xpub: key.xkey.to_string(),
+            path: Vec::new(),
+        });
+        paths.push(key.derivation_path.to_u32_vec());
+    }
+
+    signer_origins.sort();
+    let mut summary = format!("{variant}|{}|", address.threshold);
+    for (fingerprint, path) in signer_origins {
+        summary.push_str(&hex::encode(fingerprint));
+        summary.push('|');
+        summary.push_str(&format!("{path:?}"));
+        summary.push('|');
+    }
+    let digest = sha256::Hash::hash(summary.as_bytes());
+    let multisig_name = format!("hwi{}", &digest.to_string()[..12]);
+
+    Ok(JadeCommand::RegisterMultisig {
+        multisig_name,
+        descriptor: api::MultisigDescriptor {
+            variant: variant.to_string(),
+            sorted: address.sorted,
+            threshold: address.threshold,
+            signers,
+            master_blinding_key: None,
+        },
+        paths,
+    })
+}
+
+fn jade_path_variant(address_format: Option<AddressType>) -> Result<&'static str, Error> {
+    match address_format.unwrap_or(AddressType::P2wpkh) {
+        AddressType::P2pkh => Ok("pkh(k)"),
+        AddressType::P2sh => Ok("sh(wpkh(k))"),
+        AddressType::P2wpkh => Ok("wpkh(k)"),
+        AddressType::P2wsh | AddressType::P2tr => Err(Error::UnsupportedDisplayAddress(
+            "Jade does not support this path address format".into(),
+        )),
+        _ => Err(Error::UnsupportedDisplayAddress(
+            "Jade does not support this path address format".into(),
+        )),
+    }
+}
+
+impl From<JadeResponse> for Response {
+    fn from(response: JadeResponse) -> Self {
+        match response {
+            JadeResponse::TaskDone => Self::TaskDone,
+            JadeResponse::MasterFingerprint(fingerprint) => Self::MasterFingerprint(fingerprint),
+            JadeResponse::Xpub(xpub) => Self::Xpub(xpub),
+            JadeResponse::Signature(header, signature) => Self::Signature(header, signature),
+            JadeResponse::GetInfo(info) => Self::Info(Info {
+                version: info.jade_version,
+                networks: info.jade_networks.into(),
+                firmware: None,
+                initialized: None,
+            }),
+            JadeResponse::Address(address) => Self::Address(address),
+            JadeResponse::RegisteredDescriptor => {
+                Self::WalletRegistration(WalletRegistration::Complete { hmac: None })
+            }
+            JadeResponse::SignedPsbt(psbt) => Self::SignedPsbt(psbt),
+        }
+    }
+}
+
+impl From<JadeRecipient> for Recipient {
+    fn from(recipient: JadeRecipient) -> Self {
+        match recipient {
+            JadeRecipient::Device => Self::Device,
+            JadeRecipient::PinServer { url } => Self::PinServer { url },
+        }
+    }
+}
+
+impl From<JadeTransmit> for Transmit {
+    fn from(transmit: JadeTransmit) -> Self {
+        Self {
+            recipient: transmit.recipient.into(),
+            payload: transmit.payload,
+            encrypted: false,
+        }
+    }
+}
+
+impl From<JadeError> for Error {
+    fn from(error: JadeError) -> Self {
+        match error {
+            JadeError::Cbor => Self::Serialization("cbor".to_string()),
+            JadeError::NoErrorOrResult => Self::NoErrorOrResult,
+            JadeError::Rpc(error) => Self::Rpc(error.code, error.message),
+            JadeError::Serialization(error) => Self::Serialization(error),
+            JadeError::UnexpectedResult(message) => Self::unexpected_result(
+                message.clone().into_bytes(),
+                format!("jade unexpected result: {message}"),
+            ),
+            JadeError::HandshakeRefused => Self::AuthenticationRefused,
+            JadeError::UnsupportedDisplayAddress => {
+                Self::UnsupportedDisplayAddress("unsupported display address on Jade".into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn path_display_rejects_unsupported_jade_address_format() {
+        let result = JadeCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByPath {
+                path: "m/86'/1'/0'/0/0".parse().unwrap(),
+                display: true,
+                address_format: Some(AddressType::P2tr),
+            },
+            None,
+        ));
+
+        assert!(matches!(result, Err(Error::UnsupportedDisplayAddress(_))));
+    }
+
+    #[test]
+    fn multisig_display_uses_upstream_hwi_registration_shape_and_name() {
+        let keys = [
+            "[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/0/7",
+            "[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/0/7",
+        ]
+        .map(|key| DescriptorPublicKey::from_str(key).unwrap())
+        .to_vec();
+
+        let command = jade_multisig_command(MultisigDisplayAddress {
+            threshold: 2,
+            address_type: MultisigAddressType::Wit,
+            sorted: true,
+            keys,
+        })
+        .unwrap();
+
+        let JadeCommand::RegisterMultisig {
+            multisig_name,
+            descriptor,
+            paths,
+        } = command
+        else {
+            panic!("expected multisig registration");
+        };
+        assert_eq!(multisig_name, "hwi78631c5c8b92");
+        assert_eq!(descriptor.variant, "wsh(multi(k))");
+        assert!(descriptor.sorted);
+        assert_eq!(descriptor.threshold, 2);
+        assert_eq!(descriptor.signers.len(), 2);
+        assert!(
+            descriptor
+                .signers
+                .iter()
+                .all(|signer| signer.path.is_empty())
+        );
+        assert_eq!(paths, vec![vec![0, 7], vec![0, 7]]);
+    }
+
+    #[test]
+    fn pin_server_transmit_maps_recipient() {
+        let transmit = Transmit::from(JadeTransmit {
+            recipient: JadeRecipient::PinServer {
+                url: "https://pin.example".into(),
+            },
+            payload: vec![1, 2, 3],
+        });
+
+        assert!(matches!(
+            transmit.recipient,
+            Recipient::PinServer { ref url } if url == "https://pin.example"
+        ));
+        assert!(!transmit.encrypted);
+    }
+}

--- a/bhwi/src/common/adapters/ledger.rs
+++ b/bhwi/src/common/adapters/ledger.rs
@@ -1,0 +1,298 @@
+use crate::common::{
+    Command, DeviceContext, DisplayAddress, Error, Info, Recipient, Response, Transmit,
+    WalletRegistration,
+};
+use crate::ledger::apdu::ApduCommand;
+use crate::ledger::{
+    LedgerCommand, LedgerDisplayAddress, LedgerError, LedgerResponse, LedgerWalletPolicy, Version,
+};
+
+impl TryFrom<Command> for LedgerCommand {
+    type Error = LedgerError;
+
+    fn try_from(command: Command) -> Result<Self, Self::Error> {
+        match command {
+            Command::Setup(..) => Err(LedgerError::MissingCommandInfo(
+                "Setup not supported by Ledger",
+            )),
+            Command::Wipe => Err(LedgerError::MissingCommandInfo(
+                "Wipe not supported by Ledger",
+            )),
+            Command::Restore(..) => Err(LedgerError::MissingCommandInfo(
+                "Restore not supported by Ledger",
+            )),
+            Command::TogglePassphrase => Err(LedgerError::MissingCommandInfo(
+                "Toggle passphrase not supported by Ledger",
+            )),
+            Command::Backup => Err(LedgerError::MissingCommandInfo(
+                "Backup not supported by Ledger",
+            )),
+            Command::Unlock { options } => options
+                .network
+                .map(Self::OpenApp)
+                .ok_or(LedgerError::MissingCommandInfo("network")),
+            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
+            Command::GetXpub { path, display } => Ok(Self::GetXpub { path, display }),
+            Command::DisplayAddress(address, context) => {
+                let address = match address {
+                    DisplayAddress::ByPath { path, display, .. } => {
+                        LedgerDisplayAddress::ByPath { path, display }
+                    }
+                    DisplayAddress::ByDescriptor {
+                        index,
+                        change,
+                        display,
+                        ..
+                    } => {
+                        let (policy, hmac) = context
+                            .and_then(|context| match context {
+                                DeviceContext::Ledger {
+                                    wallet_policy,
+                                    wallet_hmac,
+                                } => Some((wallet_policy, wallet_hmac)),
+                                #[cfg(feature = "bitbox")]
+                                _ => None,
+                            })
+                            .ok_or(LedgerError::MissingCommandInfo(
+                                "Ledger requires DeviceContext::Ledger for descriptor-based address display",
+                            ))?;
+                        LedgerDisplayAddress::ByWalletPolicy {
+                            policy,
+                            hmac,
+                            change,
+                            address_index: index,
+                            display,
+                        }
+                    }
+                    DisplayAddress::ByMultisig(_) => {
+                        return Err(LedgerError::UnsupportedDisplayAddress(
+                            "Ledger raw multisig display is not implemented".into(),
+                        ));
+                    }
+                };
+                Ok(Self::GetWalletAddress { address })
+            }
+            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
+            Command::GetVersion => Ok(Self::GetAppInfo),
+            Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
+                policy: LedgerWalletPolicy::new(name, Version::V2, policy),
+            }),
+            Command::SignTx(psbt, context) => {
+                let (policy, hmac) = context
+                    .and_then(|context| match context {
+                        DeviceContext::Ledger {
+                            wallet_policy,
+                            wallet_hmac,
+                        } => Some((wallet_policy, wallet_hmac)),
+                        #[cfg(feature = "bitbox")]
+                        _ => None,
+                    })
+                    .ok_or(LedgerError::MissingCommandInfo("ledger sign tx context"))?;
+                Ok(Self::SignPsbt { psbt, policy, hmac })
+            }
+        }
+    }
+}
+
+impl From<LedgerResponse> for Response {
+    fn from(response: LedgerResponse) -> Self {
+        match response {
+            LedgerResponse::AppInfo(response) => {
+                let network = response.network();
+                Self::Info(Info {
+                    version: response.version,
+                    networks: vec![network],
+                    firmware: Some(response.app_name),
+                    initialized: None,
+                })
+            }
+            LedgerResponse::Signature(header, signature) => Self::Signature(header, signature),
+            LedgerResponse::TaskDone => Self::TaskDone,
+            LedgerResponse::Xpub(xpub) => Self::Xpub(xpub),
+            LedgerResponse::MasterFingerprint(fingerprint) => Self::MasterFingerprint(fingerprint),
+            LedgerResponse::Address(address) => Self::Address(address),
+            LedgerResponse::WalletHmac(hmac) => {
+                Self::WalletRegistration(WalletRegistration::Complete { hmac: Some(hmac) })
+            }
+            LedgerResponse::SignedPsbt(psbt) => Self::SignedPsbt(psbt),
+        }
+    }
+}
+
+impl From<LedgerError> for Error {
+    fn from(error: LedgerError) -> Self {
+        match error {
+            LedgerError::MissingCommandInfo(error) => Self::MissingCommandInfo(error),
+            LedgerError::NoErrorOrResult => Self::NoErrorOrResult,
+            LedgerError::Apdu(error) => Self::Serialization(format!("{error:?}")),
+            LedgerError::Store(_) => Self::Request("Store operation failed"),
+            LedgerError::Wallet(_) => Self::Request("Wallet operation failed"),
+            LedgerError::Interrupted => Self::Request("Operation interrupted"),
+            LedgerError::UnexpectedResult(data, context) => Self::unexpected_result(data, context),
+            LedgerError::UnsupportedDisplayAddress(context) => {
+                Self::UnsupportedDisplayAddress(context)
+            }
+            LedgerError::FailedToOpenApp(_) => Self::AuthenticationRefused,
+            LedgerError::InvalidPsbt(error) => Self::Serialization(error),
+        }
+    }
+}
+
+impl From<ApduCommand> for Transmit {
+    fn from(command: ApduCommand) -> Self {
+        Self {
+            recipient: Recipient::Device,
+            payload: command.encode(),
+            encrypted: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::Network;
+    use bitcoin::bip32::DerivationPath;
+    use miniscript::descriptor::{DescriptorPublicKey, WalletPolicy};
+
+    use super::*;
+    use crate::Interpreter;
+    use crate::common::LedgerInterpreter;
+
+    const KEY: &str = "[f5acc2fd/84'/1'/0']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP";
+
+    #[test]
+    fn path_display_maps_to_ledger_native_address() {
+        let path = DerivationPath::from_str("m/84'/1'/0'/0/7").unwrap();
+        let command = LedgerCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByPath {
+                path: path.clone(),
+                display: true,
+                address_format: None,
+            },
+            None,
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            LedgerCommand::GetWalletAddress {
+                address: LedgerDisplayAddress::ByPath {
+                    path: mapped,
+                    display: true,
+                },
+            } if mapped == path
+        ));
+    }
+
+    #[test]
+    fn descriptor_display_maps_context_to_wallet_policy_request() {
+        let policy = LedgerWalletPolicy::new("wallet".into(), Version::V2, wallet_policy());
+        let command = LedgerCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByDescriptor {
+                index: 3,
+                change: true,
+                display: true,
+                descriptor_name: "ignored-by-ledger".into(),
+            },
+            Some(DeviceContext::Ledger {
+                wallet_policy: policy,
+                wallet_hmac: Some([42; 32]),
+            }),
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            command,
+            LedgerCommand::GetWalletAddress {
+                address: LedgerDisplayAddress::ByWalletPolicy {
+                    hmac: Some(hmac),
+                    change: true,
+                    address_index: 3,
+                    display: true,
+                    ..
+                },
+            } if hmac == [42; 32]
+        ));
+    }
+
+    #[test]
+    fn descriptor_display_requires_ledger_context() {
+        let result = LedgerCommand::try_from(Command::DisplayAddress(
+            DisplayAddress::ByDescriptor {
+                index: 0,
+                change: false,
+                display: true,
+                descriptor_name: "wallet".into(),
+            },
+            None,
+        ));
+
+        assert!(matches!(result, Err(LedgerError::MissingCommandInfo(_))));
+    }
+
+    #[test]
+    fn policy_display_starts_with_wallet_address_apdu() {
+        let policy = LedgerWalletPolicy::new("wallet".into(), Version::V2, wallet_policy());
+        let mut interpreter = LedgerInterpreter::default();
+        let transmit = interpreter
+            .start(Command::DisplayAddress(
+                DisplayAddress::ByDescriptor {
+                    index: 0,
+                    change: false,
+                    display: true,
+                    descriptor_name: "wallet".into(),
+                },
+                Some(DeviceContext::Ledger {
+                    wallet_policy: policy,
+                    wallet_hmac: None,
+                }),
+            ))
+            .unwrap();
+
+        assert_eq!(
+            transmit.payload[1],
+            crate::ledger::apdu::BitcoinCommandCode::GetWalletAddress as u8
+        );
+    }
+
+    #[test]
+    fn nonstandard_xpub_path_retries_with_display() {
+        let path = DerivationPath::from_str("m/0h/0h/4h").unwrap();
+        let mut interpreter = LedgerInterpreter::default();
+
+        let initial = interpreter
+            .start(Command::GetXpub {
+                path,
+                display: false,
+            })
+            .unwrap();
+        assert_eq!(initial.payload[5], 0);
+
+        let retry = interpreter
+            .exchange(vec![0x6a, 0x82])
+            .unwrap()
+            .expect("non-standard path should be retried");
+        assert_eq!(retry.payload[5], 1);
+    }
+
+    fn wallet_policy() -> WalletPolicy {
+        let mut policy = WalletPolicy::from_str("wpkh(@0/**)").unwrap();
+        let key = DescriptorPublicKey::from_str(KEY).unwrap();
+        policy.set_key_info(&[key]).unwrap();
+        policy
+    }
+
+    #[test]
+    fn unlock_preserves_network_mapping() {
+        assert!(matches!(
+            LedgerCommand::try_from(Command::Unlock {
+                options: crate::common::UnlockOptions {
+                    network: Some(Network::Testnet),
+                },
+            }),
+            Ok(LedgerCommand::OpenApp(Network::Testnet))
+        ));
+    }
+}

--- a/bhwi/src/jade/mod.rs
+++ b/bhwi/src/jade/mod.rs
@@ -6,22 +6,15 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use base64ct::{Base64, Encoding};
 use bitcoin::Network;
-use bitcoin::address::AddressType;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
-use bitcoin::hashes::{Hash, sha256};
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::ecdsa::Signature;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::Interpreter;
-use crate::common::{
-    Command, DisplayAddress, Error, Info, MultisigAddressType, MultisigDisplayAddress, Recipient,
-    Response, Transmit,
-};
 use crate::device::DeviceId;
 use crate::jade::api::GetInfoResponse;
-use crate::miniscript::descriptor::{DescriptorPublicKey, Wildcard};
 
 pub const JADE_NETWORK_MAINNET: &str = "mainnet";
 pub const JADE_NETWORK_TESTNET: &str = "testnet";
@@ -523,217 +516,15 @@ where
     }
 }
 
-impl TryFrom<Command> for JadeCommand {
-    type Error = Error;
-
-    fn try_from(cmd: Command) -> Result<Self, Self::Error> {
-        match cmd {
-            Command::Setup(..) => Err(Error::MissingCommandInfo("Setup not supported by Jade")),
-            Command::Wipe => Err(Error::MissingCommandInfo("Wipe not supported by Jade")),
-            Command::Restore(..) => Err(Error::MissingCommandInfo("Restore not supported by Jade")),
-            Command::TogglePassphrase => Err(Error::MissingCommandInfo(
-                "Toggle passphrase not supported by Jade",
-            )),
-            Command::Backup => Err(Error::MissingCommandInfo("Backup not supported by Jade")),
-            Command::Unlock { .. } => Ok(Self::Auth),
-            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
-            Command::GetXpub { path, .. } => Ok(Self::GetXpub(path)),
-            Command::DisplayAddress(
-                DisplayAddress::ByDescriptor {
-                    index,
-                    change,
-                    descriptor_name,
-                    ..
-                },
-                _ctx,
-            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Descriptor {
-                index,
-                change,
-                descriptor_name,
-            })),
-            Command::DisplayAddress(
-                DisplayAddress::ByPath {
-                    path,
-                    address_format,
-                    ..
-                },
-                _,
-            ) => Ok(Self::GetReceiveAddress(ReceiveAddress::Path {
-                path,
-                variant: jade_path_variant(address_format)?,
-            })),
-            Command::DisplayAddress(DisplayAddress::ByMultisig(address), _) => {
-                jade_multisig_command(address)
-            }
-            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
-            Command::GetVersion => Ok(Self::GetInfo),
-            Command::RegisterWallet { name, policy } => {
-                let (descriptor, keys) = crate::policy::extract_parts(&policy)
-                    .map_err(|err| Error::Serialization(err.to_string()))?;
-                // Jade's descriptor parser uses the explicit multipath spelling,
-                // while BIP-388 WalletPolicy display canonicalizes it to `/**`.
-                let descriptor = descriptor.replace("/**", "/<0;1>/*");
-                let datavalues = keys
-                    .iter()
-                    .enumerate()
-                    .map(|(index, key)| (format!("@{index}"), crate::policy::format_key_info(key)))
-                    .collect();
-                Ok(Self::RegisterDescriptor {
-                    descriptor_name: name,
-                    descriptor,
-                    datavalues,
-                })
-            }
-            Command::SignTx(psbt, _) => Ok(Self::SignPsbt { psbt }),
-        }
-    }
-}
-
-fn jade_multisig_command(address: MultisigDisplayAddress) -> Result<JadeCommand, Error> {
-    let variant = match address.address_type {
-        MultisigAddressType::Legacy => "sh(multi(k))",
-        MultisigAddressType::Wit => "wsh(multi(k))",
-        MultisigAddressType::ShWit => "sh(wsh(multi(k)))",
-    };
-    let mut signer_origins = Vec::with_capacity(address.keys.len());
-    let mut signers = Vec::with_capacity(address.keys.len());
-    let mut paths = Vec::with_capacity(address.keys.len());
-
-    for key in address.keys {
-        let DescriptorPublicKey::XPub(key) = key else {
-            return Err(Error::InvalidInput(
-                "Jade multisig display requires extended public keys".into(),
-            ));
-        };
-        if key.wildcard != Wildcard::None {
-            return Err(Error::InvalidInput(
-                "Jade multisig display requires concrete key derivation paths".into(),
-            ));
-        }
-        let (fingerprint, origin_path) = key.origin.ok_or_else(|| {
-            Error::InvalidInput("Jade multisig display requires key origin information".into())
-        })?;
-        let origin = origin_path.to_u32_vec();
-        signer_origins.push((fingerprint.to_bytes(), origin.clone()));
-        signers.push(api::MultisigSigner {
-            fingerprint: fingerprint.to_bytes().to_vec(),
-            derivation: origin,
-            xpub: key.xkey.to_string(),
-            path: Vec::new(),
-        });
-        paths.push(key.derivation_path.to_u32_vec());
-    }
-
-    signer_origins.sort();
-    let mut summary = format!("{variant}|{}|", address.threshold);
-    for (fingerprint, path) in signer_origins {
-        summary.push_str(&hex::encode(fingerprint));
-        summary.push('|');
-        summary.push_str(&format!("{path:?}"));
-        summary.push('|');
-    }
-    let digest = sha256::Hash::hash(summary.as_bytes());
-    let multisig_name = format!("hwi{}", &digest.to_string()[..12]);
-
-    Ok(JadeCommand::RegisterMultisig {
-        multisig_name,
-        descriptor: api::MultisigDescriptor {
-            variant: variant.to_string(),
-            sorted: address.sorted,
-            threshold: address.threshold,
-            signers,
-            master_blinding_key: None,
-        },
-        paths,
-    })
-}
-
-fn jade_path_variant(address_format: Option<AddressType>) -> Result<&'static str, Error> {
-    match address_format.unwrap_or(AddressType::P2wpkh) {
-        AddressType::P2pkh => Ok("pkh(k)"),
-        AddressType::P2sh => Ok("sh(wpkh(k))"),
-        AddressType::P2wpkh => Ok("wpkh(k)"),
-        AddressType::P2wsh | AddressType::P2tr => Err(Error::UnsupportedDisplayAddress(
-            "Jade does not support this path address format".into(),
-        )),
-        _ => Err(Error::UnsupportedDisplayAddress(
-            "Jade does not support this path address format".into(),
-        )),
-    }
-}
-
-impl From<JadeResponse> for Response {
-    fn from(res: JadeResponse) -> Response {
-        match res {
-            JadeResponse::TaskDone => Response::TaskDone,
-            JadeResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
-            JadeResponse::Xpub(xpub) => Response::Xpub(xpub),
-            JadeResponse::Signature(header, signature) => Response::Signature(header, signature),
-            JadeResponse::GetInfo(info) => Response::Info(Info {
-                version: info.jade_version.as_str().into(),
-                networks: info.jade_networks.into(),
-                firmware: None,
-                initialized: None,
-            }),
-            JadeResponse::Address(address) => Response::Address(address),
-            JadeResponse::RegisteredDescriptor => {
-                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
-                    hmac: None,
-                })
-            }
-            JadeResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
-        }
-    }
-}
-
-impl From<JadeRecipient> for Recipient {
-    fn from(recipient: JadeRecipient) -> Recipient {
-        match recipient {
-            JadeRecipient::Device => Recipient::Device,
-            JadeRecipient::PinServer { url } => Recipient::PinServer { url },
-        }
-    }
-}
-
-impl From<JadeTransmit> for Transmit {
-    fn from(transmit: JadeTransmit) -> Transmit {
-        Transmit {
-            recipient: transmit.recipient.into(),
-            payload: transmit.payload,
-            encrypted: false,
-        }
-    }
-}
-
-impl From<JadeError> for Error {
-    fn from(error: JadeError) -> Error {
-        match error {
-            JadeError::Cbor => Error::Serialization("cbor".to_string()),
-            JadeError::NoErrorOrResult => Error::NoErrorOrResult,
-            JadeError::Rpc(api_error) => Error::Rpc(api_error.code, api_error.message),
-            JadeError::Serialization(s) => Error::Serialization(s),
-            JadeError::UnexpectedResult(msg) => Error::unexpected_result(
-                msg.clone().into_bytes(),
-                format!("jade unexpected result: {msg}"),
-            ),
-            JadeError::HandshakeRefused => Error::AuthenticationRefused,
-            JadeError::UnsupportedDisplayAddress => {
-                Error::UnsupportedDisplayAddress("unsupported display address on Jade".into())
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
+    use bitcoin::address::AddressType;
+
     use super::*;
     use crate::Interpreter;
-    use crate::common::{
-        Command, DisplayAddress, JadeInterpreter, MultisigAddressType, MultisigDisplayAddress,
-    };
-    use crate::miniscript::descriptor::DescriptorPublicKey;
+    use crate::common::{Command, DisplayAddress, JadeInterpreter, Response, WalletRegistration};
     use crate::miniscript::descriptor::WalletPolicy;
     use serde::Deserialize;
 
@@ -792,20 +583,6 @@ mod tests {
     }
 
     #[test]
-    fn path_display_rejects_unsupported_jade_address_format() {
-        let result = JadeCommand::try_from(Command::DisplayAddress(
-            DisplayAddress::ByPath {
-                path: "m/86'/1'/0'/0/0".parse().unwrap(),
-                display: true,
-                address_format: Some(AddressType::P2tr),
-            },
-            None,
-        ));
-
-        assert!(matches!(result, Err(Error::UnsupportedDisplayAddress(_))));
-    }
-
-    #[test]
     fn register_wallet_encodes_jade_descriptor_params() {
         let mut interpreter = JadeInterpreter::default().with_network(Network::Testnet);
         let transmit = interpreter
@@ -856,9 +633,7 @@ mod tests {
         assert!(interpreter.exchange(response).unwrap().is_none());
         assert!(matches!(
             interpreter.end().unwrap(),
-            Response::WalletRegistration(crate::common::WalletRegistration::Complete {
-                hmac: None
-            })
+            Response::WalletRegistration(WalletRegistration::Complete { hmac: None })
         ));
     }
 
@@ -889,44 +664,5 @@ mod tests {
                 .to_string()
                 .contains("register_descriptor returned false")
         );
-    }
-
-    #[test]
-    fn multisig_display_uses_upstream_hwi_registration_shape_and_name() {
-        let keys = [
-            "[f5acc2fd/48'/1'/0'/2']tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/0/7",
-            "[00000000/48'/1'/0'/2']tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/0/7",
-        ]
-        .map(|key| DescriptorPublicKey::from_str(key).unwrap())
-        .to_vec();
-
-        let command = jade_multisig_command(MultisigDisplayAddress {
-            threshold: 2,
-            address_type: MultisigAddressType::Wit,
-            sorted: true,
-            keys,
-        })
-        .unwrap();
-
-        let JadeCommand::RegisterMultisig {
-            multisig_name,
-            descriptor,
-            paths,
-        } = command
-        else {
-            panic!("expected multisig registration");
-        };
-        assert_eq!(multisig_name, "hwi78631c5c8b92");
-        assert_eq!(descriptor.variant, "wsh(multi(k))");
-        assert!(descriptor.sorted);
-        assert_eq!(descriptor.threshold, 2);
-        assert_eq!(descriptor.signers.len(), 2);
-        assert!(
-            descriptor
-                .signers
-                .iter()
-                .all(|signer| signer.path.is_empty())
-        );
-        assert_eq!(paths, vec![vec![0, 7], vec![0, 7]]);
     }
 }

--- a/bhwi/src/ledger/apdu.rs
+++ b/bhwi/src/ledger/apdu.rs
@@ -1,8 +1,6 @@
 use core::convert::TryFrom;
 use core::fmt::Debug;
 
-use crate::common::{Recipient, Transmit};
-
 // p2 encodes the protocol version implemented
 pub const CURRENT_PROTOCOL_VERSION: u8 = 1;
 
@@ -122,16 +120,6 @@ impl ApduCommand {
         let mut vec = vec![self.cla, self.ins, self.p1, self.p2, self.data.len() as u8];
         vec.extend(self.data.iter());
         vec
-    }
-}
-
-impl From<ApduCommand> for Transmit {
-    fn from(payload: ApduCommand) -> Transmit {
-        Transmit {
-            recipient: Recipient::Device,
-            payload: payload.encode(),
-            encrypted: false,
-        }
     }
 }
 

--- a/bhwi/src/ledger/mod.rs
+++ b/bhwi/src/ledger/mod.rs
@@ -19,7 +19,6 @@ use store::{DelegatedStore, StoreError};
 pub use wallet::{AddressType, LedgerWalletPolicy, Version, WalletError, singlesig_wallet_policy};
 
 use crate::Interpreter;
-use crate::common::{Command, DeviceContext, DisplayAddress, Error, Info, Response};
 use crate::device::DeviceId;
 
 pub const LEDGER_DEVICE_ID: DeviceId = DeviceId::new(0x2c97)
@@ -76,8 +75,7 @@ pub enum LedgerCommand {
         display: bool,
     },
     GetWalletAddress {
-        address: DisplayAddress,
-        context: Option<DeviceContext>,
+        address: LedgerDisplayAddress,
     },
     SignMessage {
         message: Vec<u8>,
@@ -90,6 +88,27 @@ pub enum LedgerCommand {
         psbt: Psbt,
         policy: LedgerWalletPolicy,
         hmac: Option<[u8; 32]>,
+    },
+}
+
+/// Ledger-native address request consumed by the interpreter.
+///
+/// A path request derives the corresponding singlesig wallet policy through
+/// Ledger API calls. A policy request carries the exact inputs required by the
+/// device's `GET_WALLET_ADDRESS` command.
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum LedgerDisplayAddress {
+    ByPath {
+        path: DerivationPath,
+        display: bool,
+    },
+    ByWalletPolicy {
+        policy: LedgerWalletPolicy,
+        hmac: Option<[u8; 32]>,
+        change: bool,
+        address_index: u32,
+        display: bool,
     },
 }
 
@@ -167,14 +186,13 @@ enum State {
 
 enum GetWalletAddressStep {
     Fingerprint {
-        address: DisplayAddress,
-        context: Option<DeviceContext>,
+        path: DerivationPath,
+        display: bool,
     },
     Xpub {
-        address: DisplayAddress,
+        path: DerivationPath,
         fingerprint: Fingerprint,
         display: bool,
-        context: Option<DeviceContext>,
     },
     WalletAddress {
         store: Option<DelegatedStore>,
@@ -345,11 +363,34 @@ where
                     Some(store),
                 )
             }
-            LedgerCommand::GetWalletAddress { address, context } => {
-                self.state =
-                    State::GetWalletAddress(GetWalletAddressStep::Fingerprint { address, context });
-                return Ok(Self::Transmit::from(command::get_master_fingerprint()));
-            }
+            LedgerCommand::GetWalletAddress { ref address } => match address {
+                LedgerDisplayAddress::ByPath { path, display } => {
+                    self.state = State::GetWalletAddress(GetWalletAddressStep::Fingerprint {
+                        path: path.clone(),
+                        display: *display,
+                    });
+                    return Ok(Self::Transmit::from(command::get_master_fingerprint()));
+                }
+                LedgerDisplayAddress::ByWalletPolicy {
+                    policy,
+                    hmac,
+                    change,
+                    address_index,
+                    display,
+                } => (
+                    Self::Transmit::from(
+                        command::get_wallet_address(
+                            policy,
+                            hmac.as_ref(),
+                            *change,
+                            *address_index,
+                            *display,
+                        )
+                        .map_err(LedgerError::from)?,
+                    ),
+                    Some(policy.to_store().map_err(LedgerError::from)?),
+                ),
+            },
             LedgerCommand::RegisterWallet { ref policy } => (
                 Self::Transmit::from(command::register_wallet(policy).map_err(LedgerError::from)?),
                 Some(policy.to_store().map_err(LedgerError::from)?),
@@ -445,10 +486,7 @@ where
         let res = ApduResponse::try_from(data).map_err(LedgerError::from)?;
         let state = std::mem::take(&mut self.state);
         let (next_state, result) = match state {
-            State::GetWalletAddress(GetWalletAddressStep::Fingerprint {
-                mut address,
-                context,
-            }) => {
+            State::GetWalletAddress(GetWalletAddressStep::Fingerprint { path, display }) => {
                 if res.data.len() < 4 {
                     return Err(LedgerError::unexpected_result(
                         res.data,
@@ -459,124 +497,45 @@ where
                 let mut fg = [0x00; 4];
                 fg.copy_from_slice(&res.data[0..4]);
                 let fingerprint = Fingerprint::from(fg);
-                match &mut address {
-                    DisplayAddress::ByPath { path, display, .. } => {
-                        let children: Vec<_> = path.as_ref().to_vec();
-                        if children.len() < 5 {
-                            return Err(LedgerError::UnsupportedDisplayAddress(
-                                "Ledger requires a full 5-level derivation path (e.g. m/84'/0'/0'/0/0)".into(),
-                            )
-                            .into());
-                        }
-                        let account_path = DerivationPath::from(children[..3].to_vec());
-                        let display = *display;
-                        let cmd = Self::Transmit::from(command::get_extended_pubkey(
-                            &account_path,
-                            false,
-                        ));
-                        (
-                            State::GetWalletAddress(GetWalletAddressStep::Xpub {
-                                address,
-                                fingerprint,
-                                display,
-                                context,
-                            }),
-                            Some(cmd),
-                        )
-                    }
-                    DisplayAddress::ByDescriptor {
-                        index,
-                        change,
-                        display,
-                        ..
-                    } => {
-                        let (ledger_policy, wallet_hmac) = context
-                            .as_ref()
-                            .and_then(|ctx| match ctx {
-                                DeviceContext::Ledger { wallet_policy, wallet_hmac } => {
-                                    Some((wallet_policy.clone(), *wallet_hmac))
-                                }
-                                #[cfg(feature = "bitbox")]
-                                _ => None,
-                            })
-                            .ok_or(LedgerError::MissingCommandInfo(
-                                "Ledger requires DeviceContext::Ledger for descriptor-based address display",
-                            ))?;
-                        let store = Some(ledger_policy.to_store().map_err(LedgerError::from)?);
-                        let cmd = Self::Transmit::from(
-                            command::get_wallet_address(
-                                &ledger_policy,
-                                wallet_hmac.as_ref(),
-                                *change,
-                                *index,
-                                *display,
-                            )
-                            .map_err(LedgerError::from)?,
-                        );
-                        (
-                            State::GetWalletAddress(GetWalletAddressStep::WalletAddress { store }),
-                            Some(cmd),
-                        )
-                    }
-                    DisplayAddress::ByMultisig(_) => {
-                        return Err(LedgerError::UnsupportedDisplayAddress(
-                            "Ledger raw multisig display is not implemented".into(),
-                        )
-                        .into());
-                    }
+                let children: Vec<_> = path.as_ref().to_vec();
+                if children.len() < 5 {
+                    return Err(LedgerError::UnsupportedDisplayAddress(
+                        "Ledger requires a full 5-level derivation path (e.g. m/84'/0'/0'/0/0)"
+                            .into(),
+                    )
+                    .into());
                 }
+                let account_path = DerivationPath::from(children[..3].to_vec());
+                let cmd = Self::Transmit::from(command::get_extended_pubkey(&account_path, false));
+                (
+                    State::GetWalletAddress(GetWalletAddressStep::Xpub {
+                        path,
+                        fingerprint,
+                        display,
+                    }),
+                    Some(cmd),
+                )
             }
             State::GetWalletAddress(GetWalletAddressStep::Xpub {
-                address,
+                path,
                 fingerprint,
                 display,
-                context,
             }) => {
                 let xpub = Xpub::from_str(&String::from_utf8_lossy(&res.data)).map_err(|_| {
                     LedgerError::unexpected_result(res.data, "display address: xpub")
                 })?;
-                let (ledger_policy, wallet_hmac, change, address_index) = match address {
-                    DisplayAddress::ByPath { path, .. } => {
-                        let children: Vec<_> = path.as_ref().to_vec();
-                        let change =
-                            children[3] == bitcoin::bip32::ChildNumber::from_normal_idx(1).unwrap();
-                        let address_index = u32::from(children[4]);
-                        let policy = singlesig_wallet_policy(&path, fingerprint, xpub)
-                            .map_err(LedgerError::from)?;
-                        (
-                            LedgerWalletPolicy::new(String::new(), Version::V2, policy),
-                            None,
-                            change,
-                            address_index,
-                        )
-                    }
-                    DisplayAddress::ByDescriptor { index, change, .. } => {
-                        let (wallet_policy, wallet_hmac) = context
-                            .as_ref()
-                            .and_then(|ctx| match ctx {
-                                DeviceContext::Ledger { wallet_policy, wallet_hmac } => {
-                                    Some((wallet_policy.clone(), *wallet_hmac))
-                                }
-                                #[cfg(feature = "bitbox")]
-                                _ => None,
-                            })
-                            .ok_or(LedgerError::MissingCommandInfo(
-                                "Ledger requires DeviceContext::Ledger for descriptor-based address display",
-                            ))?;
-                        (wallet_policy, wallet_hmac, change, index)
-                    }
-                    DisplayAddress::ByMultisig(_) => {
-                        return Err(LedgerError::UnsupportedDisplayAddress(
-                            "Ledger raw multisig display is not implemented".into(),
-                        )
-                        .into());
-                    }
-                };
+                let children: Vec<_> = path.as_ref().to_vec();
+                let change =
+                    children[3] == bitcoin::bip32::ChildNumber::from_normal_idx(1).unwrap();
+                let address_index = u32::from(children[4]);
+                let policy =
+                    singlesig_wallet_policy(&path, fingerprint, xpub).map_err(LedgerError::from)?;
+                let ledger_policy = LedgerWalletPolicy::new(String::new(), Version::V2, policy);
                 let store = Some(ledger_policy.to_store().map_err(LedgerError::from)?);
                 let cmd = Self::Transmit::from(
                     command::get_wallet_address(
                         &ledger_policy,
-                        wallet_hmac.as_ref(),
+                        None,
                         change,
                         address_index,
                         display,
@@ -796,114 +755,9 @@ where
     }
 }
 
-impl TryFrom<Command> for LedgerCommand {
-    type Error = LedgerError;
-    fn try_from(cmd: Command) -> Result<Self, Self::Error> {
-        match cmd {
-            Command::Setup(..) => Err(LedgerError::MissingCommandInfo(
-                "Setup not supported by Ledger",
-            )),
-            Command::Wipe => Err(LedgerError::MissingCommandInfo(
-                "Wipe not supported by Ledger",
-            )),
-            Command::Restore(..) => Err(LedgerError::MissingCommandInfo(
-                "Restore not supported by Ledger",
-            )),
-            Command::TogglePassphrase => Err(LedgerError::MissingCommandInfo(
-                "Toggle passphrase not supported by Ledger",
-            )),
-            Command::Backup => Err(LedgerError::MissingCommandInfo(
-                "Backup not supported by Ledger",
-            )),
-            Command::Unlock { options } => options
-                .network
-                .map(Self::OpenApp)
-                .ok_or(LedgerError::MissingCommandInfo("network")),
-            Command::GetMasterFingerprint => Ok(Self::GetMasterFingerprint),
-            Command::GetXpub { path, display } => Ok(Self::GetXpub { path, display }),
-            Command::DisplayAddress(addr, ctx) => Ok(Self::GetWalletAddress {
-                address: match addr {
-                    DisplayAddress::ByMultisig(_) => {
-                        return Err(LedgerError::UnsupportedDisplayAddress(
-                            "Ledger raw multisig display is not implemented".into(),
-                        ));
-                    }
-                    address => address,
-                },
-                context: ctx,
-            }),
-            Command::SignMessage { message, path } => Ok(Self::SignMessage { message, path }),
-            Command::GetVersion => Ok(Self::GetAppInfo),
-            Command::RegisterWallet { name, policy } => Ok(Self::RegisterWallet {
-                policy: LedgerWalletPolicy::new(name, Version::V2, policy),
-            }),
-            Command::SignTx(psbt, context) => {
-                let (ledger_policy, wallet_hmac) = context
-                    .and_then(|ctx| match ctx {
-                        DeviceContext::Ledger {
-                            wallet_policy,
-                            wallet_hmac,
-                        } => Some((wallet_policy, wallet_hmac)),
-                        #[cfg(feature = "bitbox")]
-                        _ => None,
-                    })
-                    .ok_or(LedgerError::MissingCommandInfo("ledger sign tx context"))?;
-                Ok(Self::SignPsbt {
-                    psbt,
-                    policy: ledger_policy,
-                    hmac: wallet_hmac,
-                })
-            }
-        }
-    }
-}
-
-impl From<LedgerResponse> for Response {
-    fn from(res: LedgerResponse) -> Response {
-        match res {
-            LedgerResponse::AppInfo(res) => Response::Info(Info {
-                version: res.version.to_string(),
-                networks: vec![res.network()],
-                firmware: Some(res.app_name),
-                initialized: None,
-            }),
-            LedgerResponse::Signature(header, signature) => Response::Signature(header, signature),
-            LedgerResponse::TaskDone => Response::TaskDone,
-            LedgerResponse::Xpub(xpub) => Response::Xpub(xpub),
-            LedgerResponse::MasterFingerprint(fg) => Response::MasterFingerprint(fg),
-            LedgerResponse::Address(address) => Response::Address(address),
-            LedgerResponse::WalletHmac(hmac) => {
-                Response::WalletRegistration(crate::common::WalletRegistration::Complete {
-                    hmac: Some(hmac),
-                })
-            }
-            LedgerResponse::SignedPsbt(psbt) => Response::SignedPsbt(psbt),
-        }
-    }
-}
-
-impl From<LedgerError> for Error {
-    fn from(error: LedgerError) -> Error {
-        match error {
-            LedgerError::MissingCommandInfo(e) => Error::MissingCommandInfo(e),
-            LedgerError::NoErrorOrResult => Error::NoErrorOrResult,
-            LedgerError::Apdu(e) => Error::Serialization(format!("{:?}", e)),
-            LedgerError::Store(_) => Error::Request("Store operation failed"),
-            LedgerError::Wallet(_) => Error::Request("Wallet operation failed"),
-            LedgerError::Interrupted => Error::Request("Operation interrupted"),
-            LedgerError::UnexpectedResult(data, ctx) => Error::unexpected_result(data, ctx),
-            LedgerError::UnsupportedDisplayAddress(ctx) => Error::UnsupportedDisplayAddress(ctx),
-            LedgerError::FailedToOpenApp(_) => Error::AuthenticationRefused,
-            LedgerError::InvalidPsbt(e) => Error::Serialization(e),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Interpreter;
-    use std::str::FromStr;
 
     const XONLY: [u8; 32] = [
         0x4f, 0x35, 0x5b, 0xdc, 0xb7, 0xcc, 0x0a, 0xf7, 0x28, 0xef, 0x3c, 0xce, 0xb9, 0x61, 0x5d,
@@ -979,24 +833,5 @@ mod tests {
         payload.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
 
         assert_ignored(&payload, 11);
-    }
-
-    #[test]
-    fn nonstandard_xpub_path_retries_with_display() {
-        let path = DerivationPath::from_str("m/0h/0h/4h").unwrap();
-        let command = crate::common::Command::GetXpub {
-            path,
-            display: false,
-        };
-        let mut interpreter = crate::common::LedgerInterpreter::default();
-
-        let initial = interpreter.start(command).unwrap();
-        assert_eq!(initial.payload[5], 0);
-
-        let retry = interpreter
-            .exchange(vec![0x6a, 0x82])
-            .unwrap()
-            .expect("non-standard path should be retried");
-        assert_eq!(retry.payload[5], 1);
     }
 }


### PR DESCRIPTION
## Summary

- move conversions between common and device-native commands, responses, errors, and transmits into `common::adapters`
- remove production `common` dependencies from the Ledger, Coldcard, Jade, and BitBox interpreters
- model Ledger address display with `LedgerDisplayAddress`, allowing registered policies to start directly with the wallet-address APDU
- add focused adapter coverage while retaining protocol-focused tests in each device module

## Dependency

This is a draft pending #78. After it merges, this branch needs to be rebased and its detailed Ledger `StoreError` mapping preserved before final review.

## Validation

Passed:

- `cargo fmt --all --check`
- `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
- `cargo test --verbose --no-default-features`
- `cargo test --verbose --color always -- --nocapture`
- `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
- Coldcard emulator startup and native e2e: 9/9
- Coldcard CLI e2e: 6/6
- Jade PIN server, QEMU startup, and initialization
- Jade native e2e: 9/9
- Jade CLI e2e: 8/8
- BitBox simulator startup and native e2e: 8/8
- BitBox restore lifecycle fixture: 1/1
- BitBox CLI e2e: 4/4, with 2 intentionally ignored lifecycle tests

Closes #65
