### PR TITLE
docs: rewrite the pr description format

### DIFF
--- a/.agents/templates/pr-description.md
+++ b/.agents/templates/pr-description.md
@@ -1,29 +1,50 @@
-# PR Description Template
+# PR Description Format
 
-## Summary
+Write for a reviewer about to read the diff. Facts only.
 
-- 
+## Rules
 
-## Behavior
+- No prose narration. No restating the issue, no describing how the work went,
+  no listing approaches that were tried and discarded. That belongs in PR
+  comments if anywhere.
+- Lead with a blocker when one exists: a one-line blockquote naming the blocking
+  PR and why it blocks.
+- Link the issue with `Closes #<n>` when the PR closes one.
+- List changes as bullets: the file or module, then what it now does. Group by
+  surface when a PR touches several.
+- State behavior changes explicitly and separately: public API, CLI output,
+  exit statuses, JSON shapes, dependencies. A reviewer must not have to infer
+  them from the diff.
+- Use a table when the content is a contract, a support matrix, or a
+  before/after measurement. Do not use a table for a list of changes.
+- Limit prose to at most one sentence, and only for a root cause that the
+  bullets cannot carry.
+- End with one line naming the checks that ran and their results, including
+  emulator jobs. List what ran, not an unchecked checklist.
+- Keep the whole body scannable in one screen where the change allows it.
 
-- Public API:
-- CLI:
-- Device protocol:
-- HWI parity:
-- Security/logging:
+## Shape
 
-## Tests
+```markdown
+> **Blocked on #<n>** — one line on why.        (only when blocked)
 
-- [ ] `cargo fmt --all --check`
-- [ ] `cargo clippy --all --all-features --all-targets -- -A dead_code -D warnings`
-- [ ] `cargo test --verbose --no-default-features`
-- [ ] `cargo test --verbose --color always -- --nocapture`
-- [ ] `cargo test --all --exclude "bhwi-e2e-*" --verbose --color always -- --nocapture`
-- [ ] Device e2e:
-- [ ] CLI e2e:
-- [ ] HWI parity:
+Closes #<n>.
 
-## Docs
+<one line naming what the PR does, only if the bullets need framing>
 
-- Updated:
-- Not needed because:
+- `path/to/file.rs` — what it now does
+- `path/to/other.rs` — what it now does
+
+Behavior changes:
+
+- <public API / CLI / exit status / JSON / dependency change>
+
+Checks: `fmt`, `clippy -D warnings`, <test commands>, emulator: <devices>.
+```
+
+## Notes
+
+- Out-of-scope findings belong in follow-up issues, referenced by number.
+- Do not add attribution trailers.
+- Emulator-backed results are facts a reviewer needs: name the device jobs that
+  ran and whether they passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,12 @@
 - Do not mix formatting-only churn into feature commits. Use a separate `style:` commit if needed.
 - Keep commit messages brief and direct. Avoid ticket references unless asked.
 
+## Pull Requests
+
+- Follow [`.agents/templates/pr-description.md`](.agents/templates/pr-description.md). Read it before opening a PR.
+- Descriptions are facts for a reviewer: what changed, what behavior changed, what was run. No prose narration of the work.
+- Call out blockers, public API changes, CLI output changes, and new dependencies explicitly.
+
 ## Definition Of Done
 
 - The requested behavior or documentation change is complete and scoped to the task.


### PR DESCRIPTION
- `.agents/templates/pr-description.md` — replaced the Summary/Behavior/Tests-checkbox/Docs skeleton with `Rules`, a copyable `Shape`, and `Notes`; requires facts over prose narration, a blocker blockquote when one applies, `Closes #<n>`, file-to-behavior bullets, an explicit behavior-changes section, tables only for contracts and before/after measurements, and one line naming the checks that actually ran
- `AGENTS.md` — new `Pull Requests` section pointing at the template

Behavior changes: none. Docs only.

Checks: none run; no code changed.