### PR TITLE
HWI parity: define and enforce the error exit-status contract

### DIFF
--- a/.agents/runbooks/hwi-parity.md
+++ b/.agents/runbooks/hwi-parity.md
@@ -10,6 +10,10 @@ enumeration, command parsing, command output, or HWI status docs.
   shapes, error codes, and base64 formats where parity is claimed.
 - Parse unsupported Python HWI commands and return Python-HWI-shaped unsupported
   errors instead of clap parse errors.
+- Match Python HWI's exit statuses: `0` for success, `--help`, `--version`, and
+  every runtime `{"error", "code"}` JSON response; `2` for usage errors, which
+  print code `-2` JSON on stdout and usage text on stderr; `1` is reserved for
+  internal crashes. The harness asserts process status, not just JSON.
 - Record every intentional divergence in `docs/HWI_PARITY.md`.
 - Treat the unmodified upstream HWI device suite as the final acceptance gate.
   Do not patch upstream tests or add BHWI-owned skips.

--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -25,7 +25,7 @@ use bitcoin::{
     secp256k1::{PublicKey as SecpPublicKey, Secp256k1, XOnlyPublicKey},
 };
 use chrono::{Datelike, Local, Timelike};
-use clap::{ArgAction, ArgGroup, Parser, Subcommand, ValueEnum, error::ErrorKind};
+use clap::{ArgAction, ArgGroup, CommandFactory, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use miniscript::{
     Descriptor, DescriptorPublicKey,
     descriptor::{DescriptorType, WalletPolicy, checksum},
@@ -276,6 +276,7 @@ pub struct HwiError {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum HwiErrorCode {
     NoDeviceType,
+    MissingArguments,
     UnknownDevice,
     BadArgument,
     UnsupportedCommand,
@@ -289,6 +290,7 @@ impl HwiErrorCode {
     fn code(self) -> i32 {
         match self {
             HwiErrorCode::NoDeviceType => -1,
+            HwiErrorCode::MissingArguments => -2,
             HwiErrorCode::UnknownDevice => -4,
             HwiErrorCode::BadArgument => -7,
             HwiErrorCode::UnsupportedCommand => -9,
@@ -495,27 +497,162 @@ where
             )));
         }
     };
-    let request = match HwiCli::try_parse_from(args) {
-        Ok(args) => match request_from_cli(args) {
-            Ok(request) => request,
-            Err(err) => return print_response(HwiResponse::Error(err)),
-        },
-        Err(err) if err.kind() == ErrorKind::DisplayHelp => {
-            print!("{err}");
-            return ExitCode::SUCCESS;
+    let outcome = cli_outcome(args);
+    let status = ExitCode::from(exit_status(&outcome));
+    match outcome {
+        CliOutcome::Stdout(text) => {
+            print!("{text}");
+            status
         }
-        Err(err) if err.kind() == ErrorKind::DisplayVersion => {
-            print!("{err}");
-            return ExitCode::SUCCESS;
+        CliOutcome::Usage(usage) => {
+            println!(
+                "{}",
+                serde_json::to_string(&HwiError {
+                    error: usage.message,
+                    code: HwiErrorCode::MissingArguments.code(),
+                })
+                .expect("serialize HWI usage error")
+            );
+            eprintln!("{}", usage.usage);
+            status
         }
-        Err(err) => {
-            return print_response(HwiResponse::Error(HwiError::new(
-                HwiErrorCode::BadArgument,
-                err.to_string(),
-            )));
-        }
+        CliOutcome::Response(response) => print_response(response),
+        CliOutcome::Request(request) => print_response(process_request(*request).await),
+    }
+}
+
+/// Argparse-style usage failure: `message` goes to stdout as HWI JSON, `usage` to stderr.
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct UsageError {
+    message: String,
+    usage: String,
+}
+
+#[derive(Debug)]
+enum CliOutcome {
+    Stdout(String),
+    Usage(UsageError),
+    Response(HwiResponse),
+    Request(Box<HwiRequest>),
+}
+
+fn exit_status(outcome: &CliOutcome) -> u8 {
+    match outcome {
+        CliOutcome::Usage(_) => 2,
+        _ => 0,
+    }
+}
+
+fn cli_outcome(args: Vec<OsString>) -> CliOutcome {
+    let prog = program_name(&args);
+    let cli = match HwiCli::try_parse_from(args) {
+        Ok(cli) => cli,
+        Err(err) => return clap_outcome(&prog, err),
     };
-    print_response(process_request(request).await)
+    match request_from_cli(cli) {
+        Ok(request) => {
+            if let HwiCommand::Unsupported(command) = &request.command {
+                CliOutcome::Usage(UsageError {
+                    message: format!(
+                        "{prog}: error: argument command: invalid choice: '{command}'"
+                    ),
+                    usage: top_level_usage(&prog),
+                })
+            } else {
+                CliOutcome::Request(Box::new(request))
+            }
+        }
+        Err(err) if err.code == HwiErrorCode::MissingArguments.code() => {
+            CliOutcome::Usage(UsageError {
+                message: format!("{prog}: error: {}", err.error),
+                usage: top_level_usage(&prog),
+            })
+        }
+        Err(err) => CliOutcome::Response(HwiResponse::Error(err)),
+    }
+}
+
+fn clap_outcome(prog: &str, err: clap::Error) -> CliOutcome {
+    match err.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => CliOutcome::Stdout(err.to_string()),
+        ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::MissingSubcommand => {
+            CliOutcome::Usage(UsageError {
+                message: format!("{prog}: error: the following arguments are required: command"),
+                usage: top_level_usage(prog),
+            })
+        }
+        ErrorKind::MissingRequiredArgument
+        | ErrorKind::UnknownArgument
+        | ErrorKind::InvalidValue
+        | ErrorKind::InvalidSubcommand
+        | ErrorKind::ArgumentConflict
+        | ErrorKind::NoEquals
+        | ErrorKind::WrongNumberOfValues
+        | ErrorKind::TooManyValues
+        | ErrorKind::TooFewValues => CliOutcome::Usage(clap_usage_error(prog, &err)),
+        // Every other kind keeps the pre-existing runtime error JSON.
+        _ => CliOutcome::Response(HwiResponse::Error(HwiError::new(
+            HwiErrorCode::BadArgument,
+            err.to_string(),
+        ))),
+    }
+}
+
+fn clap_usage_error(prog: &str, err: &clap::Error) -> UsageError {
+    let rendered = err.render().to_string();
+    let mut message = String::new();
+    let mut usage = String::new();
+    let mut in_usage = false;
+    for line in rendered.lines() {
+        if line.starts_with("Usage:") {
+            in_usage = true;
+        }
+        if line.starts_with("For more information, try") {
+            continue;
+        }
+        if in_usage {
+            if !usage.is_empty() {
+                usage.push('\n');
+            }
+            usage.push_str(line);
+        } else {
+            for word in line.split_whitespace() {
+                if !message.is_empty() {
+                    message.push(' ');
+                }
+                message.push_str(word);
+            }
+        }
+    }
+    let message = message
+        .strip_prefix("error: ")
+        .unwrap_or(&message)
+        .to_owned();
+    let usage = usage.trim();
+    UsageError {
+        message: format!("{prog}: error: {message}"),
+        usage: if usage.is_empty() {
+            top_level_usage(prog)
+        } else {
+            usage.to_owned()
+        },
+    }
+}
+
+fn program_name(args: &[OsString]) -> String {
+    args.first()
+        .map(PathBuf::from)
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "hwi".to_owned())
+}
+
+fn top_level_usage(prog: &str) -> String {
+    let mut command = HwiCli::command().bin_name(prog);
+    command.render_usage().to_string()
 }
 
 fn args_from_stdin<I, T>(args: I) -> io::Result<Vec<OsString>>
@@ -2751,22 +2888,12 @@ fn hwi_unavailable_action_message(
 }
 
 fn print_response(response: HwiResponse) -> ExitCode {
-    match response {
-        HwiResponse::Error(error) => {
-            println!(
-                "{}",
-                serde_json::to_string(&HwiResponse::Error(error)).expect("serialize HWI error")
-            );
-            ExitCode::from(1)
-        }
-        response => {
-            println!(
-                "{}",
-                serde_json::to_string(&response).expect("serialize HWI response")
-            );
-            ExitCode::SUCCESS
-        }
-    }
+    println!(
+        "{}",
+        serde_json::to_string(&response).expect("serialize HWI response")
+    );
+    // Runtime error JSON exits 0 to match Python HWI 3.2.0 (hwilib/_cli.py main).
+    ExitCode::SUCCESS
 }
 
 fn parse_device_type(value: &str) -> HwiResult<DeviceType> {
@@ -2918,10 +3045,10 @@ fn parse_chain(value: &str) -> HwiResult<Network> {
     match value {
         "main" | "mainnet" => Ok(Network::Bitcoin),
         "test" | "testnet" => Ok(Network::Testnet),
-        _ => Network::from_str(value).map_err(|err| {
+        _ => Network::from_str(value).map_err(|_| {
             HwiError::new(
-                HwiErrorCode::BadArgument,
-                format!("Unsupported chain {value}: {err}"),
+                HwiErrorCode::MissingArguments,
+                format!("argument --chain: invalid choice: '{value}'"),
             )
         }),
     }
@@ -3479,6 +3606,134 @@ mod tests {
             request.command,
             HwiCommand::Unsupported("unknowncommand".to_owned())
         );
+    }
+
+    fn outcome_of(args: &[&str]) -> CliOutcome {
+        cli_outcome(args.iter().map(OsString::from).collect())
+    }
+
+    fn usage_of(args: &[&str]) -> UsageError {
+        match outcome_of(args) {
+            CliOutcome::Usage(usage) => usage,
+            other => panic!("expected usage error for {args:?}, got {other:?}"),
+        }
+    }
+
+    fn runtime_error_of(args: &[&str]) -> HwiError {
+        match outcome_of(args) {
+            CliOutcome::Response(HwiResponse::Error(error)) => error,
+            other => panic!("expected runtime error for {args:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_command_is_a_usage_error() {
+        let args = ["hwi"];
+        let usage = usage_of(&args);
+
+        assert_eq!(
+            usage.message,
+            "hwi: error: the following arguments are required: command"
+        );
+        assert!(usage.usage.contains("Usage:"), "{}", usage.usage);
+        assert!(usage.usage.contains("hwi"), "{}", usage.usage);
+        assert_eq!(exit_status(&outcome_of(&args)), 2);
+    }
+
+    #[test]
+    fn unknown_subcommand_is_a_usage_error() {
+        let args = ["hwi", "boguscmd"];
+        let usage = usage_of(&args);
+
+        assert_eq!(
+            usage.message,
+            "hwi: error: argument command: invalid choice: 'boguscmd'"
+        );
+        assert_eq!(exit_status(&outcome_of(&args)), 2);
+    }
+
+    #[test]
+    fn missing_required_argument_is_a_usage_error() {
+        let usage = usage_of(&["hwi", "getxpub"]);
+
+        assert!(usage.message.contains("required"), "{}", usage.message);
+        assert!(usage.message.contains("<PATH>"), "{}", usage.message);
+        assert!(usage.usage.contains("getxpub"), "{}", usage.usage);
+    }
+
+    #[test]
+    fn invalid_flag_choice_is_a_usage_error() {
+        let usage = usage_of(&["hwi", "getmasterxpub", "--addr-type", "bogus"]);
+
+        assert!(
+            usage.message.contains("invalid value 'bogus'"),
+            "{}",
+            usage.message
+        );
+        assert!(usage.usage.contains("Usage:"), "{}", usage.usage);
+    }
+
+    #[test]
+    fn invalid_chain_choice_is_a_usage_error() {
+        let usage = usage_of(&["hwi", "--chain", "foo", "enumerate"]);
+
+        assert_eq!(
+            usage.message,
+            "hwi: error: argument --chain: invalid choice: 'foo'"
+        );
+    }
+
+    #[test]
+    fn usage_errors_serialize_python_hwi_json() {
+        let usage = usage_of(&["hwi", "boguscmd"]);
+        let json = serde_json::to_string(&HwiError {
+            error: usage.message,
+            code: HwiErrorCode::MissingArguments.code(),
+        })
+        .expect("serialize usage error");
+
+        assert_eq!(
+            json,
+            r#"{"error":"hwi: error: argument command: invalid choice: 'boguscmd'","code":-2}"#
+        );
+    }
+
+    #[test]
+    fn runtime_errors_keep_their_code_and_exit_zero() {
+        let bad_path = ["hwi", "getxpub", "not_a_path"];
+        assert_eq!(
+            runtime_error_of(&bad_path).code,
+            HwiErrorCode::BadArgument.code()
+        );
+        assert_eq!(exit_status(&outcome_of(&bad_path)), 0);
+
+        let bad_device = ["hwi", "--device-type", "trezor", "enumerate"];
+        assert_eq!(
+            runtime_error_of(&bad_device).code,
+            HwiErrorCode::UnknownDevice.code()
+        );
+        assert_eq!(exit_status(&outcome_of(&bad_device)), 0);
+    }
+
+    #[test]
+    fn help_and_version_print_to_stdout_and_exit_zero() {
+        for args in [["hwi", "--help"], ["hwi", "--version"]] {
+            let outcome = outcome_of(&args);
+            let CliOutcome::Stdout(text) = &outcome else {
+                panic!("expected stdout outcome for {args:?}, got {outcome:?}");
+            };
+            assert!(!text.is_empty());
+            assert_eq!(exit_status(&outcome), 0);
+        }
+    }
+
+    #[test]
+    fn successful_parse_yields_a_request_and_exits_zero() {
+        let args = ["hwi", "--device-type", "ledger", "enumerate"];
+        let outcome = outcome_of(&args);
+
+        assert!(matches!(outcome, CliOutcome::Request(_)));
+        assert_eq!(exit_status(&outcome), 0);
     }
 
     #[test]

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -20,6 +20,11 @@ features marked unsupported by the device firmware are shown as `n/a` here.
 For device-management commands that are not applicable to Ledger, Jade, and
 Coldcard, BHWI still tests Python HWI-compatible unsupported-action errors.
 
+The `hwi` binary also follows Python HWI's exit-status contract: runtime JSON
+errors exit `0`, and argparse-style usage errors exit `2` with
+`{"error": "...", "code": -2}` on stdout and usage text on stderr. See
+[HWI_PARITY.md](HWI_PARITY.md#exit-status-contract).
+
 ## Feature Parity
 
 |Command           |Ledger|Jade |Coldcard|Trezor|KeepKey|BitBox01|BitBox02|Notes                                                                 |

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -20,6 +20,32 @@ commands and devices where parity is claimed.
   emulator and runs the pinned upstream HWI suite as that job's final test
   gate.
 
+## Exit status contract
+
+The `hwi` binary matches pinned Python HWI 3.2.0 process status
+(`hwilib/_cli.py`, `HWIArgumentParser.error` and `main`).
+
+|Status|Cases                                                                      |
+|------|---------------------------------------------------------------------------|
+|`0`   |Success, `--help`, `--version`, every runtime `{"error", "code"}` JSON response (`-1`, `-3`, `-4`, `-5`, `-7`, `-9`, `-13`, `-14`, `-16`, `-18`), and per-device `enumerate` failures.|
+|`2`   |Usage errors: no arguments, unknown subcommand, missing required argument, invalid flag choice. These print `{"error": "...", "code": -2}` on stdout and usage text on stderr.|
+|`1`   |Reserved for internal crashes that produce no JSON on stdout.               |
+
+Runtime errors exiting `0` is deliberate: upstream prints the error JSON and
+returns normally, so a nonzero status would break callers that treat a failed
+device operation as a well-formed HWI response.
+
+The parity harness asserts process status on both sides, not just JSON. Exact
+usage-error message and usage text is not compared, because the reference
+reports the nix store script as its program name and lists argparse-specific
+choice sets. Only status, JSON shape, code `-2`, and non-empty stderr are
+compared for usage errors.
+
+Known divergence: values rejected by a type or value parser rather than by
+argument structure, such as `getkeypool notanum 5` or an invalid derivation
+path, stay on the runtime path and exit `0` with code `-7` where upstream exits
+`2` with code `-2`. That ordering difference is tracked separately.
+
 ## Final acceptance gate
 
 Parity is accepted only when the unmodified Bitcoin Core HWI 3.2.0 device

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -25,6 +25,13 @@ pub struct HwiOutput {
     pub json: Value,
 }
 
+#[derive(Clone, Debug)]
+pub struct RawHwiOutput {
+    pub status_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
 impl HwiBinary {
     pub fn from_env(label: &'static str, var: &str, default: Option<&str>) -> Result<Self> {
         let path = match env::var(var) {
@@ -49,7 +56,23 @@ impl HwiBinary {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        parse_output(self.label, self.run_raw(args, |_| {})?)
+        parse_output(self.label, self.run_command(args, |_| {})?)
+    }
+
+    /// Like [`HwiBinary::run`] but tolerates non-JSON stdout, as `--help` produces.
+    pub fn run_raw<I, S>(&self, args: I) -> Result<RawHwiOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = self.run_command(args, |_| {})?;
+        Ok(RawHwiOutput {
+            status_code: output.status.code(),
+            stdout: String::from_utf8(output.stdout)
+                .with_context(|| format!("{} hwi wrote non-utf8 stdout", self.label))?,
+            stderr: String::from_utf8(output.stderr)
+                .with_context(|| format!("{} hwi wrote non-utf8 stderr", self.label))?,
+        })
     }
 
     pub fn run_with_envs<I, S>(&self, args: I, envs: &[(&str, &str)]) -> Result<HwiOutput>
@@ -57,7 +80,7 @@ impl HwiBinary {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let output = self.run_raw(args, |command| {
+        let output = self.run_command(args, |command| {
             command.envs(envs.iter().copied());
         })?;
         parse_output(self.label, output)
@@ -68,7 +91,7 @@ impl HwiBinary {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let output = self.run_raw(args, |command| {
+        let output = self.run_command(args, |command| {
             command.current_dir(cwd);
         })?;
         parse_output(self.label, output)
@@ -104,7 +127,7 @@ impl HwiBinary {
         )
     }
 
-    fn run_raw<I, S>(&self, args: I, configure: impl FnOnce(&mut Command)) -> Result<Output>
+    fn run_command<I, S>(&self, args: I, configure: impl FnOnce(&mut Command)) -> Result<Output>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
@@ -324,6 +347,58 @@ mod tests {
         let output = HwiBinary::reference()?.run(["enumerate"])?;
         assert_success("reference", &output)?;
         assert_enumerate_array("reference", &output.json)?;
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_usage_errors_match_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        let cases: [&[&str]; 7] = [
+            &[],
+            &["boguscmd"],
+            &["getxpub"],
+            &["--chain", "foo", "enumerate"],
+            &["displayaddress"],
+            &["getmasterxpub", "--addr-type", "bogus"],
+            &["--bogus", "enumerate"],
+        ];
+
+        for case in cases {
+            let args = case.iter().map(|arg| (*arg).to_owned()).collect::<Vec<_>>();
+            assert_usage_error_parity(args)
+                .with_context(|| format!("usage error parity failed for args: {case:?}"))?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_help_and_version_status_matches_reference() -> Result<()> {
+        if env::var("HWI_BIN").is_err() {
+            return Ok(());
+        }
+
+        for flag in ["--help", "--version"] {
+            for binary in [HwiBinary::reference()?, HwiBinary::candidate()?] {
+                let output = binary.run_raw([flag])?;
+                if output.status_code != Some(0) {
+                    bail!(
+                        "{} hwi {flag} exited {:?}\nstdout:\n{}\nstderr:\n{}",
+                        binary.label,
+                        output.status_code,
+                        output.stdout,
+                        output.stderr
+                    );
+                }
+                if output.stdout.trim().is_empty() {
+                    bail!("{} hwi {flag} wrote no stdout", binary.label);
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -872,13 +947,66 @@ mod tests {
         Ok(())
     }
 
+    /// Usage-error text is not compared across sides: the reference reports the nix
+    /// store script as its program name and lists argparse-specific choices.
+    fn assert_usage_error_parity(args: Vec<String>) -> Result<()> {
+        for binary in [HwiBinary::reference()?, HwiBinary::candidate()?] {
+            let output = binary.run_raw(args.clone())?;
+            if output.status_code != Some(2) {
+                bail!(
+                    "{} hwi did not exit 2 for a usage error\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    binary.label,
+                    output.status_code,
+                    output.stdout,
+                    output.stderr
+                );
+            }
+
+            let json: Value = serde_json::from_str(output.stdout.trim()).with_context(|| {
+                format!(
+                    "{} hwi usage error stdout was not JSON\nstdout:\n{}\nstderr:\n{}",
+                    binary.label, output.stdout, output.stderr
+                )
+            })?;
+            assert_error_shape(binary.label, &json)?;
+            if json.get("code").and_then(Value::as_i64) != Some(-2) {
+                bail!(
+                    "{} hwi usage error code was not -2:\n{}",
+                    binary.label,
+                    serde_json::to_string_pretty(&json)?
+                );
+            }
+            if json
+                .get("error")
+                .and_then(Value::as_str)
+                .is_none_or(str::is_empty)
+            {
+                bail!(
+                    "{} hwi usage error message was empty:\n{}",
+                    binary.label,
+                    serde_json::to_string_pretty(&json)?
+                );
+            }
+
+            if !output.stderr.to_lowercase().contains("usage:") {
+                bail!(
+                    "{} hwi usage error stderr had no usage text\nstderr:\n{}",
+                    binary.label,
+                    output.stderr
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     fn assert_error_json_parity(args: Vec<String>) -> Result<()> {
         let reference = HwiBinary::reference()?.run(args.clone())?;
         let candidate = HwiBinary::candidate()?.run(args)?;
 
-        // Python HWI 3.2.0 sometimes exits 0 for JSON error responses; keep
-        // command parity focused on the HWI JSON contract until the dedicated
-        // error-model work standardizes process status.
+        assert_success("reference", &reference)?;
+        assert_success("candidate", &candidate)?;
+
         assert_error_shape("reference", &reference.json)?;
         assert_error_shape("candidate", &candidate.json)?;
 
@@ -950,7 +1078,10 @@ mod tests {
                 assert_success(label, output)?;
                 assert_displayaddress_shape(label, &output.json)
             }
-            ExpectedResult::Error => assert_error_shape(label, &output.json),
+            ExpectedResult::Error => {
+                assert_success(label, output)?;
+                assert_error_shape(label, &output.json)
+            }
         }
     }
 


### PR DESCRIPTION
> **Blocked on #88** — `coldcard-e2e` fails here for a pre-existing reason; it also fails on unmodified `main`.

Closes #72.

Exit-status contract for the `hwi` shim, matching pinned Python HWI 3.2.0:

| Status | Cases |
|---|---|
| 0 | success, `--help`, `--version`, every runtime `{"error","code"}` JSON, per-device `enumerate` failures |
| 2 | usage errors: no args, unknown subcommand, missing required argument, invalid flag choice — code `-2` JSON on stdout, usage text on stderr |
| 1 | internal crash, no JSON on stdout |

Measured against the pinned reference before this change: runtime errors exited 1 instead of 0; usage errors exited 1 with code `-7`/`-9` and clap's multi-line text inside the JSON.

Changes:

- `bhwi-cli/src/hwi.rs` — parse half of `run_cli` extracted into `cli_outcome` + `exit_status`; `print_response` always returns success; unknown subcommand and invalid `--chain` join the usage class; 9 unit tests
- `e2e/hwi-parity/src/lib.rs` — asserts process status (ignore comment deleted), new usage-error and `--help`/`--version` parity cases, raw runner for non-JSON stdout. Usage-error text is not compared: the reference reports its nix store script as the program name
- `docs/HWI_PARITY.md` status table, pointers from `docs/HWI.md` and `.agents/runbooks/hwi-parity.md`

Behavior changes:

- runtime error JSON: exit 1 → 0
- unknown subcommand: `{"error":"Unsupported HWI command: X","code":-9}` exit 1 → `{"error":"hwi: error: argument command: invalid choice: 'X'","code":-2}` exit 2
- invalid `--chain`: code `-7` → `-2`
- `HwiErrorCode` gains `MissingArguments`

Nothing in-repo reads the old statuses: the upstream final gate parses stdout and never reads `returncode`; no CI step, nix script, or e2e test inspects it.

Out of scope, filed separately: #83, #84, #85, #86. The type-validation divergence noted on #84 is recorded in `docs/HWI_PARITY.md`.

Checks: `fmt`, `clippy -D warnings`, `cargo test -p bhwi-e2e-hwi-parity` (also with `REFERENCE_HWI_BIN`/`HWI_BIN` set so the new cases run against the reference), `cargo test --all --exclude "bhwi-e2e-*"`, `--no-default-features`. Emulator: bitbox, ledger, jade green.
