### PR TITLE
feat: report Trezor passphrase protection and empty-passphrase warnings

### DIFF
--- a/bhwi-cli/src/hwi.rs
+++ b/bhwi-cli/src/hwi.rs
@@ -343,6 +343,8 @@ pub struct HwiEnumeratedDevice {
     pub fingerprint: Option<Fingerprint>,
     pub needs_pin_sent: bool,
     pub needs_passphrase_sent: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -715,6 +717,8 @@ where
     Ok(args)
 }
 
+const EMPTY_PASSPHRASE_WARNING: &str = "Passphrase protection enabled but passphrase was not provided. Using default passphrase of the empty string (\"\")";
+
 async fn enumerate(selector: DeviceSelector) -> HwiResponse {
     let manager = DeviceManager::new(DeviceSelector {
         device_type: None,
@@ -734,6 +738,8 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
         let mut info = None;
         let mut fingerprint = None;
         let mut needs_pin_sent = false;
+        let mut needs_passphrase_sent = false;
+        let mut warnings = Vec::new();
         match device.device().unlock(manager.selector.network).await {
             Ok(()) => {
                 // A device waiting for a PIN stops answering every other request, and the
@@ -751,12 +757,23 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
                     .as_ref()
                     .and_then(|info| info.needs_pin_sent)
                     .unwrap_or(false);
+                needs_passphrase_sent = info
+                    .as_ref()
+                    .and_then(|info| info.needs_passphrase_sent)
+                    .unwrap_or(false);
                 if needs_pin_sent {
                     error = Some(bhwi::trezor::TrezorError::LOCKED.to_owned());
                     code = Some(HwiErrorCode::DeviceNotReady.code());
                 } else if error.is_none() {
+                    if needs_passphrase_sent && manager.selector.passphrase.is_none() {
+                        warnings.push(vec![EMPTY_PASSPHRASE_WARNING.to_owned()]);
+                    }
                     match device.fingerprint().await {
-                        Ok(device_fingerprint) => fingerprint = Some(device_fingerprint),
+                        Ok(device_fingerprint) => {
+                            fingerprint = Some(device_fingerprint);
+                            // Deriving it required the passphrase, so it has been sent.
+                            needs_passphrase_sent = false;
+                        }
                         Err(err) => {
                             error = Some(err.to_string());
                             code = Some(HwiErrorCode::DeviceConnectionError.code());
@@ -783,7 +800,8 @@ async fn enumerate(selector: DeviceSelector) -> HwiResponse {
             label: label_for(device.device_type(), label),
             fingerprint,
             needs_pin_sent,
-            needs_passphrase_sent: false,
+            needs_passphrase_sent,
+            warnings,
             error,
             code,
         });
@@ -4071,6 +4089,7 @@ mod tests {
                 fingerprint: None,
                 needs_pin_sent: false,
                 needs_passphrase_sent: false,
+                warnings: Vec::new(),
                 error: None,
                 code: None,
             })
@@ -4086,6 +4105,7 @@ mod tests {
                 fingerprint: None,
                 needs_pin_sent: false,
                 needs_passphrase_sent: false,
+                warnings: Vec::new(),
                 error: None,
                 code: None,
             })
@@ -4104,6 +4124,7 @@ mod tests {
             fingerprint: None,
             needs_pin_sent: false,
             needs_passphrase_sent: false,
+            warnings: Vec::new(),
             error: Some("connection failed".to_owned()),
             code: Some(HwiErrorCode::DeviceConnectionError.code()),
         })
@@ -4123,6 +4144,7 @@ mod tests {
             fingerprint: None,
             needs_pin_sent: false,
             needs_passphrase_sent: false,
+            warnings: Vec::new(),
             error: None,
             code: None,
         })

--- a/bhwi-cli/src/lib.rs
+++ b/bhwi-cli/src/lib.rs
@@ -55,6 +55,8 @@ pub struct Info {
     pub on_device_passphrase_entry: Option<bool>,
     #[serde(skip)]
     pub needs_pin_sent: Option<bool>,
+    #[serde(skip)]
+    pub needs_passphrase_sent: Option<bool>,
 }
 
 impl Info {
@@ -77,6 +79,7 @@ impl From<bhwi_async::Info> for Info {
             label: info.label,
             on_device_passphrase_entry: info.on_device_passphrase_entry,
             needs_pin_sent: info.needs_pin_sent,
+            needs_passphrase_sent: info.needs_passphrase_sent,
         }
     }
 }

--- a/bhwi/src/common.rs
+++ b/bhwi/src/common.rs
@@ -184,6 +184,8 @@ pub struct Info {
     pub on_device_passphrase_entry: Option<bool>,
     /// Whether the device is waiting for a PIN from the host, when it reports a lock state.
     pub needs_pin_sent: Option<bool>,
+    /// Whether the device expects the BIP39 passphrase from the host rather than its own screen.
+    pub needs_passphrase_sent: Option<bool>,
 }
 
 pub enum Recipient {

--- a/bhwi/src/common/adapters/bitbox.rs
+++ b/bhwi/src/common/adapters/bitbox.rs
@@ -181,6 +181,7 @@ impl From<BitBoxResponse> for Response {
                 label: None,
                 on_device_passphrase_entry: None,
                 needs_pin_sent: None,
+                needs_passphrase_sent: None,
             }),
             BitBoxResponse::MasterFingerprint(fingerprint) => Self::MasterFingerprint(fingerprint),
             BitBoxResponse::Xpub(xpub) => Self::Xpub(xpub),

--- a/bhwi/src/common/adapters/coldcard.rs
+++ b/bhwi/src/common/adapters/coldcard.rs
@@ -286,6 +286,7 @@ impl From<ColdcardResponse> for Response {
                 label: None,
                 on_device_passphrase_entry: None,
                 needs_pin_sent: None,
+                needs_passphrase_sent: None,
             }),
             ColdcardResponse::MyPub { encryption_key, .. } => Self::EncryptionKey(encryption_key),
             ColdcardResponse::Signature(header, signature) => Self::Signature(header, signature),

--- a/bhwi/src/common/adapters/jade.rs
+++ b/bhwi/src/common/adapters/jade.rs
@@ -168,6 +168,7 @@ impl From<JadeResponse> for Response {
                 label: None,
                 on_device_passphrase_entry: None,
                 needs_pin_sent: None,
+                needs_passphrase_sent: None,
             }),
             JadeResponse::Address(address) => Self::Address(address),
             JadeResponse::RegisteredDescriptor => {

--- a/bhwi/src/common/adapters/ledger.rs
+++ b/bhwi/src/common/adapters/ledger.rs
@@ -111,6 +111,7 @@ impl From<LedgerResponse> for Response {
                     label: None,
                     on_device_passphrase_entry: None,
                     needs_pin_sent: None,
+                    needs_passphrase_sent: None,
                 })
             }
             LedgerResponse::Signature(header, signature) => Self::Signature(header, signature),

