### PR TITLE
fix(bhwi-cli): exit 1 when the hwi shim panics

### DIFF
--- a/bhwi-cli/src/bin/hwi.rs
+++ b/bhwi-cli/src/bin/hwi.rs
@@ -2,5 +2,18 @@ use std::process::ExitCode;
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    // Python HWI crashes exit 1 with a traceback on stderr. Chain the default
+    // hook so the panic message still reaches stderr, then force status 1
+    // (instead of Rust's 101) from whichever thread panicked.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+        std::process::exit(1);
+    }));
+    // Undocumented crash trigger so the exit-status contract test can provoke
+    // a real panic in the built binary.
+    if std::env::var_os("HWI_DEBUG_PANIC").is_some() {
+        panic!("HWI_DEBUG_PANIC requested a crash");
+    }
     bhwi_cli::hwi::run_cli(std::env::args()).await
 }

--- a/bhwi-cli/tests/hwi_panic.rs
+++ b/bhwi-cli/tests/hwi_panic.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+
+/// A panic must honor the HWI exit-status contract: status 1, no JSON on
+/// stdout, traceback-ish output on stderr (docs/HWI_PARITY.md).
+#[test]
+fn panic_exits_one_with_empty_stdout_and_stderr_traceback() {
+    let output = Command::new(env!("CARGO_BIN_EXE_hwi"))
+        .env("HWI_DEBUG_PANIC", "1")
+        .arg("enumerate")
+        .output()
+        .expect("run hwi binary");
+
+    assert_eq!(output.status.code(), Some(1), "panic must exit 1");
+    assert!(
+        output.stdout.is_empty(),
+        "panic must not write stdout, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !output.stderr.is_empty(),
+        "panic must report the crash on stderr"
+    );
+}

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -36,7 +36,7 @@ The `hwi` binary matches pinned Python HWI 3.2.0 process status
 |------|---------------------------------------------------------------------------|
 |`0`   |Success, `--help`, `--version`, every runtime `{"error", "code"}` JSON response (`-1`, `-3`, `-4`, `-5`, `-7`, `-9`, `-13`, `-14`, `-16`, `-18`), and per-device `enumerate` failures.|
 |`2`   |Usage errors: no arguments, unknown subcommand, missing required argument, invalid flag choice. These print `{"error": "...", "code": -2}` on stdout and usage text on stderr.|
-|`1`   |Reserved for internal crashes that produce no JSON on stdout.               |
+|`1`   |Internal crashes that produce no JSON on stdout. A panic hook in the `hwi` binary chains the default panic output to stderr and forces status 1 from any thread, matching upstream's exit-1-with-traceback behavior.|
 
 Runtime errors exiting `0` is deliberate: upstream prints the error JSON and
 returns normally, so a nonzero status would break callers that treat a failed


### PR DESCRIPTION
Closes #86.

- `bhwi-cli/src/bin/hwi.rs` — chains the default panic hook, then forces `std::process::exit(1)` from any thread (including tokio workers); adds an undocumented `HWI_DEBUG_PANIC` env trigger for the test
- `bhwi-cli/tests/hwi_panic.rs` — integration test spawns the built binary with `HWI_DEBUG_PANIC=1` and asserts status 1, empty stdout, non-empty stderr
- `docs/HWI_PARITY.md` — status-1 row now covers panics

Behavior changes:

- `hwi` exit status on panic: 101 → 1; panic output stays on stderr, stdout stays empty

Candidate-only test: the reference cannot be made to panic on demand.

Checks: `cargo fmt --all --check`, `clippy --all --all-features --all-targets -D warnings`, `cargo test --no-default-features`, `cargo test --all --exclude "bhwi-e2e-*"` — all passed locally; parity suite ran with reference + candidate (no emulator needed for this PR).