### PR TITLE
feat(bhwi-cli): match Python HWI's --help JSON response shape

### DIFF
--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -284,6 +284,7 @@ pub enum HwiErrorCode {
     DeviceConnectionError,
     NeedToBeRoot,
     DeviceNotInitialized,
+    HelpText,
 }
 
 impl HwiErrorCode {
@@ -298,6 +299,7 @@ impl HwiErrorCode {
             HwiErrorCode::DeviceConnectionError => -3,
             HwiErrorCode::NeedToBeRoot => -16,
             HwiErrorCode::DeviceNotInitialized => -18,
+            HwiErrorCode::HelpText => -17,
         }
     }
 }
@@ -504,6 +506,20 @@ where
             print!("{text}");
             status
         }
+        CliOutcome::Help(help) => {
+            // Python HWI 3.2.0 prints a `-17` JSON object on stdout and the
+            // help text on stderr (hwilib/_cli.py HWIHelpAction).
+            println!(
+                "{}",
+                serde_json::to_string(&HwiError::new(
+                    HwiErrorCode::HelpText,
+                    "Help text requested",
+                ))
+                .expect("serialize HWI help error")
+            );
+            eprint!("{help}");
+            status
+        }
         CliOutcome::Usage(usage) => {
             println!(
                 "{}",
@@ -531,6 +547,7 @@ struct UsageError {
 #[derive(Debug)]
 enum CliOutcome {
     Stdout(String),
+    Help(String),
     Usage(UsageError),
     Response(HwiResponse),
     Request(Box<HwiRequest>),
@@ -574,7 +591,10 @@ fn cli_outcome(args: Vec<OsString>) -> CliOutcome {
 
 fn clap_outcome(prog: &str, err: clap::Error) -> CliOutcome {
     match err.kind() {
-        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => CliOutcome::Stdout(err.to_string()),
+        // Upstream shares one HWIArgumentParser across subparsers, so every
+        // `--help` takes the `-17` JSON path; `--version` stays plain stdout.
+        ErrorKind::DisplayHelp => CliOutcome::Help(err.to_string()),
+        ErrorKind::DisplayVersion => CliOutcome::Stdout(err.to_string()),
         ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::MissingSubcommand => {
             CliOutcome::Usage(UsageError {
                 message: format!("{prog}: error: the following arguments are required: command"),
@@ -3716,15 +3736,36 @@ mod tests {
     }
 
     #[test]
-    fn help_and_version_print_to_stdout_and_exit_zero() {
-        for args in [["hwi", "--help"], ["hwi", "--version"]] {
-            let outcome = outcome_of(&args);
-            let CliOutcome::Stdout(text) = &outcome else {
-                panic!("expected stdout outcome for {args:?}, got {outcome:?}");
+    fn version_prints_to_stdout_and_exits_zero() {
+        let args = ["hwi", "--version"];
+        let outcome = outcome_of(&args);
+        let CliOutcome::Stdout(text) = &outcome else {
+            panic!("expected stdout outcome for {args:?}, got {outcome:?}");
+        };
+        assert!(!text.is_empty());
+        assert_eq!(exit_status(&outcome), 0);
+    }
+
+    #[test]
+    fn help_yields_json_error_and_help_text_for_top_level_and_subcommand() {
+        for args in [
+            ["hwi", "--help"].as_slice(),
+            ["hwi", "getxpub", "--help"].as_slice(),
+        ] {
+            let outcome = outcome_of(args);
+            let CliOutcome::Help(help) = &outcome else {
+                panic!("expected help outcome for {args:?}, got {outcome:?}");
             };
-            assert!(!text.is_empty());
+            assert!(!help.is_empty());
             assert_eq!(exit_status(&outcome), 0);
         }
+
+        let json = serde_json::to_string(&HwiError::new(
+            HwiErrorCode::HelpText,
+            "Help text requested",
+        ))
+        .expect("serialize help error");
+        assert_eq!(json, r#"{"error":"Help text requested","code":-17}"#);
     }
 
     #[test]

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -34,7 +34,7 @@ The `hwi` binary matches pinned Python HWI 3.2.0 process status
 
 |Status|Cases                                                                      |
 |------|---------------------------------------------------------------------------|
-|`0`   |Success, `--help`, `--version`, every runtime `{"error", "code"}` JSON response (`-1`, `-3`, `-4`, `-5`, `-7`, `-9`, `-13`, `-14`, `-16`, `-18`), and per-device `enumerate` failures.|
+|`0`   |Success, `--help` (which prints `{"error": "Help text requested", "code": -17}` on stdout and the help text on stderr), `--version`, every runtime `{"error", "code"}` JSON response (`-1`, `-3`, `-4`, `-5`, `-7`, `-9`, `-13`, `-14`, `-16`, `-17`, `-18`), and per-device `enumerate` failures.|
 |`2`   |Usage errors: no arguments, unknown subcommand, missing required argument, invalid flag choice. These print `{"error": "...", "code": -2}` on stdout and usage text on stderr.|
 |`1`   |Reserved for internal crashes that produce no JSON on stdout.               |
 

--- a/e2e/hwi-parity/src/lib.rs
+++ b/e2e/hwi-parity/src/lib.rs
@@ -383,20 +383,54 @@ mod tests {
             return Ok(());
         }
 
-        for flag in ["--help", "--version"] {
+        // `--version` prints plain text on stdout and exits 0 on both sides.
+        for binary in [HwiBinary::reference()?, HwiBinary::candidate()?] {
+            let output = binary.run_raw(["--version"])?;
+            if output.status_code != Some(0) {
+                bail!(
+                    "{} hwi --version exited {:?}\nstdout:\n{}\nstderr:\n{}",
+                    binary.label,
+                    output.status_code,
+                    output.stdout,
+                    output.stderr
+                );
+            }
+            if output.stdout.trim().is_empty() {
+                bail!("{} hwi --version wrote no stdout", binary.label);
+            }
+        }
+
+        // `--help` prints the `-17` JSON object on stdout and the help text on
+        // stderr, exiting 0 (hwilib/_cli.py HWIHelpAction). The help body is
+        // not compared: prog name and argparse/clap formatting differ.
+        let expected = serde_json::json!({"error": "Help text requested", "code": -17});
+        for args in [["--help"].as_slice(), ["getxpub", "--help"].as_slice()] {
             for binary in [HwiBinary::reference()?, HwiBinary::candidate()?] {
-                let output = binary.run_raw([flag])?;
+                let output = binary.run_raw(args.iter().copied())?;
                 if output.status_code != Some(0) {
                     bail!(
-                        "{} hwi {flag} exited {:?}\nstdout:\n{}\nstderr:\n{}",
+                        "{} hwi {args:?} exited {:?}\nstdout:\n{}\nstderr:\n{}",
                         binary.label,
                         output.status_code,
                         output.stdout,
                         output.stderr
                     );
                 }
-                if output.stdout.trim().is_empty() {
-                    bail!("{} hwi {flag} wrote no stdout", binary.label);
+                let json: Value =
+                    serde_json::from_str(output.stdout.trim()).with_context(|| {
+                        format!(
+                            "{} hwi {args:?} stdout was not JSON\nstdout:\n{}",
+                            binary.label, output.stdout
+                        )
+                    })?;
+                if json != expected {
+                    bail!(
+                        "{} hwi {args:?} help JSON mismatch\nexpected: {expected}\ngot: {json}",
+                        binary.label
+                    );
+                }
+                if output.stderr.trim().is_empty() {
+                    bail!("{} hwi {args:?} wrote no help text on stderr", binary.label);
                 }
             }
         }


### PR DESCRIPTION
Closes #83.

- `bhwi-cli/src/hwi.rs` — `--help` (top-level and subcommand) now prints `{"error": "Help text requested", "code": -17}` on stdout and the clap help text on stderr, exiting 0; adds `HwiErrorCode::HelpText` (-17); `--version` keeps plain stdout; unit tests cover the top-level and a subcommand help outcome
- `e2e/hwi-parity/src/lib.rs` — `candidate_help_and_version_status_matches_reference` now asserts on both binaries: exit 0, stdout parses as JSON equal to the `-17` object, non-empty stderr; help body text is not compared (prog name and argparse/clap formatting differ)
- `docs/HWI_PARITY.md` — status table row updated with the `-17` shape

Behavior changes:

- `hwi --help` stdout: plain help text → `-17` error JSON; help text moves to stderr; exit status unchanged (0)

Checks: `cargo fmt --all --check`, `clippy --all --all-features --all-targets -D warnings`, `cargo test --no-default-features`, `cargo test --all --exclude "bhwi-e2e-*"`, and the parity help/usage tests with reference + candidate binaries — all passed locally (no emulator needed for this PR).