--- a/bhwi/src/common/adapters/trezor.rs
+++ b/bhwi/src/common/adapters/trezor.rs
@@ -158,6 +158,9 @@ impl From<TrezorError> for Error {
 }
 
 fn device_info(info: TrezorDeviceInfo) -> Info {
+    // Only the Model One takes the passphrase from the host; later models use
+    // their own screen. A device that reports no model is a Model One.
+    let is_model_one = info.model.as_deref().unwrap_or("1") == "1";
     Info {
         version: info.version,
         networks: vec![info.network],
@@ -166,6 +169,7 @@ fn device_info(info: TrezorDeviceInfo) -> Info {
         label: info.label,
         on_device_passphrase_entry: Some(info.on_device_passphrase_entry),
         needs_pin_sent: Some(info.needs_pin_sent),
+        needs_passphrase_sent: Some(is_model_one && info.passphrase_protection),
     }
 }
 

--- a/bhwi/src/trezor/interpreter.rs
+++ b/bhwi/src/trezor/interpreter.rs
@@ -83,6 +83,7 @@ pub struct TrezorDeviceInfo {
     pub label: Option<String>,
     pub on_device_passphrase_entry: bool,
     pub needs_pin_sent: bool,
+    pub passphrase_protection: bool,
 }
 
 enum PublicKeyKind {
@@ -705,6 +706,7 @@ fn features_info(features: mgmt::Features, network: Network) -> TrezorDeviceInfo
         on_device_passphrase_entry: on_device,
         needs_pin_sent: features.pin_protection.unwrap_or(false)
             && !features.unlocked.unwrap_or(false),
+        passphrase_protection: features.passphrase_protection.unwrap_or(false),
     }
 }
 

--- a/docs/HWI.md
+++ b/docs/HWI.md
@@ -43,7 +43,7 @@ errors exit `0`, and argparse-style usage errors exit `2` with
 |`backup`          |`n/a` |`n/a`|`[x]`   |`n/a` |`n/a`  |`[ ]`   |`[x]`   |Coldcard file backup and BitBox02 mnemonic-export backup are covered. BitBox01 remains open.|
 |`promptpin`       |`n/a` |`n/a`|`n/a`   |`[x]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN prompting for Trezor-class devices.      |
 |`sendpin`         |`n/a` |`n/a`|`n/a`   |`[x]` |`[ ]`  |`n/a`   |`n/a`   |Python HWI supports host PIN entry for Trezor-class devices.          |
-|`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[~]` |`[ ]`  |`n/a`   |`[x]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
+|`togglepassphrase`|`n/a` |`n/a`|`n/a`   |`[x]` |`[ ]`  |`n/a`   |`[x]`   |Python HWI supports this for Trezor, KeepKey, and BitBox02.           |
 |`installudevrules`|`n/a` |`n/a`|`n/a`   |`n/a` |`n/a`  |`n/a`   |`n/a`   |Host-side Python HWI command covered by the shared udev installer. Registered on Linux only.|
 
 ## Running Parity Tests

--- a/docs/HWI_PARITY.md
+++ b/docs/HWI_PARITY.md
@@ -181,7 +181,3 @@ only, because the Model T takes its PIN and passphrase on its own screen.
 covered by `bhwi-e2e-trezor` and `bhwi-e2e-cli` instead. It is supported on the
 Model T, which takes the recovery phrase on its own screen; the Trezor One
 requires host word entry and is unsupported.
-
-`togglepassphrase` runs but is not at parity. Python HWI's enumerate emits a
-`warnings` field for a Trezor One with passphrase protection enabled and no
-passphrase supplied; BHWI emits no `warnings` key for any device.

--- a/nix/scripts/init-trezor.sh
+++ b/nix/scripts/init-trezor.sh
@@ -8,6 +8,7 @@ device="${TREZOR_DEVICE:-udp:127.0.0.1:21324}"
 mnemonic="${TREZOR_MNEMONIC:-all all all all all all all all all all all all}"
 label="${TREZOR_LABEL:-bhwi}"
 pin="${TREZOR_PIN:-}"
+passphrase_protection="${TREZOR_PASSPHRASE_PROTECTION:-0}"
 
 python3 - <<PY
 from trezorlib import debuglink, device
@@ -21,7 +22,7 @@ debuglink.load_device(
     client,
     mnemonic="${mnemonic}",
     pin="${pin}" or None,
-    passphrase_protection=False,
+    passphrase_protection="${passphrase_protection}" == "1",
     label="${label}",
 )
 client.close()

--- a/nix/scripts/run-hwi-upstream-suite.sh
+++ b/nix/scripts/run-hwi-upstream-suite.sh
@@ -191,7 +191,7 @@ case " \$* " in
   *" wipe "* | *" signtx "* | *" signmessage "* | *" displayaddress "* | *" togglepassphrase "* | *" setup "* | *" restore "*) press=1 ;;
 esac
 case " \$* " in
-  *" sendpin "*) case " \$* " in *" -p "*) press=1 ;; esac ;;
+  *" sendpin "* | *" enumerate "*) case " \$* " in *" -p "*) press=1 ;; esac ;;
 esac
 case "\$press" in
   1)


### PR DESCRIPTION
Brings `hwi enumerate` to parity with Python HWI for a passphrase-protected Trezor One. BHWI previously hardcoded `needs_passphrase_sent: false` for every device and emitted no `warnings` key at all.

- `bhwi` — the Trezor interpreter reads `Features.passphrase_protection`; `Info` carries a new `needs_passphrase_sent`, set by the Trezor adapter and `None` for the other four devices. Only the Model One takes the passphrase from the host, so the adapter gates on model.
- `bhwi-cli` — `enumerate` reports the real `needs_passphrase_sent` and emits the empty-passphrase warning. Ordering matches upstream: a locked device reports `LOCKED` and nothing else, and the flag clears once a fingerprint is derived, since that required the passphrase.
- `nix/scripts` — `TREZOR_PASSPHRASE_PROTECTION=1` seeds a passphrase-protected device, and the upstream-suite harness now answers the ButtonRequest that `enumerate -p` raises.
- `docs` — `togglepassphrase` moves to `[x]`; the stale "BHWI emits no `warnings` key" gap is removed.

Behavior changes:

- Public API: `bhwi::common::Info` gains `needs_passphrase_sent: Option<bool>`. Breaking for struct-literal construction.
- JSON: `hwi enumerate` gains `warnings`, omitted when empty. Nested `Vec<Vec<String>>` matches Python HWI's shape.
- JSON: `needs_passphrase_sent` now reflects the device instead of always being `false`.
- New env var `TREZOR_PASSPHRASE_PROTECTION`, default `0`, so existing runs are unchanged.
- No new dependencies.

Checks: `fmt`, `clippy --all-features -D warnings`, `cargo test` across no-default-features, default, and workspace-excluding-e2e (237 passed each). Emulator: upstream HWI suite passed on Trezor One and Model T.
